### PR TITLE
feat: add auth menu with sign out option

### DIFF
--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -205,4 +205,9 @@ class AuthService {
     final digest = sha256.convert(bytes);
     return digest.toString();
   }
+
+  /// Sign out the current user.
+  Future<void> signOut() async {
+    await FirebaseAuth.instance.signOut();
+  }
 }

--- a/lib/widgets/auth_menu.dart
+++ b/lib/widgets/auth_menu.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:tech_world/auth/auth_service.dart';
+import 'package:tech_world/utils/locator.dart';
+
+/// A user avatar with dropdown menu for auth actions (sign out, etc.)
+class AuthMenu extends StatelessWidget {
+  final String displayName;
+
+  const AuthMenu({super.key, required this.displayName});
+
+  String get _initials {
+    if (displayName.isEmpty) return '?';
+    final parts = displayName.trim().split(' ');
+    if (parts.length >= 2) {
+      return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
+    }
+    return displayName[0].toUpperCase();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      offset: const Offset(0, 48),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Colors.black54,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 16,
+              backgroundColor: Colors.blue,
+              child: Text(
+                _initials,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            const Icon(Icons.arrow_drop_down, color: Colors.white),
+          ],
+        ),
+      ),
+      itemBuilder: (context) => [
+        PopupMenuItem<String>(
+          enabled: false,
+          child: Text(
+            displayName.isEmpty ? 'Guest' : displayName,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        const PopupMenuDivider(),
+        const PopupMenuItem<String>(
+          value: 'signout',
+          child: Row(
+            children: [
+              Icon(Icons.logout, size: 20),
+              SizedBox(width: 8),
+              Text('Sign out'),
+            ],
+          ),
+        ),
+      ],
+      onSelected: (value) async {
+        if (value == 'signout') {
+          await locate<AuthService>().signOut();
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add user avatar menu in top-right corner with sign out option
- Add `signOut()` method to `AuthService`
- Create `AuthMenu` widget showing user initials and dropdown

## Changes
- `lib/auth/auth_service.dart`: Add `signOut()` method
- `lib/widgets/auth_menu.dart`: New widget with avatar and dropdown menu
- `lib/main.dart`: Add auth menu overlay positioned above game area

## Test plan
- [x] Static analysis passes
- [x] Unit tests pass
- [ ] Manual test: Sign in, see avatar in top-right, click to open menu, click "Sign out"

🤖 Generated with [Claude Code](https://claude.com/claude-code)