### PR TITLE
fix(ci): add coverage exclusions to merge workflow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -52,6 +52,16 @@ jobs:
         run: flutter analyze --fatal-infos
       - name: Run tests with coverage
         run: flutter test --coverage
+      - name: Install lcov
+        run: sudo apt-get install -y lcov
+      - name: Remove untestable files from coverage
+        run: |
+          lcov --remove coverage/lcov.info \
+            '*/native/video_frame_ffi.dart' \
+            '*/native/video_frame_web_stub.dart' \
+            '*/flame/components/video_bubble_component.dart' \
+            '*/auth/auth_service.dart' \
+            -o coverage/lcov.info
       - name: Check coverage threshold
         uses: VeryGoodOpenSource/very_good_coverage@v3
         with:


### PR DESCRIPTION
## Summary
- Add same coverage exclusions to merge workflow that PR workflow already has
- Excludes untestable platform-specific files (FFI, web stubs, video bubble)

Fixes deploy failure caused by coverage drop after #68.

## Test plan
- [x] CI will skip these files when calculating coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)