### PR TITLE
Implement web video frame capture for in-game video bubbles

### DIFF
--- a/lib/native/video_frame_web.dart
+++ b/lib/native/video_frame_web.dart
@@ -1,0 +1,263 @@
+// Web implementation for video frame capture.
+//
+// Uses a hidden HTMLVideoElement + createImageBitmap for GPU-efficient
+// video frame capture on web platforms.
+//
+// This file should only be imported on web platforms.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:web/web.dart' as web;
+
+/// Web-based video frame capture using createImageBitmap.
+///
+/// Creates a hidden HTMLVideoElement, attaches the MediaStream to it,
+/// and captures frames for rendering in Flame/Flutter.
+class WebVideoFrameCapture {
+  WebVideoFrameCapture._(this._videoElement);
+
+  final web.HTMLVideoElement _videoElement;
+  ui.Image? _currentFrame;
+  bool _hasNewFrame = false;
+  bool _isCapturing = false;
+  int _frameNumber = 0;
+  Timer? _captureTimer;
+
+  /// Create a capture instance from a MediaStream.
+  ///
+  /// Creates a hidden video element and attaches the stream to it.
+  static Future<WebVideoFrameCapture?> createFromStream(
+      web.MediaStream stream) async {
+    // Create a hidden video element
+    final video = web.document.createElement('video') as web.HTMLVideoElement;
+    video.autoplay = true;
+    video.muted = true;
+    video.playsInline = true;
+    video.style.display = 'none';
+
+    // Attach the stream
+    video.srcObject = stream;
+
+    // Add to document (required for some browsers)
+    web.document.body?.appendChild(video);
+
+    // Wait for video to be ready
+    try {
+      await video.play().toDart;
+    } catch (e) {
+      debugPrint('WebVideoFrameCapture: play() failed: $e');
+    }
+
+    // Wait for video dimensions to be available
+    var attempts = 0;
+    while (video.videoWidth == 0 && attempts < 50) {
+      await Future.delayed(const Duration(milliseconds: 50));
+      attempts++;
+    }
+
+    if (video.videoWidth == 0) {
+      debugPrint('WebVideoFrameCapture: Video dimensions not available');
+      video.remove();
+      return null;
+    }
+
+    debugPrint(
+        'WebVideoFrameCapture: Created video element ${video.videoWidth}x${video.videoHeight}');
+    return WebVideoFrameCapture._(video);
+  }
+
+  /// Create a capture instance from a MediaStreamTrack.
+  static Future<WebVideoFrameCapture?> createFromTrack(
+      web.MediaStreamTrack track) async {
+    final stream = web.MediaStream();
+    stream.addTrack(track);
+    return createFromStream(stream);
+  }
+
+  /// Find a video element by matching its MediaStream track ID.
+  /// (Legacy method - kept for compatibility but prefer createFromStream)
+  static web.HTMLVideoElement? findVideoElementByTrackId(String trackId) {
+    final videos = web.document.querySelectorAll('video');
+    debugPrint('WebVideoFrameCapture: Found ${videos.length} video elements');
+
+    for (var i = 0; i < videos.length; i++) {
+      final node = videos.item(i);
+      if (node == null) continue;
+
+      final video = node as web.HTMLVideoElement;
+      final srcObject = video.srcObject;
+      debugPrint(
+          'WebVideoFrameCapture: Video[$i] srcObject=${srcObject != null}');
+
+      if (srcObject == null) continue;
+
+      // Check if srcObject is a MediaStream
+      if (srcObject.isA<web.MediaStream>()) {
+        final stream = srcObject as web.MediaStream;
+        final tracks = stream.getVideoTracks();
+        debugPrint(
+            'WebVideoFrameCapture: Video[$i] has ${tracks.length} video tracks');
+
+        for (var j = 0; j < tracks.length; j++) {
+          final track = tracks.toDart[j];
+          debugPrint('WebVideoFrameCapture: Track[$j] id=${track.id}');
+          if (track.id == trackId) {
+            debugPrint('WebVideoFrameCapture: MATCH FOUND!');
+            return video;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Debug: List all video elements and their track IDs.
+  static void debugListVideoElements() {
+    final videos = web.document.querySelectorAll('video');
+    debugPrint(
+        'WebVideoFrameCapture DEBUG: Found ${videos.length} video elements');
+
+    for (var i = 0; i < videos.length; i++) {
+      final node = videos.item(i);
+      if (node == null) continue;
+
+      final video = node as web.HTMLVideoElement;
+      debugPrint('  Video[$i]: id=${video.id}, readyState=${video.readyState}, '
+          'size=${video.videoWidth}x${video.videoHeight}');
+
+      final srcObject = video.srcObject;
+      if (srcObject == null) {
+        debugPrint('    srcObject: null');
+        continue;
+      }
+
+      if (srcObject.isA<web.MediaStream>()) {
+        final stream = srcObject as web.MediaStream;
+        final videoTracks = stream.getVideoTracks();
+        final audioTracks = stream.getAudioTracks();
+        debugPrint(
+            '    MediaStream: ${videoTracks.length} video, ${audioTracks.length} audio tracks');
+
+        for (var j = 0; j < videoTracks.length; j++) {
+          final track = videoTracks.toDart[j];
+          debugPrint(
+              '      VideoTrack[$j]: id=${track.id}, label=${track.label}, enabled=${track.enabled}');
+        }
+      }
+    }
+  }
+
+  /// Whether a new frame is available.
+  bool get hasNewFrame => _hasNewFrame;
+
+  /// Whether capture is active.
+  bool get isActive => _isCapturing;
+
+  /// The current captured frame, or null if no frame available.
+  ui.Image? get currentFrame => _currentFrame;
+
+  /// Video width in pixels.
+  int get width => _videoElement.videoWidth;
+
+  /// Video height in pixels.
+  int get height => _videoElement.videoHeight;
+
+  /// Current frame number.
+  int get frameNumber => _frameNumber;
+
+  /// Start capturing frames.
+  ///
+  /// Uses a timer-based approach for compatibility.
+  /// Captures at approximately 15fps (66ms interval).
+  void startCapture() {
+    if (_isCapturing) return;
+    _isCapturing = true;
+
+    // Use timer-based capture for broad compatibility
+    // 66ms = ~15fps
+    _captureTimer = Timer.periodic(
+      const Duration(milliseconds: 66),
+      (_) => _captureFrame(),
+    );
+  }
+
+  /// Stop capturing frames.
+  void stopCapture() {
+    _isCapturing = false;
+    _captureTimer?.cancel();
+    _captureTimer = null;
+  }
+
+  /// Capture the current video frame.
+  Future<void> _captureFrame() async {
+    if (!_isCapturing) return;
+    if (_videoElement.readyState < 2) return; // HAVE_CURRENT_DATA
+
+    final videoWidth = _videoElement.videoWidth;
+    final videoHeight = _videoElement.videoHeight;
+    if (videoWidth == 0 || videoHeight == 0) return;
+
+    try {
+      // Create ImageBitmap from video element (GPU-efficient)
+      final imageBitmapPromise = web.window.createImageBitmap(
+        _videoElement as web.ImageBitmapSource,
+      );
+
+      final imageBitmap = await imageBitmapPromise.toDart;
+
+      // Convert to Flutter ui.Image
+      final newFrame = await ui_web.createImageFromImageBitmap(
+        imageBitmap as JSAny,
+      );
+
+      // Swap frames (dispose old one)
+      final oldFrame = _currentFrame;
+      _currentFrame = newFrame;
+      _hasNewFrame = true;
+      _frameNumber++;
+
+      // Log first successful frame
+      if (_frameNumber == 1) {
+        debugPrint(
+            'WebVideoFrameCapture: First frame captured! ${videoWidth}x$videoHeight');
+      }
+
+      oldFrame?.dispose();
+    } catch (e, stackTrace) {
+      debugPrint('WebVideoFrameCapture: Frame capture error: $e');
+      debugPrint('WebVideoFrameCapture: Stack trace: $stackTrace');
+    }
+  }
+
+  /// Mark the current frame as consumed.
+  void markConsumed() {
+    _hasNewFrame = false;
+  }
+
+  /// Get the current frame (and transfer ownership to caller).
+  ///
+  /// Returns the current frame and clears the internal reference.
+  /// The caller is now responsible for disposing the returned image.
+  /// Returns null if no frame is available.
+  ui.Image? consumeFrame() {
+    _hasNewFrame = false;
+    final frame = _currentFrame;
+    _currentFrame = null;
+    return frame;
+  }
+
+  /// Dispose resources.
+  void dispose() {
+    stopCapture();
+    _currentFrame?.dispose();
+    _currentFrame = null;
+
+    // Remove the hidden video element
+    _videoElement.srcObject = null;
+    _videoElement.remove();
+  }
+}

--- a/lib/native/video_frame_web_stub.dart
+++ b/lib/native/video_frame_web_stub.dart
@@ -1,0 +1,58 @@
+// Stub implementation for non-web platforms.
+//
+// This provides no-op implementations so the code compiles on native platforms
+// without the web package dependencies.
+
+import 'dart:ui' as ui;
+
+/// Stub WebVideoFrameCapture that does nothing on non-web platforms.
+class WebVideoFrameCapture {
+  WebVideoFrameCapture._();
+
+  /// Always returns null on non-web platforms.
+  static Future<WebVideoFrameCapture?> createFromStream(dynamic stream) async =>
+      null;
+
+  /// Always returns null on non-web platforms.
+  static Future<WebVideoFrameCapture?> createFromTrack(dynamic track) async =>
+      null;
+
+  /// Always returns null on non-web platforms.
+  static dynamic findVideoElementByTrackId(String trackId) => null;
+
+  /// No-op on non-web platforms.
+  static void debugListVideoElements() {}
+
+  /// Always returns false.
+  bool get hasNewFrame => false;
+
+  /// Always returns false.
+  bool get isActive => false;
+
+  /// Always returns null.
+  ui.Image? get currentFrame => null;
+
+  /// Always returns 0.
+  int get width => 0;
+
+  /// Always returns 0.
+  int get height => 0;
+
+  /// Always returns 0.
+  int get frameNumber => 0;
+
+  /// No-op.
+  void startCapture() {}
+
+  /// No-op.
+  void stopCapture() {}
+
+  /// No-op.
+  void markConsumed() {}
+
+  /// Always returns null.
+  ui.Image? consumeFrame() => null;
+
+  /// No-op.
+  void dispose() {}
+}

--- a/lib/native/web_video_capture.dart
+++ b/lib/native/web_video_capture.dart
@@ -1,0 +1,8 @@
+// Platform-aware web video frame capture.
+//
+// This file exports the appropriate implementation based on the platform:
+// - On web: Uses createImageBitmap-based implementation
+// - On native platforms: Uses a stub that returns null/no-op
+
+export 'video_frame_web_stub.dart'
+    if (dart.library.js_interop) 'video_frame_web.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1046,7 +1046,7 @@ packages:
     source: hosted
     version: "15.0.2"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.0.0+1
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.6.0
 
 dependencies:
   flutter:
@@ -27,6 +27,7 @@ dependencies:
   web_socket_channel: ^3.0.0 # used by networking service
   collection: ^1.19.1
   ffi: ^2.1.5
+  web: ^1.1.0 # For web video capture APIs
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Adds web platform support for rendering LiveKit video feeds as circular bubbles in the Flame game world.

## Implementation
Uses `createImageBitmap()` + `createImageFromImageBitmap()` for GPU-efficient frame capture:

1. Creates a hidden `HTMLVideoElement` off-screen
2. Attaches the LiveKit `MediaStream` directly to the video element
3. Captures frames at ~15fps using timer-based approach
4. Converts to Flutter `ui.Image` via `createImageFromImageBitmap()`
5. Renders as circular clipped image in Flame canvas

## Files Changed
- `lib/native/video_frame_web.dart` - Main web capture implementation
- `lib/native/video_frame_web_stub.dart` - Stub for non-web platforms
- `lib/native/web_video_capture.dart` - Platform-conditional export
- `lib/flame/components/video_bubble_component.dart` - Added web capture initialization
- `pubspec.yaml` - SDK ^3.6.0, added `web: ^1.1.0`

## Platform Support
| Platform | Implementation |
|----------|----------------|
| Web | createImageBitmap + createImageFromImageBitmap |
| macOS | FFI zero-copy frame capture (existing) |
| Other | Placeholder with user initial |

## Testing
Tested manually on Chrome - video bubbles render correctly with smooth frame updates.