### PR TITLE
fix(maps): auto-exit editor mode on map switch

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -668,8 +668,10 @@ class TechWorld extends World with TapCallbacks {
 
   /// Switch to a different map at runtime.
   Future<void> loadMap(GameMap map) async {
-    if (mapEditorActive.value) return; // Don't switch while editing.
     if (map.id == currentMap.value.id) return; // Already on this map.
+
+    // Auto-exit editor mode if active.
+    if (mapEditorActive.value) exitEditorMode();
 
     // Close code editor if open — the terminals are about to change.
     activeChallenge.value = null;


### PR DESCRIPTION
## Summary
- When the map editor was active, `loadMap()` silently returned without switching maps, making the dropdown appear broken after accidentally triggering the editor button
- Now auto-exits editor mode before switching maps instead of blocking

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 504 tests pass
- [x] Verified on macOS: map selector works repeatedly, including when editor mode was active

🤖 Generated with [Claude Code](https://claude.com/claude-code)