### PR TITLE
feat(editor): display code editor as centered modal

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:tech_world/auth/auth_gate.dart';
 import 'package:tech_world/auth/auth_service.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -490,34 +491,45 @@ class _CodeEditorModal extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Positioned.fill(
-      child: Stack(
-        children: [
-          // Semi-transparent scrim — tap to close
-          GestureDetector(
-            onTap: onClose,
-            child: Container(color: Colors.black54),
-          ),
-          // Centered editor
-          Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 720),
-              child: FractionallySizedBox(
-                heightFactor: 0.85,
-                child: Material(
-                  color: const Color(0xFF1E1E1E),
-                  borderRadius: BorderRadius.circular(12),
-                  clipBehavior: Clip.antiAlias,
-                  elevation: 24,
-                  child: CodeEditorPanel(
-                    challenge: challenge,
-                    onClose: onClose,
-                    onSubmit: onSubmit,
+      child: Focus(
+        autofocus: true,
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent &&
+              event.logicalKey == LogicalKeyboardKey.escape) {
+            onClose();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: Stack(
+          children: [
+            // Semi-transparent scrim — tap to close
+            GestureDetector(
+              onTap: onClose,
+              child: Container(color: Colors.black54),
+            ),
+            // Centered editor
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 720),
+                child: FractionallySizedBox(
+                  heightFactor: 0.85,
+                  child: Material(
+                    color: const Color(0xFF1E1E1E),
+                    borderRadius: BorderRadius.circular(12),
+                    clipBehavior: Clip.antiAlias,
+                    elevation: 24,
+                    child: CodeEditorPanel(
+                      challenge: challenge,
+                      onClose: onClose,
+                      onSubmit: onSubmit,
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Move the code editor from the sidebar panel into a centered modal overlay
- Editor renders with a semi-transparent scrim backdrop (click to dismiss)
- Constrained to 720px max width and 85% screen height with rounded corners
- Chat panel remains visible behind the modal when editor is open
- Sidebar chain simplified to: map editor or chat (no intermediate editor branch)
- Toolbar offset logic cleaned up (no longer accounts for editor sidebar width)

## Test plan
- [x] `flutter analyze --fatal-infos` passes
- [x] All 506 tests pass
- [ ] Manual: walk to terminal, tap → modal appears centered with scrim
- [ ] Click outside modal or press close/cancel → modal dismisses
- [ ] Submit code → modal closes, chat message sent
- [ ] Map editor still works as sidebar (unaffected)
- [ ] Chat panel stays visible behind the modal scrim

🤖 Generated with [Claude Code](https://claude.com/claude-code)