### PR TITLE
ci: fix lcov in merge workflow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -56,9 +56,10 @@ jobs:
         run: sudo apt-get install -y lcov
       - name: Remove untestable files from coverage
         run: |
-          lcov --remove coverage/lcov.info \
+          lcov --ignore-errors unused --remove coverage/lcov.info \
             '*/native/video_frame_ffi.dart' \
             '*/native/video_frame_web_stub.dart' \
+            '*/native/video_frame_web_v2_stub.dart' \
             '*/flame/components/video_bubble_component.dart' \
             '*/auth/auth_service.dart' \
             -o coverage/lcov.info


### PR DESCRIPTION
## Summary
- Same fix as PR workflow - add `--ignore-errors unused` flag
- Add `video_frame_web_v2_stub.dart` to exclusions

Fixes the failed deployment from PR #77 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)