### PR TITLE
feat(rooms): add room system with persistence, lobby, and dynamic LiveKit rooms

### DIFF
--- a/lib/flame/maps/generators/cave_generator.dart
+++ b/lib/flame/maps/generators/cave_generator.dart
@@ -25,7 +25,7 @@ GameMap generateCave({required int seed, required GeneratorConfig config}) {
   removeDisconnectedRegions(grid, region);
   final spawn = findSpawnPoint(grid, region);
 
-  final layers = buildTileLayers(grid, floorTileIndex: 162);
+  final layers = buildTileLayers(grid, floorTileIndex: floorTileBrownEarth);
 
   return GameMap(
     id: 'generated_cave_$seed',

--- a/lib/flame/maps/generators/dungeon_generator.dart
+++ b/lib/flame/maps/generators/dungeon_generator.dart
@@ -57,7 +57,7 @@ GameMap generateDungeon({required int seed, required GeneratorConfig config}) {
       ? Point(_centerX(rooms.first), _centerY(rooms.first))
       : findSpawnPoint(grid, region);
 
-  final layers = buildTileLayers(grid, floorTileIndex: 120);
+  final layers = buildTileLayers(grid, floorTileIndex: floorTileGrayStone);
 
   return GameMap(
     id: 'generated_dungeon_$seed',

--- a/lib/flame/maps/generators/grid_utils.dart
+++ b/lib/flame/maps/generators/grid_utils.dart
@@ -115,14 +115,30 @@ Point<int> findSpawnPoint(Grid grid, Set<Point<int>> region) {
   return best ?? const Point(25, 25);
 }
 
+// ---------------------------------------------------------------------------
+// Tile index constants for `room_builder_office` tileset (16 cols × 14 rows).
+// ---------------------------------------------------------------------------
+
+/// Dark wall fill tile (row 4, col 5).
+const wallTileDefault = 69;
+
+/// Light stone center — used for maze floors (row 5, col 3).
+const floorTileLightStone = 83;
+
+/// Gray stone — used for dungeon floors (row 7, col 8).
+const floorTileGrayStone = 120;
+
+/// Brown/earth — used for cave floors (row 10, col 2).
+const floorTileBrownEarth = 162;
+
 /// Builds floor and object tile layers from a boolean [grid].
 ///
 /// Open cells get a floor tile at [floorTileIndex], wall cells get a wall tile
 /// at [wallTileIndex]. Both reference the [tilesetId] tileset.
 ({TileLayerData floor, TileLayerData objects}) buildTileLayers(
   Grid grid, {
-  int floorTileIndex = 83,
-  int wallTileIndex = 69,
+  int floorTileIndex = floorTileLightStone,
+  int wallTileIndex = wallTileDefault,
   String tilesetId = 'room_builder_office',
 }) {
   final floor = TileLayerData();

--- a/lib/map_editor/map_editor_panel.dart
+++ b/lib/map_editor/map_editor_panel.dart
@@ -679,46 +679,95 @@ class _GenerateSection extends StatefulWidget {
 
 class _GenerateSectionState extends State<_GenerateSection> {
   MapAlgorithm _selected = MapAlgorithm.dungeon;
+  int? _lastSeed;
+
+  void _generate() {
+    final seed = Random().nextInt(1 << 32);
+    final map = generateMap(
+      algorithm: _selected,
+      config: GeneratorConfig(seed: seed),
+    );
+    widget.state.loadFromGameMap(map);
+    setState(() => _lastSeed = seed);
+  }
+
+  void _regenerateWithSeed(int seed) {
+    final map = generateMap(
+      algorithm: _selected,
+      config: GeneratorConfig(seed: seed),
+    );
+    widget.state.loadFromGameMap(map);
+    setState(() => _lastSeed = seed);
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(
-          child: DropdownButtonHideUnderline(
-            child: DropdownButton<MapAlgorithm>(
-              isExpanded: true,
-              value: _selected,
-              dropdownColor: const Color(0xFF2D2D2D),
-              iconEnabledColor: Colors.grey,
-              style: const TextStyle(color: Colors.white, fontSize: 13),
-              items: [
-                for (final algo in MapAlgorithm.values)
-                  DropdownMenuItem(
-                    value: algo,
-                    child: Text(algo.displayName),
-                  ),
+        Row(
+          children: [
+            Expanded(
+              child: DropdownButtonHideUnderline(
+                child: DropdownButton<MapAlgorithm>(
+                  isExpanded: true,
+                  value: _selected,
+                  dropdownColor: const Color(0xFF2D2D2D),
+                  iconEnabledColor: Colors.grey,
+                  style: const TextStyle(color: Colors.white, fontSize: 13),
+                  items: [
+                    for (final algo in MapAlgorithm.values)
+                      DropdownMenuItem(
+                        value: algo,
+                        child: Text(algo.displayName),
+                      ),
+                  ],
+                  onChanged: (algo) {
+                    if (algo != null) setState(() => _selected = algo);
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton.icon(
+              onPressed: _generate,
+              icon: const Icon(Icons.casino, size: 14),
+              label: const Text('Generate', style: TextStyle(fontSize: 12)),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.orange.shade700,
+                foregroundColor: Colors.white,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              ),
+            ),
+          ],
+        ),
+        if (_lastSeed != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Row(
+              children: [
+                Text(
+                  'Seed: $_lastSeed',
+                  style: TextStyle(color: Colors.grey.shade500, fontSize: 10),
+                ),
+                const SizedBox(width: 4),
+                InkWell(
+                  onTap: () {
+                    Clipboard.setData(
+                        ClipboardData(text: _lastSeed.toString()));
+                  },
+                  child: Icon(Icons.copy, size: 12, color: Colors.grey.shade500),
+                ),
+                const SizedBox(width: 4),
+                InkWell(
+                  onTap: () => _regenerateWithSeed(_lastSeed!),
+                  child: Icon(Icons.refresh, size: 12,
+                      color: Colors.grey.shade500),
+                ),
               ],
-              onChanged: (algo) {
-                if (algo != null) setState(() => _selected = algo);
-              },
             ),
           ),
-        ),
-        const SizedBox(width: 8),
-        ElevatedButton.icon(
-          onPressed: () {
-            final map = generateMap(algorithm: _selected);
-            widget.state.loadFromGameMap(map);
-          },
-          icon: const Icon(Icons.casino, size: 14),
-          label: const Text('Generate', style: TextStyle(fontSize: 12)),
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.orange.shade700,
-            foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          ),
-        ),
       ],
     );
   }

--- a/test/flame/maps/generators/grid_utils_test.dart
+++ b/test/flame/maps/generators/grid_utils_test.dart
@@ -185,20 +185,23 @@ void main() {
 
       final layers = buildTileLayers(grid);
 
-      // Wall cells get object tiles.
+      // Wall cells get object tiles (default wall index).
       expect(
         layers.objects.tileAt(0, 0),
-        const TileRef(tilesetId: 'room_builder_office', tileIndex: 69),
+        const TileRef(
+            tilesetId: 'room_builder_office', tileIndex: wallTileDefault),
       );
       expect(
         layers.objects.tileAt(3, 2),
-        const TileRef(tilesetId: 'room_builder_office', tileIndex: 69),
+        const TileRef(
+            tilesetId: 'room_builder_office', tileIndex: wallTileDefault),
       );
 
-      // Open cells get floor tiles.
+      // Open cells get floor tiles (default light stone).
       expect(
         layers.floor.tileAt(1, 1),
-        const TileRef(tilesetId: 'room_builder_office', tileIndex: 83),
+        const TileRef(
+            tilesetId: 'room_builder_office', tileIndex: floorTileLightStone),
       );
 
       // Open cells have no object tile.


### PR DESCRIPTION
## Summary
- Add Firestore-backed room persistence (RoomData model, RoomService CRUD)
- Add room browser lobby UI with public/my rooms tabs, create and delete
- Dynamic LiveKit room names (room ID instead of hardcoded 'tech-world')
- Save button in map editor (create new or update existing rooms)
- Editor permission checks (owner + editors can edit)
- Firestore security rules for rooms collection
- Fix backgroundImage missing from TileMapFormat serialization
- Fix MapPreviewComponent not rendering background on mount
- Fix exitEditorMode not syncing background with editor state

## Test plan
- [x] 663 tests pass (19 new room tests + 644 existing)
- [x] `flutter analyze --fatal-infos` clean
- [ ] Manual: create room, load predefined map, save, rejoin from lobby
- [ ] Manual: background image persists through editor open/close cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)