### PR TITLE
feat(chat): add text-to-speech for Clawd responses

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -4,16 +4,19 @@ import 'package:flutter/foundation.dart';
 import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
+import 'package:tech_world/services/tts_service.dart';
 
 /// Service that manages shared chat with Claude bot via LiveKit data channels.
 /// All participants see all messages (questions and responses).
 class ChatService {
   ChatService({required LiveKitService liveKitService})
-      : _liveKitService = liveKitService {
+      : _liveKitService = liveKitService,
+        _ttsService = TtsService() {
     _subscribeToMessages();
   }
 
   final LiveKitService _liveKitService;
+  final TtsService _ttsService;
   final _messagesController = StreamController<List<ChatMessage>>.broadcast();
   final List<ChatMessage> _messages = [];
   final Map<String, Completer<void>> _pendingMessages = {};
@@ -62,6 +65,8 @@ class ChatService {
         senderName: 'Clawd',
         isBot: true,
       ));
+      // Speak the response
+      _ttsService.speak(text);
     } else {
       // Message from another user
       _messages.add(ChatMessage(
@@ -153,5 +158,6 @@ class ChatService {
   void dispose() {
     _chatSubscription?.cancel();
     _messagesController.close();
+    _ttsService.dispose();
   }
 }

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -1,0 +1,7 @@
+// Platform-aware TTS service.
+//
+// Exports the appropriate implementation based on platform:
+// - On web: Uses browser's speechSynthesis API
+// - On native: Uses a no-op stub
+
+export 'tts_service_stub.dart' if (dart.library.js_interop) 'tts_service_web.dart';

--- a/lib/services/tts_service_stub.dart
+++ b/lib/services/tts_service_stub.dart
@@ -1,0 +1,18 @@
+// Stub implementation of TTS service for non-web platforms.
+//
+// This is a no-op implementation used when running on platforms
+// that don't support browser speechSynthesis.
+
+/// Stub TTS service that does nothing.
+class TtsService {
+  bool get isReady => false;
+
+  Future<void> speak(String text) async {
+    // No-op on non-web platforms
+  }
+
+  void stop() {}
+  void setRate(double rate) {}
+  void setPitch(double pitch) {}
+  void dispose() {}
+}

--- a/lib/services/tts_service_web.dart
+++ b/lib/services/tts_service_web.dart
@@ -1,0 +1,130 @@
+// Web implementation of text-to-speech using browser's speechSynthesis API.
+//
+// This file should only be imported on web platforms.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:web/web.dart' as web;
+
+/// Text-to-speech service using browser's speechSynthesis API.
+class TtsService {
+  TtsService() {
+    _loadVoices();
+  }
+
+  web.SpeechSynthesisVoice? _selectedVoice;
+  bool _isReady = false;
+  double _rate = 1.0;
+  double _pitch = 1.0;
+
+  /// Whether the TTS service is ready to speak.
+  bool get isReady => _isReady;
+
+  /// Load available voices.
+  void _loadVoices() {
+    // Voices may not be available immediately
+    final voices = web.window.speechSynthesis.getVoices();
+    if (voices.length > 0) {
+      _selectBestVoice(voices);
+      _isReady = true;
+    } else {
+      // Wait for voices to load
+      web.window.speechSynthesis.onvoiceschanged = (web.Event event) {
+        final loadedVoices = web.window.speechSynthesis.getVoices();
+        _selectBestVoice(loadedVoices);
+        _isReady = true;
+      }.toJS;
+    }
+  }
+
+  /// Select the best voice for Clawd.
+  void _selectBestVoice(JSArray<web.SpeechSynthesisVoice> voices) {
+    final voiceList = voices.toDart;
+    debugPrint('TtsService: ${voiceList.length} voices available');
+
+    // Preference order for a friendly tutor voice:
+    // 1. Google UK English (clear, friendly)
+    // 2. Any UK English voice
+    // 3. Google US English
+    // 4. Any US English voice
+    // 5. First English voice
+    // 6. Default
+
+    for (final voice in voiceList) {
+      debugPrint('TtsService: Voice: ${voice.name} (${voice.lang})');
+    }
+
+    // Try to find a good English voice
+    _selectedVoice = voiceList.cast<web.SpeechSynthesisVoice?>().firstWhere(
+          (v) => v!.name.contains('Google UK English'),
+          orElse: () => voiceList.cast<web.SpeechSynthesisVoice?>().firstWhere(
+                (v) => v!.lang.startsWith('en-GB'),
+                orElse: () => voiceList.cast<web.SpeechSynthesisVoice?>().firstWhere(
+                      (v) => v!.name.contains('Google US English'),
+                      orElse: () => voiceList.cast<web.SpeechSynthesisVoice?>().firstWhere(
+                            (v) => v!.lang.startsWith('en'),
+                            orElse: () => voiceList.isNotEmpty ? voiceList.first : null,
+                          ),
+                    ),
+              ),
+        );
+
+    if (_selectedVoice != null) {
+      debugPrint('TtsService: Selected voice: ${_selectedVoice!.name}');
+    }
+  }
+
+  /// Speak the given text.
+  Future<void> speak(String text) async {
+    if (text.isEmpty) return;
+
+    // Cancel any ongoing speech
+    web.window.speechSynthesis.cancel();
+
+    final utterance = web.SpeechSynthesisUtterance(text);
+
+    if (_selectedVoice != null) {
+      utterance.voice = _selectedVoice;
+    }
+
+    utterance.rate = _rate;
+    utterance.pitch = _pitch;
+
+    final completer = Completer<void>();
+
+    utterance.onend = (web.Event event) {
+      if (!completer.isCompleted) completer.complete();
+    }.toJS;
+
+    utterance.onerror = (web.Event event) {
+      debugPrint('TtsService: Speech error');
+      if (!completer.isCompleted) completer.complete();
+    }.toJS;
+
+    web.window.speechSynthesis.speak(utterance);
+
+    // Don't wait for completion - let it speak in background
+    // return completer.future;
+  }
+
+  /// Stop any ongoing speech.
+  void stop() {
+    web.window.speechSynthesis.cancel();
+  }
+
+  /// Set speech rate (0.1 to 10, default 1.0).
+  void setRate(double rate) {
+    _rate = rate.clamp(0.1, 10.0);
+  }
+
+  /// Set speech pitch (0 to 2, default 1.0).
+  void setPitch(double pitch) {
+    _pitch = pitch.clamp(0.0, 2.0);
+  }
+
+  void dispose() {
+    stop();
+  }
+}


### PR DESCRIPTION
## Summary
- Clawd now speaks responses using browser's `speechSynthesis` API
- Web-only implementation (no-op stub for native platforms)
- Auto-selects best available English voice (prefers UK English)

## How it works
1. When Clawd's response is received via LiveKit
2. `TtsService.speak()` is called with the response text
3. Browser speaks the text (can be interrupted by new responses)

## Test plan
- [ ] Open the web app
- [ ] Send a message to Clawd
- [ ] Verify Clawd's response is spoken aloud
- [ ] Verify text still appears in chat panel

## Future improvements
- Add mute/unmute toggle in UI
- Upgrade to ElevenLabs for better voice quality
- Add voice selection UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)