### PR TITLE
fix(progress): refresh terminal states on auth change

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -699,6 +699,8 @@ class TechWorld extends World with TapCallbacks {
       if (authUser is SignedOutUser) {
         // User signed out - clear LiveKit state so we can reconnect on next sign-in
         _disconnectFromLiveKit();
+        // Clear stale terminal completion indicators from the previous user.
+        refreshTerminalStates();
       } else if (authUser is! PlaceholderUser) {
         _userPlayerComponent.id = authUser.id;
         _userPlayerComponent.displayName = authUser.displayName;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -165,6 +165,7 @@ class _MyAppState extends State<MyApp> {
         // Continue — terminals will render as incomplete, which is safe.
       }
       Locator.add<ProgressService>(_progressService!);
+      locate<TechWorld>().refreshTerminalStates();
 
       _liveKitService = LiveKitService(
         userId: user.id,


### PR DESCRIPTION
## Summary

Terminal completion indicators (gold borders/checkmarks) persisted across sign-out/sign-in because `refreshTerminalStates()` was never called on auth state changes. A new user would see the previous user's completed challenges even though Firestore data is correctly scoped per-UID.

**Two lines added:**
- On sign-out in `TechWorld`: call `refreshTerminalStates()` after `_disconnectFromLiveKit()` to clear stale gold borders (ProgressService already removed from Locator, so `_isChallengeCompleted` returns `false`)
- On sign-in in `main.dart`: call `refreshTerminalStates()` after registering the new `ProgressService` to load the new user's actual completion state

## Test plan
- [x] All 580 tests pass
- [x] `flutter analyze` clean
- [ ] Manual: sign in as guest, complete a challenge, sign out, sign in as new guest → terminals should show as incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)