### PR TITLE
fix(chat): prevent loadHistory from blocking room loading

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -457,62 +457,74 @@ class ChatService {
   }
 
   /// Load chat history from Firestore for the given room.
+  ///
+  /// This is called on the critical sign-in path, so it must never throw.
+  /// Failures are logged and silently ignored — the UI proceeds without
+  /// history, and new messages will still arrive via LiveKit.
   Future<void> loadHistory(String roomId) async {
     _roomId = roomId;
     final repository = _repository;
     if (repository == null) return;
 
-    final conversationIds =
-        await repository.loadConversationIds(roomId, _liveKitService.userId);
+    try {
+      final conversationIds = await repository
+          .loadConversationIds(roomId, _liveKitService.userId)
+          .timeout(const Duration(seconds: 10));
 
-    for (final convId in conversationIds) {
-      final messages = await repository.loadMessages(roomId, convId);
-      if (messages.isEmpty) continue;
+      for (final convId in conversationIds) {
+        final messages = await repository
+            .loadMessages(roomId, convId)
+            .timeout(const Duration(seconds: 10));
+        if (messages.isEmpty) continue;
 
-      if (convId == 'group') {
-        for (final msg in messages) {
-          _messages.add(ChatMessage(
-            text: msg.text,
-            senderName: msg.senderName,
-            senderId: msg.senderId,
-            conversationId: 'group',
-            isLocalUser: msg.senderId == _liveKitService.userId,
-            isBot: msg.senderId == _botIdentity,
-            timestamp: msg.timestamp,
-          ));
-        }
-        _messagesController.add(List.from(_messages));
-      } else {
-        // DM conversation — figure out peer from the conversation ID.
-        _dmMessagesByConversation[convId] = messages.map((msg) {
-          return ChatMessage(
-            text: msg.text,
-            senderName: msg.senderName,
-            senderId: msg.senderId,
-            conversationId: convId,
-            isLocalUser: msg.senderId == _liveKitService.userId,
-            isBot: msg.senderId == _botIdentity,
-            timestamp: msg.timestamp,
+        if (convId == 'group') {
+          for (final msg in messages) {
+            _messages.add(ChatMessage(
+              text: msg.text,
+              senderName: msg.senderName,
+              senderId: msg.senderId,
+              conversationId: 'group',
+              isLocalUser: msg.senderId == _liveKitService.userId,
+              isBot: msg.senderId == _botIdentity,
+              timestamp: msg.timestamp,
+            ));
+          }
+          _messagesController.add(List.from(_messages));
+        } else {
+          // DM conversation — figure out peer from the conversation ID.
+          _dmMessagesByConversation[convId] = messages.map((msg) {
+            return ChatMessage(
+              text: msg.text,
+              senderName: msg.senderName,
+              senderId: msg.senderId,
+              conversationId: convId,
+              isLocalUser: msg.senderId == _liveKitService.userId,
+              isBot: msg.senderId == _botIdentity,
+              timestamp: msg.timestamp,
+            );
+          }).toList();
+
+          // Determine peer info from the most recent message not from us.
+          final peerMsg = messages.lastWhere(
+            (m) => m.senderId != _liveKitService.userId,
+            orElse: () => messages.last,
           );
-        }).toList();
 
-        // Determine peer info from the most recent message not from us.
-        final peerMsg = messages.lastWhere(
-          (m) => m.senderId != _liveKitService.userId,
-          orElse: () => messages.last,
-        );
-
-        _conversations[convId] ??= Conversation(
-          id: convId,
-          type: ConversationType.dm,
-          peerId: peerMsg.senderId,
-          peerDisplayName: peerMsg.senderName,
-          lastActivity: messages.last.timestamp,
-        );
+          _conversations[convId] ??= Conversation(
+            id: convId,
+            type: ConversationType.dm,
+            peerId: peerMsg.senderId,
+            peerDisplayName: peerMsg.senderName,
+            lastActivity: messages.last.timestamp,
+          );
+        }
       }
-    }
 
-    _emitConversations();
+      _emitConversations();
+    } catch (e) {
+      debugPrint('ChatService: Failed to load history: $e');
+      // Don't rethrow — allow the room to load without history.
+    }
   }
 
   /// Handle a help-response message from the bot.

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:livekit_client/livekit_client.dart' show RemoteParticipant;
 import 'package:tech_world/chat/chat_message.dart';
+import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/chat_service.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
@@ -652,7 +653,126 @@ void main() {
         expect(conv.type, equals(ConversationType.dm));
       });
     });
+
+    group('loadHistory (regression)', () {
+      test('does not throw when repository fails', () async {
+        final failingRepo = FailingChatMessageRepository();
+        final service = ChatService(
+          liveKitService: fakeLiveKit,
+          repository: failingRepo,
+        );
+        addTearDown(service.dispose);
+
+        // Should complete without throwing — room loading must not block.
+        await service.loadHistory('room-1');
+
+        // Service should still be functional after failed history load.
+        expect(service.currentMessages, isEmpty);
+      });
+
+      test('does not throw on timeout', () async {
+        final hangingRepo = HangingChatMessageRepository();
+        final service = ChatService(
+          liveKitService: fakeLiveKit,
+          repository: hangingRepo,
+        );
+        addTearDown(service.dispose);
+
+        // Should complete within the timeout (10s), not hang forever.
+        // We use a shorter-than-timeout expectation to verify it doesn't hang.
+        await expectLater(
+          service.loadHistory('room-1'),
+          completes,
+        );
+      });
+
+      test('still allows sending messages after failed history load', () async {
+        final failingRepo = FailingChatMessageRepository();
+        final service = ChatService(
+          liveKitService: fakeLiveKit,
+          repository: failingRepo,
+        );
+        addTearDown(service.dispose);
+
+        await service.loadHistory('room-1');
+
+        // Service should work normally despite failed history load.
+        fakeLiveKit.connected = true;
+        botStatusNotifier.value = BotStatus.idle;
+        unawaited(service.sendMessage('Hello after failed history'));
+        await Future.delayed(const Duration(milliseconds: 10));
+
+        expect(service.currentMessages.length, equals(1));
+        expect(service.currentMessages.first.text,
+            equals('Hello after failed history'));
+      });
+    });
   });
+}
+
+/// A [ChatMessageRepository] that always throws, simulating Firestore failures.
+class FailingChatMessageRepository implements ChatMessageRepository {
+  @override
+  Future<Set<String>> loadConversationIds(String roomId, String userId) {
+    throw Exception('Firestore unavailable');
+  }
+
+  @override
+  Future<List<ChatMessage>> loadMessages(
+    String roomId,
+    String conversationId, {
+    int limit = 100,
+  }) {
+    throw Exception('Firestore unavailable');
+  }
+
+  @override
+  Future<void> saveMessage(String roomId, ChatMessage message) async {}
+
+  @override
+  Future<void> saveConversation(
+    String roomId, {
+    required String conversationId,
+    required List<String> participants,
+    required String type,
+    String? lastMessageText,
+  }) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// A [ChatMessageRepository] that never completes, simulating network hangs.
+class HangingChatMessageRepository implements ChatMessageRepository {
+  @override
+  Future<Set<String>> loadConversationIds(String roomId, String userId) {
+    // Never completes — simulates a network hang.
+    return Completer<Set<String>>().future;
+  }
+
+  @override
+  Future<List<ChatMessage>> loadMessages(
+    String roomId,
+    String conversationId, {
+    int limit = 100,
+  }) {
+    return Completer<List<ChatMessage>>().future;
+  }
+
+  @override
+  Future<void> saveMessage(String roomId, ChatMessage message) async {}
+
+  @override
+  Future<void> saveConversation(
+    String roomId, {
+    required String conversationId,
+    required List<String> participants,
+    required String type,
+    String? lastMessageText,
+  }) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 /// Fake LiveKitService for testing


### PR DESCRIPTION
## Summary
- `loadHistory()` is awaited on the critical sign-in path with no error handling. If the Firestore conversations query fails (missing index, permissions, network timeout), the room never finishes loading.
- Wrap internals in try-catch with 10s timeouts so the UI proceeds without history on failure.

## Changes
- `lib/chat/chat_service.dart`: Add try-catch + `.timeout(Duration(seconds: 10))` around both Firestore queries in `loadHistory()`
- `test/chat/chat_service_test.dart`: Add 3 regression tests — repository throws, repository hangs (timeout), service remains functional after failed load

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — all 41 chat service tests pass (3 new regression tests)
- [x] New test: `does not throw when repository fails`
- [x] New test: `does not throw on timeout`
- [x] New test: `still allows sending messages after failed history load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)