### PR TITLE
fix(video): use off-screen positioning for mobile video capture

### DIFF
--- a/lib/native/video_frame_web.dart
+++ b/lib/native/video_frame_web.dart
@@ -39,7 +39,13 @@ class WebVideoFrameCapture {
     video.autoplay = true;
     video.muted = true;
     video.playsInline = true;
-    video.style.display = 'none';
+    // Use off-screen positioning instead of display:none
+    // Mobile browsers may not decode frames for hidden elements
+    video.style.position = 'fixed';
+    video.style.top = '-9999px';
+    video.style.left = '-9999px';
+    video.style.width = '1px';
+    video.style.height = '1px';
 
     // Attach the stream
     video.srcObject = stream;

--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -444,7 +444,13 @@ class VideoElementCapture {
       video.autoplay = true;
       video.muted = true;
       video.playsInline = true;
-      video.style.display = 'none'; // Hide it
+      // Use off-screen positioning instead of display:none
+      // Mobile browsers may not decode frames for hidden elements
+      video.style.position = 'fixed';
+      video.style.top = '-9999px';
+      video.style.left = '-9999px';
+      video.style.width = '1px';
+      video.style.height = '1px';
       video.srcObject = stream;
 
       // Add to document body (required for some browsers to properly load video)


### PR DESCRIPTION
## Summary
- Mobile browsers may skip decoding video frames for elements with `display:none`
- Changed to off-screen positioning (`position: fixed; top: -9999px`) to keep elements in render tree while invisible
- This should fix remote video not showing on mobile Chrome

## Test plan
- [ ] Test on mobile Chrome with two participants
- [ ] Verify remote video appears (no spinner)
- [ ] Verify local video still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)