### PR TITLE
Replace A* with Jump Point Search (JPS) for faster pathfinding

### DIFF
--- a/lib/flame/components/barriers_component.dart
+++ b/lib/flame/components/barriers_component.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:pathfinding/core/grid.dart' as pf;
 import 'package:tech_world/flame/shared/constants.dart';
 
 /// A [BarriersComponent] keeps a list of points that the player cannot walk
@@ -52,8 +53,24 @@ class BarriersComponent extends PositionComponent with HasWorldReference {
     Point(17, 7),
   ];
 
-  /// Returns barriers as tuples for a_star_algorithm compatibility
+  /// Returns barriers as tuples for compatibility
   List<(int, int)> get tuples => _points.map((p) => (p.x, p.y)).toList();
+
+  /// Creates a pathfinding Grid with barriers marked as unwalkable.
+  /// Note: Grid must be cloned before each pathfinding call.
+  pf.Grid createGrid() {
+    // Create matrix: 0 = walkable, 1 = obstacle
+    final matrix = List.generate(
+      gridSize,
+      (_) => List.filled(gridSize, 0),
+    );
+
+    for (final point in _points) {
+      matrix[point.y][point.x] = 1;
+    }
+
+    return pf.Grid(gridSize, gridSize, matrix);
+  }
 
   /// Add [RectangleComponent]s to draw each barrier in the large grid that is
   /// in canvas space.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.65"
-  a_star_algorithm:
-    dependency: "direct main"
-    description:
-      name: a_star_algorithm
-      sha256: efc131ca9a3eaceebe09fa67b9a7235d6e0a6e23ff0de4c009c60d506f791349
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.1"
   adaptive_number:
     dependency: transitive
     description:
@@ -743,6 +735,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pathfinding:
+    dependency: "direct main"
+    description:
+      name: pathfinding
+      sha256: "5491d820f2f412445f05450dd15c44d1986f4f5f6763a46718540a8fa085cadd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_webrtc: ^1.2.0 # Required for controls.dart
   shared_preferences: ^2.2.3 # currently used by livekit code
   flame: ^1.18.0
-  a_star_algorithm: ^0.4.1
+  pathfinding: ^3.0.1
   firebase_core: ^4.1.1
   cloud_firestore: ^6.0.2
   firebase_auth: ^6.1.0


### PR DESCRIPTION
## Summary
Replace the `a_star_algorithm` package with the `pathfinding` package to use Jump Point Search (JPS) for faster pathfinding on the uniform-cost grid.

## Why JPS?
- **~5x faster** than A* on uniform-cost grids (benchmarks show ~7.6ms vs ~41.6ms)
- **Skips intermediate nodes** in straight lines, reducing nodes expanded
- **Same optimal path** - guarantees shortest path like A*
- **Perfect for open maps** - the more open space, the bigger the speedup
- Current 50x50 grid with sparse obstacles is ideal for JPS

## Changes

### `pubspec.yaml`
- Remove: `a_star_algorithm` dependency
- Add: `pathfinding: ^3.0.1`

### `lib/flame/components/barriers_component.dart`
- Add `createGrid()` method to generate a pathfinding Grid from barriers

### `lib/flame/components/path_component.dart`
- Replace A* with `JumpPointFinder` from pathfinding package
- Add `_expandPath()` to interpolate sparse JPS waypoints into step-by-step paths using Bresenham's line algorithm
- Add coordinate clamping to prevent out-of-bounds errors when clicking outside the grid

## Technical Details

JPS returns sparse "jump points" (waypoints) rather than step-by-step paths. For example, instead of `[(0,0), (1,1), (2,2), (3,3)]`, JPS returns `[(0,0), (3,3)]`. The `_expandPath()` method uses Bresenham's line algorithm (via `pf_util.getLine`) to interpolate between consecutive waypoints.

## Testing
- All 51 tests pass
- `flutter analyze --fatal-infos` passes