### PR TITLE
fix(flame): load background image on demand instead of from cache

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -792,7 +792,9 @@ class TechWorld extends World with TapCallbacks {
       }
     } else if (game != null && map.backgroundImage != null) {
       // Legacy background image rendering.
-      final bgImage = game.images.fromCache(map.backgroundImage!);
+      // Use load() instead of fromCache() because the GameWidget may not have
+      // mounted yet (e.g. first room join), so onLoad images aren't cached.
+      final bgImage = await game.images.load(map.backgroundImage!);
       _backgroundSprite =
           SpriteComponent(sprite: Sprite(bgImage), priority: -1);
       add(_backgroundSprite!);

--- a/test/flame/tech_world_integration_test.dart
+++ b/test/flame/tech_world_integration_test.dart
@@ -8,7 +8,7 @@ import 'package:tech_world/flame/components/player_component.dart';
 import 'package:tech_world/flame/tech_world.dart';
 import 'package:tech_world/flame/tech_world_game.dart';
 
-/// A test version of TechWorldGame that uses mock images
+/// A test version of TechWorldGame that uses mock images.
 class TestGameWithMockImages extends TechWorldGame {
   TestGameWithMockImages({required World world}) : super(world: world);
 
@@ -19,6 +19,27 @@ class TestGameWithMockImages extends TechWorldGame {
     images.add('NPC12.png', await generateImage(384, 256));
     images.add('NPC13.png', await generateImage(384, 256));
     images.add('single_room.png', await generateImage(800, 600));
+    images.add('claude_bot.png', await generateImage(48, 48));
+
+    camera.viewfinder.anchor = Anchor.center;
+  }
+}
+
+/// A test game that does NOT pre-cache background images.
+///
+/// Used to verify that [TechWorld._loadMapComponents] loads background images
+/// on demand via [Images.load] instead of requiring them to already be in the
+/// cache via [Images.fromCache].
+class TestGameWithoutBgCache extends TechWorldGame {
+  TestGameWithoutBgCache({required World world}) : super(world: world);
+
+  @override
+  Future<void> onLoad() async {
+    // Only cache character sprites — deliberately skip single_room.png
+    // so the background image must be loaded on demand by _loadMapComponents.
+    images.add('NPC11.png', await generateImage(384, 256));
+    images.add('NPC12.png', await generateImage(384, 256));
+    images.add('NPC13.png', await generateImage(384, 256));
     images.add('claude_bot.png', await generateImage(48, 48));
 
     camera.viewfinder.anchor = Anchor.center;
@@ -257,6 +278,32 @@ void main() {
 
         // Should have multiple components (grid, path, barriers, player)
         expect(children.length, greaterThanOrEqualTo(4));
+      },
+    );
+
+    // Regression test: background image loaded on demand, not from cache.
+    //
+    // The default map (lRoom) has a backgroundImage. When TechWorldGame.onLoad
+    // hasn't pre-cached it (e.g. GameWidget hasn't mounted yet), the old code
+    // used Images.fromCache() which throws. The fix uses Images.load() which
+    // loads on demand from the asset bundle.
+    testWithGame<TestGameWithoutBgCache>(
+      'loadMap loads background image on demand when not pre-cached',
+      () {
+        final world = TechWorld(authStateChanges: authController.stream);
+        return TestGameWithoutBgCache(world: world);
+      },
+      (game) async {
+        // game.ready() triggers TechWorld.onLoad → _loadMapComponents(lRoom).
+        // lRoom has backgroundImage: 'single_room.png' which is NOT in the
+        // image cache (TestGameWithoutBgCache skips it). With the fix
+        // (Images.load), this loads the image from the asset bundle. With the
+        // old code (Images.fromCache), this would throw an assertion error.
+        await game.ready();
+
+        final world = game.world as TechWorld;
+        expect(world.isMounted, isTrue);
+        expect(world.currentMap.value.backgroundImage, equals('single_room.png'));
       },
     );
   });


### PR DESCRIPTION
## Summary
- Changed `Images.fromCache()` to `Images.load()` in `_loadMapComponents` so background images are loaded on demand from the asset bundle
- Fixes crash when `_joinRoom` calls `loadMap` before the `GameWidget` has mounted (and before `TechWorldGame.onLoad` has cached images)
- Added regression test with a game variant that skips pre-caching the background image

## Test plan
- [x] `flutter analyze` passes
- [x] Regression test `loadMap loads background image on demand when not pre-cached` passes
- [x] Manually verified: room join works after hot restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)