### PR TITLE
fix: upgrade placeholder bubbles to video when track subscribes

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -363,10 +363,15 @@ class TechWorld extends World with TapCallbacks {
       _updateBubbleSpeakingState(participant.identity, isSpeaking);
     });
 
-    // Listen for track subscription events to trigger capture init immediately
+    // Listen for track subscription events to upgrade placeholder bubbles to video
     _trackSubscribedSubscription =
         _liveKitService!.trackSubscribed.listen((event) {
-      final (participant, _) = event;
+      final (participant, track) = event;
+      if (track.kind == TrackType.VIDEO) {
+        debugPrint('TechWorld: Video track subscribed for ${participant.identity}, refreshing bubble');
+        // This will upgrade PlayerBubbleComponent to VideoBubbleComponent
+        _refreshBubbleForPlayer(participant.identity);
+      }
       _notifyBubbleTrackReady(participant.identity);
     });
 


### PR DESCRIPTION
## Summary
Fixes the issue where other players' video shows a placeholder ("G") instead of actual video.

## Problem
Race condition: when a participant joins, their video track isn't subscribed yet, so `_hasVideoTrack()` returns false and a `PlayerBubbleComponent` (placeholder) is created. When the track later subscribes, the placeholder was never upgraded.

## Solution
When `TrackSubscribedEvent` fires for a video track, call `_refreshBubbleForPlayer()` to upgrade the `PlayerBubbleComponent` to a `VideoBubbleComponent`.

## Test plan
- [x] Unit tests pass
- [ ] Manual test: Open 2 browsers, verify both players see each other's video (not placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)