### PR TITLE
test: add tests for GameMap, Direction, and AuthMenu

### DIFF
--- a/test/flame/maps/game_map_test.dart
+++ b/test/flame/maps/game_map_test.dart
@@ -1,0 +1,87 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/maps/game_map.dart';
+import 'package:tech_world/flame/maps/predefined_maps.dart';
+
+void main() {
+  group('GameMap', () {
+    test('creates map with required fields', () {
+      final map = GameMap(
+        id: 'test-map',
+        name: 'Test Map',
+        barriers: [const Point(1, 1), const Point(2, 2)],
+      );
+
+      expect(map.id, equals('test-map'));
+      expect(map.name, equals('Test Map'));
+      expect(map.barriers.length, equals(2));
+      expect(map.spawnPoint, equals(const Point(25, 25))); // default
+    });
+
+    test('creates map with custom spawn point', () {
+      final map = GameMap(
+        id: 'custom',
+        name: 'Custom',
+        barriers: [],
+        spawnPoint: const Point(10, 10),
+      );
+
+      expect(map.spawnPoint, equals(const Point(10, 10)));
+    });
+
+    test('barriers list is accessible', () {
+      final barriers = [
+        const Point(5, 5),
+        const Point(6, 5),
+        const Point(7, 5),
+      ];
+      final map = GameMap(
+        id: 'wall',
+        name: 'Wall',
+        barriers: barriers,
+      );
+
+      expect(map.barriers, equals(barriers));
+      expect(map.barriers.length, equals(3));
+    });
+  });
+
+  group('Predefined Maps', () {
+    test('openArena has no barriers', () {
+      expect(openArena.id, equals('open_arena'));
+      expect(openArena.name, equals('Open Arena'));
+      expect(openArena.barriers, isEmpty);
+    });
+
+    test('lRoom has L-shaped barriers', () {
+      expect(lRoom.id, equals('l_room'));
+      expect(lRoom.name, equals('The L-Room'));
+      expect(lRoom.barriers, isNotEmpty);
+      // Verify it contains expected barrier positions (vertical wall at x=4)
+      expect(lRoom.barriers.contains(const Point(4, 10)), isTrue);
+    });
+
+    test('fourCorners has barriers in corners', () {
+      expect(fourCorners.id, equals('four_corners'));
+      expect(fourCorners.barriers, isNotEmpty);
+    });
+
+    test('simpleMaze has maze pattern', () {
+      expect(simpleMaze.id, equals('simple_maze'));
+      expect(simpleMaze.barriers, isNotEmpty);
+    });
+
+    test('defaultMap is lRoom', () {
+      expect(defaultMap, equals(lRoom));
+    });
+
+    test('allMaps contains all predefined maps', () {
+      expect(allMaps, contains(openArena));
+      expect(allMaps, contains(lRoom));
+      expect(allMaps, contains(fourCorners));
+      expect(allMaps, contains(simpleMaze));
+      expect(allMaps.length, greaterThanOrEqualTo(4));
+    });
+  });
+}

--- a/test/flame/shared/direction_test.dart
+++ b/test/flame/shared/direction_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/shared/constants.dart';
+import 'package:tech_world/flame/shared/direction.dart';
+
+void main() {
+  group('Direction', () {
+    test('up has correct offsets', () {
+      expect(Direction.up.offsetX, equals(0));
+      expect(Direction.up.offsetY, equals(-gridSquareSizeDouble));
+    });
+
+    test('down has correct offsets', () {
+      expect(Direction.down.offsetX, equals(0));
+      expect(Direction.down.offsetY, equals(gridSquareSizeDouble));
+    });
+
+    test('left has correct offsets', () {
+      expect(Direction.left.offsetX, equals(-gridSquareSizeDouble));
+      expect(Direction.left.offsetY, equals(0));
+    });
+
+    test('right has correct offsets', () {
+      expect(Direction.right.offsetX, equals(gridSquareSizeDouble));
+      expect(Direction.right.offsetY, equals(0));
+    });
+
+    test('upLeft has correct diagonal offsets', () {
+      expect(Direction.upLeft.offsetX, equals(-gridSquareSizeDouble));
+      expect(Direction.upLeft.offsetY, equals(-gridSquareSizeDouble));
+    });
+
+    test('upRight has correct diagonal offsets', () {
+      expect(Direction.upRight.offsetX, equals(gridSquareSizeDouble));
+      expect(Direction.upRight.offsetY, equals(-gridSquareSizeDouble));
+    });
+
+    test('downLeft has correct diagonal offsets', () {
+      expect(Direction.downLeft.offsetX, equals(-gridSquareSizeDouble));
+      expect(Direction.downLeft.offsetY, equals(gridSquareSizeDouble));
+    });
+
+    test('downRight has correct diagonal offsets', () {
+      expect(Direction.downRight.offsetX, equals(gridSquareSizeDouble));
+      expect(Direction.downRight.offsetY, equals(gridSquareSizeDouble));
+    });
+
+    test('none has zero offsets', () {
+      expect(Direction.none.offsetX, equals(0));
+      expect(Direction.none.offsetY, equals(0));
+    });
+
+    test('all directions are unique', () {
+      final allDirections = Direction.values;
+      final uniqueOffsets = allDirections
+          .map((d) => '${d.offsetX},${d.offsetY}')
+          .toSet();
+      expect(uniqueOffsets.length, equals(allDirections.length));
+    });
+  });
+
+  group('directionFromTuple', () {
+    test('maps (0, -1) to up', () {
+      expect(directionFromTuple[(0, -1)], equals(Direction.up));
+    });
+
+    test('maps (0, 1) to down', () {
+      expect(directionFromTuple[(0, 1)], equals(Direction.down));
+    });
+
+    test('maps (-1, 0) to left', () {
+      expect(directionFromTuple[(-1, 0)], equals(Direction.left));
+    });
+
+    test('maps (1, 0) to right', () {
+      expect(directionFromTuple[(1, 0)], equals(Direction.right));
+    });
+
+    test('maps (-1, -1) to upLeft', () {
+      expect(directionFromTuple[(-1, -1)], equals(Direction.upLeft));
+    });
+
+    test('maps (1, -1) to upRight', () {
+      expect(directionFromTuple[(1, -1)], equals(Direction.upRight));
+    });
+
+    test('maps (-1, 1) to downLeft', () {
+      expect(directionFromTuple[(-1, 1)], equals(Direction.downLeft));
+    });
+
+    test('maps (1, 1) to downRight', () {
+      expect(directionFromTuple[(1, 1)], equals(Direction.downRight));
+    });
+
+    test('returns null for invalid tuple', () {
+      expect(directionFromTuple[(5, 5)], isNull);
+      expect(directionFromTuple[(0, 0)], isNull);
+    });
+
+    test('covers all 8 directions', () {
+      expect(directionFromTuple.length, equals(8));
+    });
+  });
+}

--- a/test/widgets/auth_menu_test.dart
+++ b/test/widgets/auth_menu_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/widgets/auth_menu.dart';
+
+void main() {
+  group('AuthMenu', () {
+    testWidgets('displays user initials', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'John Doe'),
+          ),
+        ),
+      );
+
+      expect(find.text('JD'), findsOneWidget);
+    });
+
+    testWidgets('displays single initial for single name', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'Alice'),
+          ),
+        ),
+      );
+
+      expect(find.text('A'), findsOneWidget);
+    });
+
+    testWidgets('displays ? for empty name', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: ''),
+          ),
+        ),
+      );
+
+      expect(find.text('?'), findsOneWidget);
+    });
+
+    testWidgets('shows dropdown arrow', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'Test User'),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.arrow_drop_down), findsOneWidget);
+    });
+
+    testWidgets('opens popup menu on tap', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'Test User'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AuthMenu));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test User'), findsOneWidget);
+      expect(find.text('Sign out'), findsOneWidget);
+    });
+
+    testWidgets('shows Guest for empty display name in menu', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: ''),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AuthMenu));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Guest'), findsOneWidget);
+    });
+
+    testWidgets('shows logout icon in menu', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'Test'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AuthMenu));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.logout), findsOneWidget);
+    });
+
+    testWidgets('handles multi-word names correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'John Michael Doe'),
+          ),
+        ),
+      );
+
+      // Should use first and last name initials
+      expect(find.text('JD'), findsOneWidget);
+    });
+
+    testWidgets('converts initials to uppercase', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AuthMenu(displayName: 'john doe'),
+          ),
+        ),
+      );
+
+      expect(find.text('JD'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `GameMap` class and predefined maps (openArena, lRoom, fourCorners, simpleMaze)
- Add unit tests for `Direction` enum offsets and `directionFromTuple` mapping
- Add widget tests for `AuthMenu` initials display and dropdown functionality

Improves test coverage from ~19.9% to ~21.8% (55 additional lines covered).

## Test plan
- [x] All 162 tests pass locally
- [x] `flutter analyze --fatal-infos` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)