### PR TITLE
fix: improve video capture initialization for remote participants

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -125,6 +125,12 @@ class TechWorld extends World with TapCallbacks {
           bubble.position = playerComponent.position + _bubbleOffset;
           _playerBubbles[playerId] = bubble;
           add(bubble);
+
+          // If this is a video bubble, notify it that track is ready
+          // (since TrackSubscribedEvent already fired earlier)
+          if (bubble is VideoBubbleComponent) {
+            bubble.notifyTrackReady();
+          }
         }
       }
     }
@@ -198,7 +204,11 @@ class TechWorld extends World with TapCallbacks {
       String playerId, PlayerComponent playerComponent) {
     // Check if this player has a LiveKit participant with video
     final participant = _liveKitService?.getParticipant(playerId);
-    if (participant != null && _hasVideoTrack(participant)) {
+    final hasVideo = participant != null && _hasVideoTrack(participant);
+    debugPrint('_createBubbleForPlayer: playerId=$playerId, participant=${participant != null}, hasVideo=$hasVideo');
+
+    if (hasVideo) {
+      debugPrint('_createBubbleForPlayer: Creating VideoBubbleComponent for $playerId');
       final videoBubble = VideoBubbleComponent(
         participant: participant,
         displayName: playerComponent.displayName,
@@ -215,6 +225,7 @@ class TechWorld extends World with TapCallbacks {
     }
 
     // Fallback to static bubble
+    debugPrint('_createBubbleForPlayer: Creating PlayerBubbleComponent (fallback) for $playerId');
     return PlayerBubbleComponent(
       displayName: playerComponent.displayName,
       playerId: playerId,
@@ -223,19 +234,24 @@ class TechWorld extends World with TapCallbacks {
 
   /// Check if participant has an active video track
   bool _hasVideoTrack(Participant participant) {
+    debugPrint('_hasVideoTrack: checking ${participant.identity}, publications: ${participant.videoTrackPublications.length}');
     for (final publication in participant.videoTrackPublications) {
+      debugPrint('_hasVideoTrack: publication sid=${publication.sid}, track=${publication.track != null}, subscribed=${publication.subscribed}');
       if (publication.track != null) {
         // For local participant, check if track is published
         // For remote participant, check if track is subscribed
         if (participant is LocalParticipant) {
+          debugPrint('_hasVideoTrack: Local participant has track, returning true');
           return true; // Local tracks are always "active" when present
         } else {
           if (publication.subscribed) {
+            debugPrint('_hasVideoTrack: Remote participant has subscribed track, returning true');
             return true;
           }
         }
       }
     }
+    debugPrint('_hasVideoTrack: No active video track found, returning false');
     return false;
   }
 

--- a/lib/native/video_frame_web_stub.dart
+++ b/lib/native/video_frame_web_stub.dart
@@ -20,6 +20,9 @@ class WebVideoFrameCapture {
   /// Always returns null on non-web platforms.
   static dynamic findVideoElementByTrackId(String trackId) => null;
 
+  /// Always returns null on non-web platforms.
+  static Future<WebVideoFrameCapture?> createFromExistingVideo(dynamic video) async => null;
+
   /// No-op on non-web platforms.
   static void debugListVideoElements() {}
 


### PR DESCRIPTION
## Summary
- Add debug logging throughout video capture flow for troubleshooting
- Try multiple track IDs for remote participants (TR_ format vs UUID format)
- Reuse existing LiveKit video elements on web instead of creating new ones
- Add minimum dimension validation (32x32) to filter placeholder frames
- Track tried track IDs to avoid retrying failed ones
- Check track liveness during async initialization
- Handle track ownership to avoid removing LiveKit-managed video elements

## Test plan
- [ ] Test video bubbles appear for local participant
- [ ] Test video bubbles appear for remote participants
- [ ] Verify debug logs show track matching behavior
- [ ] Test on web and macOS platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)