### PR TITLE
feat(livekit): terminal-activity events for proactive pair-programming

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -381,6 +381,41 @@ class LiveKitService {
     );
   }
 
+  /// Publish a terminal-activity event to the bot.
+  ///
+  /// Notifies `bot-claude` when the local player opens or closes the code
+  /// editor so the bot can track who is working on challenges and proactively
+  /// offer help.
+  Future<void> publishTerminalActivity({
+    required String action,
+    String? challengeId,
+    String? challengeTitle,
+    String? challengeDescription,
+    int? terminalX,
+    int? terminalY,
+  }) async {
+    final message = <String, dynamic>{
+      'type': 'terminal-activity',
+      'action': action,
+      'playerId': userId,
+      'playerName': displayName,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    if (challengeId != null) message['challengeId'] = challengeId;
+    if (challengeTitle != null) message['challengeTitle'] = challengeTitle;
+    if (challengeDescription != null) {
+      message['challengeDescription'] = challengeDescription;
+    }
+    if (terminalX != null) message['terminalX'] = terminalX;
+    if (terminalY != null) message['terminalY'] = terminalY;
+
+    await publishJson(
+      message,
+      topic: 'terminal-activity',
+      destinationIdentities: const ['bot-claude'],
+    );
+  }
+
   /// Send a ping message to the bot and wait for pong response.
   ///
   /// Returns the pong response message if received within [timeout],


### PR DESCRIPTION
## Summary
- Add `publishTerminalActivity()` to `LiveKitService` — sends `terminal-activity` open/close events to `bot-claude` via targeted data channel with challenge metadata and terminal position
- Wire into `TechWorld._onTerminalInteract()` (publishes `open` on editor open) and `closeEditor()` (publishes `close` on editor close)
- Companion bot PR: https://github.com/enspyrco/tech_world_bot/pull/6

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] All 663 tests pass
- [ ] Opening a terminal editor publishes `terminal-activity: open` with challenge data
- [ ] Closing the editor publishes `terminal-activity: close`
- [ ] Map switch (which calls `closeEditor()`) sends close event
- [ ] No close event published when editor wasn't open

🤖 Generated with [Claude Code](https://claude.com/claude-code)