### PR TITLE
Add LiveKit data channel infrastructure

### DIFF
--- a/test/livekit/data_channel_message_test.dart
+++ b/test/livekit/data_channel_message_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+
+void main() {
+  group('DataChannelMessage', () {
+    test('json getter decodes valid JSON data', () {
+      final jsonData = {'type': 'chat', 'message': 'Hello'};
+      final message = DataChannelMessage(
+        senderId: 'user123',
+        topic: 'chat',
+        data: utf8.encode(jsonEncode(jsonData)),
+      );
+
+      expect(message.json, equals(jsonData));
+    });
+
+    test('json getter returns null for invalid JSON', () {
+      final message = DataChannelMessage(
+        senderId: 'user123',
+        topic: 'chat',
+        data: utf8.encode('not valid json'),
+      );
+
+      expect(message.json, isNull);
+    });
+
+    test('text getter decodes UTF-8 string', () {
+      final message = DataChannelMessage(
+        senderId: 'user123',
+        topic: 'ping',
+        data: utf8.encode('pong'),
+      );
+
+      expect(message.text, equals('pong'));
+    });
+
+    test('handles null senderId (server-sent message)', () {
+      final message = DataChannelMessage(
+        senderId: null,
+        topic: 'system',
+        data: utf8.encode('{"event": "shutdown"}'),
+      );
+
+      expect(message.senderId, isNull);
+      expect(message.json, equals({'event': 'shutdown'}));
+    });
+
+    test('toString provides readable output', () {
+      final message = DataChannelMessage(
+        senderId: 'user123',
+        topic: 'test',
+        data: [1, 2, 3],
+      );
+
+      expect(
+        message.toString(),
+        equals('DataChannelMessage(senderId: user123, topic: test, data: 3 bytes)'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `DataChannelMessage` class for received messages with JSON/text parsing helpers
- Add `publishData()` and `publishJson()` methods to `LiveKitService` for sending data
- Add `dataReceived` stream for incoming messages from other participants
- Add unit tests for `DataChannelMessage` parsing

This is PR 1 of 4 in the Claude API integration stack. It enables client-to-client and server-to-client messaging through the existing LiveKit connection.

## Test plan
- [x] Unit tests pass for DataChannelMessage JSON/text decoding
- [x] `flutter analyze --fatal-infos` passes
- [x] All existing tests continue to pass (56 tests)
- [ ] Manual test: Two clients can send/receive ping/pong messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)