### PR TITLE
ci: skip build/deploy for docs-only changes

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -70,7 +70,8 @@ jobs:
 
   build_and_deploy:
     needs: [changes, test]
-    if: always() && (needs.test.result == 'success' || needs.changes.outputs.docs_only == 'true')
+    # Skip build for docs-only changes, only run when tests pass for code changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.test.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -74,7 +74,8 @@ jobs:
 
   build_and_preview:
     needs: [changes, test]
-    if: always() && (needs.test.result == 'success' || needs.changes.outputs.docs_only == 'true') && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip build for docs-only changes, only run when tests pass for code changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.test.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip both test AND build/deploy jobs for docs-only PRs
- Previously, docs-only PRs skipped tests but still ran the full Flutter build and Firebase deploy

This saves CI time for documentation updates.

Generated with [Claude Code](https://claude.com/claude-code)