### PR TITLE
fix(ux): polish prototype for grant assessor demo

### DIFF
--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -8,10 +8,11 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:tech_world/auth/auth_user.dart';
 import 'package:tech_world/auth/user_profile_service.dart';
 
-/// When a user signs in the [User] member is updated but the only time the
-/// [authStateChanges] [Stream] emits a [User] is on
-/// [FirebaseAuth.instance.authStateChanges].
-/// TODO: this needs testing an more documentation.
+/// Manages Firebase Authentication state.
+///
+/// When a user signs in the [_user] member is updated, but the
+/// [authStateChanges] stream only emits when
+/// [FirebaseAuth.instance.authStateChanges] fires.
 class AuthService {
   AuthUser _user = PlaceholderUser();
   final _userProfileService = UserProfileService();

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' show Colors;
+import 'package:flutter/material.dart' show Colors, FontWeight, TextStyle;
 
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
@@ -719,7 +719,36 @@ class TechWorld extends World with TapCallbacks {
     );
     if (distance <= _terminalProximityThreshold) {
       activeChallenge.value = challengeId;
+    } else {
+      _showHint(
+        'Walk closer to use this terminal',
+        Vector2(
+          terminalPos.x * gridSquareSizeDouble + gridSquareSizeDouble / 2,
+          terminalPos.y * gridSquareSizeDouble - 12,
+        ),
+      );
     }
+  }
+
+  /// Show an ephemeral text hint that fades out after a short delay.
+  void _showHint(String message, Vector2 position) {
+    final hint = TextComponent(
+      text: message,
+      position: position,
+      anchor: Anchor.bottomCenter,
+      textRenderer: TextPaint(
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      priority: 1000,
+    );
+    add(hint);
+    Future.delayed(const Duration(seconds: 2), () {
+      hint.removeFromParent();
+    });
   }
 
   /// Disconnect from LiveKit and clear all related state.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ class _MyAppState extends State<MyApp> {
   ChatService? _chatService;
   ProximityService? _proximityService;
   final MapEditorState _mapEditorState = MapEditorState();
+  bool _liveKitConnectionFailed = false;
 
   @override
   void initState() {
@@ -114,6 +115,7 @@ class _MyAppState extends State<MyApp> {
       _liveKitService = null;
       _chatService = null;
       _proximityService = null;
+      _liveKitConnectionFailed = false;
       Locator.remove<LiveKitService>();
       Locator.remove<ChatService>();
       Locator.remove<ProximityService>();
@@ -144,6 +146,8 @@ class _MyAppState extends State<MyApp> {
         // Enable camera and microphone
         await _liveKitService!.setCameraEnabled(true);
         await _liveKitService!.setMicrophoneEnabled(true);
+      } else {
+        _liveKitConnectionFailed = true;
       }
 
       setState(() {}); // Trigger rebuild to show overlay
@@ -328,6 +332,39 @@ class _MyAppState extends State<MyApp> {
                     );
                   },
                 ),
+                // Connection failure banner
+                if (_liveKitConnectionFailed)
+                  Positioned(
+                    bottom: 16,
+                    left: 16,
+                    child: Material(
+                      color: Colors.transparent,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 10,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.orange.shade800,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: const Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.wifi_off, color: Colors.white, size: 18),
+                            SizedBox(width: 8),
+                            Text(
+                              'Video & chat unavailable — connection failed',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
               ],
             );
           },

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "tech_world",
-    "short_name": "tech_world",
+    "name": "Tech World",
+    "short_name": "Tech World",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#000000",
     "theme_color": "#000000",
-    "description": "A new Flutter project.",
+    "description": "A multiplayer coding adventure where real programming is the gameplay.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
## Summary
- **Auth error handling**: Added try/catch with friendly error messages to email/password auth, cleaned up error messages for anonymous, Apple, and Google sign-in (no more raw exception strings)
- **LiveKit connection banner**: Shows orange "Video & chat unavailable" banner when LiveKit connection fails; resets on sign-out
- **Terminal proximity feedback**: Shows ephemeral "Walk closer to use this terminal" hint when tapping a terminal from too far away
- **Web manifest**: Updated name/description from "A new Flutter project" to "Tech World"
- **Auth service**: Replaced TODO comment with proper doc comment

## Test plan
- [x] `flutter analyze --fatal-infos` passes (0 issues)
- [x] All 504 tests pass
- [ ] Manual: test email/password sign-in with wrong password → friendly error
- [ ] Manual: test terminal tap when far away → hint appears and fades

🤖 Generated with [Claude Code](https://claude.com/claude-code)