### PR TITLE
fix(map-editor): show background PNG through editor preview

### DIFF
--- a/lib/flame/components/map_preview_component.dart
+++ b/lib/flame/components/map_preview_component.dart
@@ -33,7 +33,9 @@ class MapPreviewComponent extends Component {
     for (var y = 0; y < gridSize; y++) {
       for (var x = 0; x < gridSize; x++) {
         final tile = editorState.tileAt(x, y);
-        paint.color = _colorForTile(tile);
+        // Skip open tiles so the background PNG shows through.
+        if (tile == TileType.open) continue;
+        paint.color = _colorForTile(tile).withValues(alpha: 0.6);
         canvas.drawRect(
           Rect.fromLTWH(
             x * gridSquareSizeDouble,


### PR DESCRIPTION
## Summary
- `MapPreviewComponent` was drawing opaque dark-grey tiles for every open cell, completely covering the `single_room.png` background when entering map editor mode
- Skip open tiles so the background art shows through, and render barrier/spawn/terminal tiles at 60% opacity so both the map art and editor state are visible

## Test plan
- [x] All 504 tests pass
- [x] Open map editor — background PNG is visible with semi-transparent editor overlays on top
- [x] Paint barriers/terminals — colored overlays appear over the map art
- [x] Close editor — normal game view restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)