### PR TITLE
fix(video): preserve LiveKit video elements on dispose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,11 @@ LiveKit VideoTrack → Native RTCVideoRenderer → Shared Memory Buffer → Dart
 
 **Timing Note:** When a remote participant joins, their video track may not be subscribed yet. The bubble is initially created as a `PlayerBubbleComponent` (placeholder with initial). When `TrackSubscribedEvent` fires, `_refreshBubbleForPlayer()` upgrades it to a `VideoBubbleComponent`. See `lib/flame/tech_world.dart` lines 366-375.
 
-**Known Issues & Debugging:** See `docs/video-capture-debugging.md` for detailed notes on:
-- Release mode (dart2js) compatibility fixes
-- Remote participant video capture
-- iOS FFI crash fix
-- **Current bug**: Video disappears when re-entering proximity (lifecycle issue with video element disposal)
+**Debugging Notes:** See `docs/video-capture-debugging.md` for detailed notes on:
+- Release mode (dart2js) compatibility fixes (PR #71)
+- Remote participant video capture (PR #72)
+- iOS FFI crash fix (PR #73)
+- Video lifecycle fix for proximity re-entry (PR #76)
 
 ### Chat Service
 


### PR DESCRIPTION
## Summary
- Fix video disappearing when re-entering proximity of another player
- Added `_ownsElement` flag to `WebVideoFrameCapture` to track video element ownership
- Only remove video element from DOM if we created it (not if LiveKit did)

## Problem
When a player moved away from another player (exiting proximity), the `VideoBubbleComponent` was disposed, which called `WebVideoFrameCapture.dispose()`. This removed the video element from the DOM **even if it was LiveKit's element**.

When the player returned to proximity, a new bubble was created, but the video element was gone.

## Solution
Track ownership of video elements:
- `createFromStream()` / `createFromTrack()`: We create the element → `ownsElement: true`
- `createFromExistingVideo()`: LiveKit owns the element → `ownsElement: false`
- `dispose()`: Only remove element if `_ownsElement` is true

## Test plan
- [x] All 406 tests pass
- [ ] Manual test: Walk to player → see video → walk away → return → video still works

Generated with [Claude Code](https://claude.com/claude-code)