### PR TITLE
feat: implement shared chat for all participants

### DIFF
--- a/lib/chat/chat_message.dart
+++ b/lib/chat/chat_message.dart
@@ -2,11 +2,18 @@
 class ChatMessage {
   ChatMessage({
     required this.text,
-    required this.isUser,
+    required this.senderName,
+    this.isLocalUser = false,
+    this.isBot = false,
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
   final String text;
-  final bool isUser;
+  final String senderName;
+  final bool isLocalUser; // true if this message was sent by the local user
+  final bool isBot; // true if this message is from Claude
   final DateTime timestamp;
+
+  /// Legacy getter for backwards compatibility
+  bool get isUser => isLocalUser;
 }

--- a/lib/chat/chat_panel.dart
+++ b/lib/chat/chat_panel.dart
@@ -228,26 +228,32 @@ class _MessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Determine avatar and colors based on message type
+    final isLocalUser = message.isLocalUser;
+    final isBot = message.isBot;
+    final avatarLetter = isBot ? 'C' : message.senderName.isNotEmpty ? message.senderName[0].toUpperCase() : '?';
+    final avatarColor = isBot ? clawdOrange : Colors.blue;
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Row(
         mainAxisAlignment:
-            message.isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+            isLocalUser ? MainAxisAlignment.end : MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (!message.isUser) ...[
+          if (!isLocalUser) ...[
             Container(
               width: 28,
               height: 28,
               decoration: BoxDecoration(
-                color: clawdOrange.withValues(alpha: 0.2),
+                color: avatarColor.withValues(alpha: 0.2),
                 shape: BoxShape.circle,
               ),
-              child: const Center(
+              child: Center(
                 child: Text(
-                  'C',
+                  avatarLetter,
                   style: TextStyle(
-                    color: clawdOrange,
+                    color: avatarColor,
                     fontSize: 12,
                     fontWeight: FontWeight.bold,
                   ),
@@ -257,27 +263,45 @@ class _MessageBubble extends StatelessWidget {
             const SizedBox(width: 8),
           ],
           Flexible(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color: message.isUser
-                    ? clawdOrange.withValues(alpha: 0.2)
-                    : const Color(0xFF2D2D2D),
-                borderRadius: BorderRadius.circular(16),
-                border: message.isUser
-                    ? Border.all(color: clawdOrange.withValues(alpha: 0.3))
-                    : null,
-              ),
-              child: Text(
-                message.text,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
+            child: Column(
+              crossAxisAlignment: isLocalUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              children: [
+                // Show sender name for other users (not bot, not self)
+                if (!isLocalUser && !isBot)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4, left: 4),
+                    child: Text(
+                      message.senderName,
+                      style: TextStyle(
+                        color: Colors.grey[400],
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: isLocalUser
+                        ? clawdOrange.withValues(alpha: 0.2)
+                        : const Color(0xFF2D2D2D),
+                    borderRadius: BorderRadius.circular(16),
+                    border: isLocalUser
+                        ? Border.all(color: clawdOrange.withValues(alpha: 0.3))
+                        : null,
+                  ),
+                  child: Text(
+                    message.text,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                    ),
+                  ),
                 ),
-              ),
+              ],
             ),
           ),
-          if (message.isUser) const SizedBox(width: 36),
+          if (isLocalUser) const SizedBox(width: 36),
         ],
       ),
     );

--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -5,54 +5,82 @@ import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
-/// Service that manages chat with the Claude bot via LiveKit data channels.
+/// Service that manages shared chat with Claude bot via LiveKit data channels.
+/// All participants see all messages (questions and responses).
 class ChatService {
   ChatService({required LiveKitService liveKitService})
       : _liveKitService = liveKitService {
-    _subscribeToResponses();
+    _subscribeToMessages();
   }
 
   final LiveKitService _liveKitService;
   final _messagesController = StreamController<List<ChatMessage>>.broadcast();
   final List<ChatMessage> _messages = [];
   final Map<String, Completer<void>> _pendingMessages = {};
-  StreamSubscription<DataChannelMessage>? _responseSubscription;
+  final Set<String> _seenMessageIds = {}; // Prevent duplicate messages
+  StreamSubscription<DataChannelMessage>? _chatSubscription;
 
   Stream<List<ChatMessage>> get messages => _messagesController.stream;
   List<ChatMessage> get currentMessages => List.unmodifiable(_messages);
 
-  void _subscribeToResponses() {
-    _responseSubscription = _liveKitService.dataReceived
-        .where((msg) => msg.topic == 'chat-response')
-        .listen(_handleChatResponse);
+  void _subscribeToMessages() {
+    // Listen for both chat messages and bot responses
+    _chatSubscription = _liveKitService.dataReceived
+        .where((msg) => msg.topic == 'chat' || msg.topic == 'chat-response')
+        .listen(_handleMessage);
   }
 
-  void _handleChatResponse(DataChannelMessage message) {
+  void _handleMessage(DataChannelMessage message) {
     final json = message.json;
     if (json == null) return;
 
     final text = json['text'] as String?;
-    final messageId = json['messageId'] as String?;
+    // 'id' is the message's own ID (for deduplication)
+    // 'messageId' is the ID of the message being responded to (for correlation)
+    final ownId = json['id'] as String?;
+    final replyToId = json['messageId'] as String?;
+    final senderName = json['senderName'] as String? ?? message.senderId ?? 'Unknown';
 
     if (text == null) return;
 
-    debugPrint('ChatService: Received response: "${text.substring(0, text.length.clamp(0, 50))}..."');
+    // Skip if we've already seen this message (prevents duplicates)
+    // Only check the message's own ID, not the ID it's replying to
+    if (ownId != null && _seenMessageIds.contains(ownId)) return;
+    if (ownId != null) _seenMessageIds.add(ownId);
 
-    // Hide thinking indicator
-    botStatusNotifier.value = BotStatus.idle;
+    // Skip our own outgoing messages (we add them locally)
+    final isFromSelf = message.senderId == _liveKitService.userId;
+    if (message.topic == 'chat' && isFromSelf) return;
 
-    // Add bot response
-    _messages.add(ChatMessage(text: text, isUser: false));
+    debugPrint('ChatService: Received ${message.topic} from ${message.senderId}: "${text.substring(0, text.length.clamp(0, 50))}..."');
+
+    if (message.topic == 'chat-response') {
+      // Bot response
+      botStatusNotifier.value = BotStatus.idle;
+      _messages.add(ChatMessage(
+        text: text,
+        senderName: 'Clawd',
+        isBot: true,
+      ));
+    } else {
+      // Message from another user
+      _messages.add(ChatMessage(
+        text: text,
+        senderName: senderName,
+        isLocalUser: false,
+      ));
+    }
+
     _messagesController.add(List.from(_messages));
 
-    // Complete the pending message future if we have one
-    if (messageId != null && _pendingMessages.containsKey(messageId)) {
-      _pendingMessages[messageId]!.complete();
-      _pendingMessages.remove(messageId);
+    // Complete pending message if this is a response to one of ours
+    if (replyToId != null && _pendingMessages.containsKey(replyToId)) {
+      _pendingMessages[replyToId]!.complete();
+      _pendingMessages.remove(replyToId);
     }
   }
 
-  /// Send a message to the bot and get a response.
+  /// Send a message to the shared chat (visible to all participants).
   Future<void> sendMessage(String text) async {
     if (text.trim().isEmpty) return;
 
@@ -60,39 +88,46 @@ class ChatService {
       debugPrint('ChatService: Not connected to LiveKit, cannot send message');
       _messages.add(ChatMessage(
         text: "I can't reach Clawd right now. Please check your connection.",
-        isUser: false,
+        senderName: 'System',
+        isBot: true,
       ));
       _messagesController.add(List.from(_messages));
       return;
     }
 
-    // Add user message
-    _messages.add(ChatMessage(text: text, isUser: true));
+    // Generate a unique message ID
+    final messageId = DateTime.now().millisecondsSinceEpoch.toString();
+    _seenMessageIds.add(messageId); // Mark as seen so we don't duplicate
+
+    // Add user message locally
+    _messages.add(ChatMessage(
+      text: text,
+      senderName: _liveKitService.displayName,
+      isLocalUser: true,
+    ));
     _messagesController.add(List.from(_messages));
 
     // Show thinking indicator
     botStatusNotifier.value = BotStatus.thinking;
 
-    // Generate a unique message ID
-    final messageId = DateTime.now().millisecondsSinceEpoch.toString();
-
     // Create a completer to track when we get a response
     final completer = Completer<void>();
     _pendingMessages[messageId] = completer;
 
-    // Send message via data channel
+    // Send message to all participants (no destinationIdentities = broadcast)
     await _liveKitService.publishJson(
       {
         'type': 'chat',
         'id': messageId,
         'text': text,
+        'senderName': _liveKitService.displayName,
         'timestamp': DateTime.now().toIso8601String(),
       },
       topic: 'chat',
-      destinationIdentities: ['bot-claude'],
+      // No destinationIdentities = broadcast to all
     );
 
-    debugPrint('ChatService: Sent message to bot: "$text"');
+    debugPrint('ChatService: Sent message: "$text"');
 
     // Wait for response with timeout
     try {
@@ -103,7 +138,8 @@ class ChatService {
           botStatusNotifier.value = BotStatus.idle;
           _messages.add(ChatMessage(
             text: "Hmm, Clawd seems to be taking a while. Try again?",
-            isUser: false,
+            senderName: 'System',
+            isBot: true,
           ));
           _messagesController.add(List.from(_messages));
           _pendingMessages.remove(messageId);
@@ -115,7 +151,7 @@ class ChatService {
   }
 
   void dispose() {
-    _responseSubscription?.cancel();
+    _chatSubscription?.cancel();
     _messagesController.close();
   }
 }

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -57,12 +57,14 @@ void main() {
 
       final published = fakeLiveKit.publishedMessages.first;
       expect(published['topic'], equals('chat'));
-      expect(published['destinationIdentities'], equals(['bot-claude']));
+      // Shared chat broadcasts to all (no destinationIdentities)
+      expect(published['destinationIdentities'], isNull);
 
       final payload = published['payload'] as Map<String, dynamic>;
       expect(payload['type'], equals('chat'));
       expect(payload['text'], equals('Test message'));
       expect(payload['id'], isNotNull);
+      expect(payload['senderName'], equals('Test User'));
       expect(payload['timestamp'], isNotNull);
     });
 
@@ -225,6 +227,12 @@ class FakeLiveKitService implements LiveKitService {
 
   @override
   bool get isConnected => connected;
+
+  @override
+  String get userId => 'test-user-id';
+
+  @override
+  String get displayName => 'Test User';
 
   @override
   Stream<DataChannelMessage> get dataReceived => _dataReceivedController.stream;


### PR DESCRIPTION
## Summary
- All participants now see all chat messages (questions and responses)
- Messages show sender name for other users' messages
- Bot responses are broadcast to everyone, not just the requester

## Changes
- `ChatMessage`: Added `senderName`, `isLocalUser`, `isBot` fields
- `ChatService`: Broadcasts messages without `destinationIdentities`, listens to both 'chat' and 'chat-response' topics
- `ChatPanel`: Updated UI to show sender avatars and names for other users
- Tests: Updated for new shared chat behavior

## Test plan
- [x] Unit tests pass
- [ ] Manual test: Open 2 browser tabs, send message from one, verify other sees both question and response
- [ ] Manual test: Verify bot responses appear for all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)