### PR TITLE
fix(wall-occlusion): correct priority and extend overlay above barrier

### DIFF
--- a/lib/flame/components/wall_occlusion_component.dart
+++ b/lib/flame/components/wall_occlusion_component.dart
@@ -7,6 +7,11 @@ import 'package:tech_world/flame/shared/constants.dart';
 /// Creates sprite overlays for each barrier cell using a sub-region of the
 /// background PNG. These overlays sit above the background but use y-based
 /// priority so that characters walking behind (north of) walls are occluded.
+///
+/// Each overlay extends [_wallArtHeight] cells above the barrier to cover the
+/// visible wall face in the PNG. The priority equals the barrier's y so that
+/// characters south of the wall (higher y) render in front, and characters
+/// north (lower y) render behind.
 class WallOcclusionComponent extends Component {
   WallOcclusionComponent({
     required ui.Image backgroundImage,
@@ -18,30 +23,38 @@ class WallOcclusionComponent extends Component {
   final List<Point<int>> _barriers;
   final List<SpriteComponent> _overlays = [];
 
+  /// How many cells above each barrier the wall art extends in the PNG.
+  static const _wallArtHeight = 1;
+
   @override
   Future<void> onLoad() async {
     for (final barrier in _barriers) {
-      final srcX = barrier.x * gridSquareSizeDouble;
-      final srcY = barrier.y * gridSquareSizeDouble;
+      // The overlay starts _wallArtHeight cells above the barrier and extends
+      // down through the barrier cell itself.
+      final topY = max(0, barrier.y - _wallArtHeight);
+      final heightInCells = barrier.y - topY + 1;
 
-      // Skip if the barrier cell falls outside the image bounds.
+      final srcX = barrier.x * gridSquareSizeDouble;
+      final srcY = topY * gridSquareSizeDouble;
+      final srcH = heightInCells * gridSquareSizeDouble;
+
+      // Skip if the source rect falls outside the image bounds.
       if (srcX + gridSquareSizeDouble > _backgroundImage.width ||
-          srcY + gridSquareSizeDouble > _backgroundImage.height) {
+          srcY + srcH > _backgroundImage.height) {
         continue;
       }
 
       final sprite = Sprite(
         _backgroundImage,
         srcPosition: Vector2(srcX, srcY),
-        srcSize: Vector2.all(gridSquareSizeDouble),
+        srcSize: Vector2(gridSquareSizeDouble, srcH),
       );
 
       final overlay = SpriteComponent(
         sprite: sprite,
         position: Vector2(srcX, srcY),
-        size: Vector2.all(gridSquareSizeDouble),
-        // +2 accounts for 64px-tall character sprites spanning 2 grid rows.
-        priority: barrier.y + 2,
+        size: Vector2(gridSquareSizeDouble, srcH),
+        priority: barrier.y,
       );
 
       _overlays.add(overlay);


### PR DESCRIPTION
## Summary
- Fix wall overlay priority from `barrier.y + 2` to `barrier.y` so characters south of walls correctly render in front
- Extend each overlay 1 cell above the barrier to cover the visible wall face art in the PNG
- Remove debug tint and logging added during investigation

Fixes the occlusion appearing below the wall instead of above it (characters south of the wall were being incorrectly occluded).

## Test plan
- [x] `flutter analyze --fatal-infos` passes
- [x] `flutter test` passes (504 tests)
- [x] Manual: walk character behind wall at y=7 — character partially occluded (head visible)
- [x] Manual: walk character south of wall — character fully visible in front of wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)