### PR TITLE
style: add missing blank line in BotCharacterComponent

### DIFF
--- a/lib/flame/components/bot_character_component.dart
+++ b/lib/flame/components/bot_character_component.dart
@@ -8,6 +8,7 @@ import 'package:flame/flame.dart';
 import 'package:flutter/painting.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/shared/constants.dart';
+
 /// A Flame component that renders the Clawd mascot as a character sprite.
 /// Unlike PlayerComponent which uses sprite sheets, this renders a static image.
 /// Tap on the bot to toggle the thinking indicator (for demo purposes).


### PR DESCRIPTION
## Summary
- Adds missing blank line between imports and doc comment in `bot_character_component.dart`
- Flagged in PR #144 review

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues

Generated with [Claude Code](https://claude.com/claude-code)