### PR TITLE
feat(chat): add speech-to-text for voice input

### DIFF
--- a/lib/services/stt_service.dart
+++ b/lib/services/stt_service.dart
@@ -1,0 +1,7 @@
+// Platform-aware STT service.
+//
+// Exports the appropriate implementation based on platform:
+// - On web: Uses browser's SpeechRecognition API
+// - On native: Uses a no-op stub
+
+export 'stt_service_stub.dart' if (dart.library.js_interop) 'stt_service_web.dart';

--- a/lib/services/stt_service_stub.dart
+++ b/lib/services/stt_service_stub.dart
@@ -1,0 +1,15 @@
+// Stub implementation of STT service for non-web platforms.
+
+import 'package:flutter/foundation.dart' show ValueNotifier;
+
+/// Stub STT service that does nothing.
+class SttService {
+  bool get isSupported => false;
+  final ValueNotifier<bool> listening = ValueNotifier(false);
+
+  Future<String?> listen() async => null;
+  void stop() {}
+  void dispose() {
+    listening.dispose();
+  }
+}

--- a/lib/services/stt_service_web.dart
+++ b/lib/services/stt_service_web.dart
@@ -1,0 +1,135 @@
+// Web implementation of speech-to-text using browser's SpeechRecognition API.
+//
+// This file should only be imported on web platforms.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter/foundation.dart' show debugPrint, ValueNotifier;
+
+/// Speech-to-text service using browser's SpeechRecognition API.
+class SttService {
+  SttService() {
+    _isSupported = globalContext.has('webkitSpeechRecognition') ||
+        globalContext.has('SpeechRecognition');
+    debugPrint('SttService: supported=$_isSupported');
+  }
+
+  bool _isSupported = false;
+  JSObject? _recognition;
+  bool _isListening = false;
+  Completer<String?>? _resultCompleter;
+
+  /// Whether speech recognition is supported in this browser.
+  bool get isSupported => _isSupported;
+
+  /// Whether currently listening for speech.
+  final ValueNotifier<bool> listening = ValueNotifier(false);
+
+  /// Start listening for speech and return the recognized text.
+  ///
+  /// Returns null if cancelled, unsupported, or error.
+  Future<String?> listen() async {
+    if (!_isSupported) {
+      debugPrint('SttService: Not supported');
+      return null;
+    }
+
+    if (_isListening) {
+      stop();
+      return null;
+    }
+
+    _resultCompleter = Completer<String?>();
+
+    try {
+      // Create SpeechRecognition instance
+      final constructor = globalContext.has('webkitSpeechRecognition')
+          ? globalContext['webkitSpeechRecognition'] as JSFunction
+          : globalContext['SpeechRecognition'] as JSFunction;
+
+      _recognition = constructor.callAsConstructor<JSObject>();
+
+      // Configure
+      _recognition!['continuous'] = false.toJS;
+      _recognition!['interimResults'] = false.toJS;
+      _recognition!['lang'] = 'en-US'.toJS;
+
+      // Handle result
+      _recognition!['onresult'] = (JSObject event) {
+        try {
+          final results = event['results']! as JSObject;
+          final firstResult = results['0'] as JSObject;
+          final firstAlt = firstResult['0'] as JSObject;
+          final transcript = (firstAlt['transcript'] as JSString).toDart;
+          debugPrint('SttService: Recognized: "$transcript"');
+          if (!_resultCompleter!.isCompleted) {
+            _resultCompleter!.complete(transcript);
+          }
+        } catch (e) {
+          debugPrint('SttService: Result parse error: $e');
+          if (!_resultCompleter!.isCompleted) {
+            _resultCompleter!.complete(null);
+          }
+        }
+        _setListening(false);
+      }.toJS;
+
+      // Handle error
+      _recognition!['onerror'] = (JSObject event) {
+        final error = (event['error'] as JSString?)?.toDart;
+        debugPrint('SttService: Error: $error');
+        if (!_resultCompleter!.isCompleted) {
+          _resultCompleter!.complete(null);
+        }
+        _setListening(false);
+      }.toJS;
+
+      // Handle end (no result)
+      _recognition!['onend'] = (JSObject event) {
+        debugPrint('SttService: Ended');
+        if (!_resultCompleter!.isCompleted) {
+          _resultCompleter!.complete(null);
+        }
+        _setListening(false);
+      }.toJS;
+
+      // Start listening
+      _recognition!.callMethod('start'.toJS);
+      _setListening(true);
+      debugPrint('SttService: Listening...');
+
+      return await _resultCompleter!.future;
+    } catch (e) {
+      debugPrint('SttService: Exception: $e');
+      _setListening(false);
+      if (_resultCompleter != null && !_resultCompleter!.isCompleted) {
+        _resultCompleter!.complete(null);
+      }
+      return null;
+    }
+  }
+
+  /// Stop listening.
+  void stop() {
+    if (_recognition != null) {
+      try {
+        _recognition!.callMethod('stop'.toJS);
+      } catch (e) {
+        debugPrint('SttService: Stop error: $e');
+      }
+    }
+    _setListening(false);
+  }
+
+  void _setListening(bool value) {
+    _isListening = value;
+    listening.value = value;
+  }
+
+  void dispose() {
+    stop();
+    listening.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds browser SpeechRecognition API integration for voice-to-text input in chat
- Mic button appears in chat panel on supported browsers (Chrome, Edge, Safari)
- Button turns red while actively listening, auto-sends recognized text to Clawd
- Platform-conditional export: web uses browser API, native platforms get no-op stub

## Test plan
- [ ] Open chat panel in Chrome, verify mic button appears
- [ ] Tap mic, speak a message, verify it's recognized and sent to Clawd
- [ ] Tap mic while listening to cancel
- [ ] Verify mic button doesn't appear on unsupported browsers
- [ ] Run `flutter test` - all 406 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)