### PR TITLE
feat(chat): add collapsible chat panel toggle

### DIFF
--- a/lib/chat/chat_panel.dart
+++ b/lib/chat/chat_panel.dart
@@ -7,10 +7,12 @@ import 'package:tech_world/services/stt_service.dart';
 class ChatPanel extends StatefulWidget {
   const ChatPanel({
     required this.chatService,
+    this.onCollapse,
     super.key,
   });
 
   final ChatService chatService;
+  final VoidCallback? onCollapse;
 
   @override
   State<ChatPanel> createState() => _ChatPanelState();
@@ -111,6 +113,21 @@ class _ChatPanelState extends State<ChatPanel> {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
+                if (widget.onCollapse != null) ...[
+                  const Spacer(),
+                  IconButton(
+                    onPressed: widget.onCollapse,
+                    icon: const Icon(Icons.chevron_right),
+                    color: Colors.grey[400],
+                    iconSize: 20,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(
+                      minWidth: 28,
+                      minHeight: 28,
+                    ),
+                    tooltip: 'Collapse chat',
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ class _MyAppState extends State<MyApp> {
   ChatService? _chatService;
   ProximityService? _proximityService;
   final MapEditorState _mapEditorState = MapEditorState();
+  final ValueNotifier<bool> _chatCollapsed = ValueNotifier<bool>(false);
   bool _liveKitConnectionFailed = false;
 
   @override
@@ -287,12 +288,47 @@ class _MyAppState extends State<MyApp> {
                                     ),
                                   );
                                 }
-                                return SizedBox(
-                                  width:
-                                      constraints.maxWidth >= 800 ? 320 : 280,
-                                  child: ChatPanel(
-                                    chatService: chatService,
-                                  ),
+                                return ValueListenableBuilder<bool>(
+                                  valueListenable: _chatCollapsed,
+                                  builder: (context, collapsed, _) {
+                                    if (collapsed) {
+                                      return Container(
+                                        width: 48,
+                                        color: const Color(0xFF2D2D2D),
+                                        child: Align(
+                                          alignment: Alignment.topCenter,
+                                          child: Padding(
+                                            padding:
+                                                const EdgeInsets.only(top: 12),
+                                            child: IconButton(
+                                              onPressed: () =>
+                                                  _chatCollapsed.value = false,
+                                              icon:
+                                                  const Icon(Icons.chat_bubble),
+                                              color: const Color(0xFFD97757),
+                                              tooltip: 'Open chat',
+                                              style: IconButton.styleFrom(
+                                                backgroundColor:
+                                                    const Color(0xFFD97757)
+                                                        .withValues(
+                                                            alpha: 0.1),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                    return SizedBox(
+                                      width: constraints.maxWidth >= 800
+                                          ? 320
+                                          : 280,
+                                      child: ChatPanel(
+                                        chatService: chatService,
+                                        onCollapse: () =>
+                                            _chatCollapsed.value = true,
+                                      ),
+                                    );
+                                  },
                                 );
                               },
                             );
@@ -309,9 +345,24 @@ class _MyAppState extends State<MyApp> {
                     if (!snapshot.hasData || snapshot.data is SignedOutUser) {
                       return const SizedBox.shrink();
                     }
+                    return ValueListenableBuilder<bool>(
+                      valueListenable: _chatCollapsed,
+                      builder: (context, chatCollapsed, child) {
+                    final techWorld = locate<TechWorld>();
+                    // Toolbar offset depends on what's showing in the side panel
+                    final double toolbarRight;
+                    if (techWorld.mapEditorActive.value) {
+                      toolbarRight = (constraints.maxWidth >= 800 ? 480 : 360) + 16;
+                    } else if (techWorld.activeChallenge.value != null) {
+                      toolbarRight = (constraints.maxWidth >= 800 ? 480 : 360) + 16;
+                    } else if (chatCollapsed) {
+                      toolbarRight = 64;
+                    } else {
+                      toolbarRight = constraints.maxWidth >= 800 ? 336 : 296;
+                    }
                     return Positioned(
                       top: 16,
-                      right: constraints.maxWidth >= 800 ? 336 : 296,
+                      right: toolbarRight,
                       child: SafeArea(
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
@@ -329,6 +380,8 @@ class _MyAppState extends State<MyApp> {
                           ],
                         ),
                       ),
+                    );
+                      },
                     );
                   },
                 ),


### PR DESCRIPTION
## Summary
- Add collapse/expand toggle to the chat panel header (chevron-right icon)
- When collapsed, the panel shrinks to a 48px strip with an orange chat icon to re-expand
- Toolbar repositions dynamically based on which side panel is showing (editor, code editor, chat expanded, or chat collapsed)

## Changes
- `lib/chat/chat_panel.dart` — Added optional `onCollapse` callback and collapse `IconButton` in the header row
- `lib/main.dart` — Added `_chatCollapsed` `ValueNotifier`, collapsed strip UI, and dynamic toolbar offset calculation

## Test plan
- [x] `flutter analyze --fatal-infos` passes
- [x] All 504 tests pass
- [ ] Manual: chat panel collapses to narrow strip on chevron click
- [ ] Manual: re-expands on chat icon click
- [ ] Manual: toolbar repositions correctly in both states
- [ ] Manual: map editor and code editor panels unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)