### PR TITLE
feat(map-editor): show PNG map overlay in editor mode

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -82,7 +82,17 @@ class TechWorld extends World with TapCallbacks {
   void enterEditorMode(MapEditorState editorState) {
     // Close code editor if open.
     activeChallenge.value = null;
+
+    // Pre-load the current map so the editor and canvas show existing layout.
+    editorState.loadFromGameMap(defaultMap);
+
     mapEditorActive.value = true;
+
+    // Bring the PNG map background above everything else.
+    final game = findGame() as TechWorldGame?;
+    if (game != null) {
+      game.background.priority = 1000;
+    }
 
     // Hide normal barriers and add the preview component.
     _barriersComponent.renderBarriers = false;
@@ -93,6 +103,12 @@ class TechWorld extends World with TapCallbacks {
   /// Exit map editor mode — removes preview, restores barriers.
   void exitEditorMode() {
     mapEditorActive.value = false;
+
+    // Restore the PNG map background to its normal layer.
+    final game = findGame() as TechWorldGame?;
+    if (game != null) {
+      game.background.priority = 0;
+    }
 
     if (_mapPreviewComponent != null) {
       _mapPreviewComponent!.removeFromParent();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -239,6 +239,7 @@ class _MyAppState extends State<MyApp> {
                                 child: MapEditorPanel(
                                   state: _mapEditorState,
                                   onClose: techWorld.exitEditorMode,
+                                  referenceMap: defaultMap,
                                 ),
                               );
                             }


### PR DESCRIPTION
## Summary
- Brings `single_room.png` background above all game components (priority 1000) when map editor mode is active, so the actual map is visible on the game canvas
- Overlays the PNG map at 50% opacity on the sidebar paintable grid with `IgnorePointer` so painting still works underneath
- Restores normal background priority when exiting editor mode

## Test plan
- [x] All 504 tests pass
- [x] Manual verification: PNG map visible on game canvas in editor mode
- [x] Manual verification: PNG map overlaid on sidebar grid in editor mode
- [x] Manual verification: Grid painting still works through the overlay
- [x] Manual verification: Exiting editor mode restores normal rendering

Generated with [Claude Code](https://claude.com/claude-code)