### PR TITLE
Fix AuthGate flash before game starts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,14 +140,17 @@ class _MyAppState extends State<MyApp> {
                   child: StreamBuilder<AuthUser>(
                     stream: locate<AuthService>().authStateChanges,
                     builder: (context, snapshot) {
-                      if (snapshot.hasData &&
-                          snapshot.data! is! SignedOutUser) {
+                      if (!snapshot.hasData) {
+                        return const LoadingScreen(
+                          message: 'Checking authentication...',
+                        );
+                      }
+                      if (snapshot.data! is! SignedOutUser) {
                         return GameWidget(
                           game: locate<TechWorldGame>(),
                         );
-                      } else {
-                        return const AuthGate();
                       }
+                      return const AuthGate();
                     },
                   ),
                 ),


### PR DESCRIPTION
## Summary
- Show loading screen while waiting for Firebase Auth to check the persisted session
- Prevents the AuthGate (sign-in page) from briefly flashing before the game appears for already-authenticated users

## Test plan
- [ ] Launch app while already authenticated from a previous session
- [ ] Verify loading screen shows "Checking authentication..." instead of AuthGate flashing
- [ ] Verify AuthGate still shows correctly for signed-out users

🤖 Generated with [Claude Code](https://claude.ai/claude-code)