### PR TITLE
feat(map-editor): add automapping rules engine

### DIFF
--- a/lib/map_editor/map_editor_state.dart
+++ b/lib/map_editor/map_editor_state.dart
@@ -263,6 +263,7 @@ class MapEditorState extends ChangeNotifier {
     if (brush == null) {
       // Eraser — clear single cell.
       layer.setTile(x, y, null);
+      _automappedCells.remove((x, y));
     } else {
       for (var dy = 0; dy < brush.height; dy++) {
         for (var dx = 0; dx < brush.width; dx++) {
@@ -270,6 +271,9 @@ class MapEditorState extends ChangeNotifier {
           final ty = y + dy;
           if (tx >= 0 && tx < gridSize && ty >= 0 && ty < gridSize) {
             layer.setTile(tx, ty, brush.tileRefAt(dx, dy));
+            // If the user paints over an automap-generated cell, stop
+            // tracking it so re-apply won't erase the manual edit.
+            _automappedCells.remove((tx, ty));
           }
         }
       }

--- a/test/map_editor/automap_integration_test.dart
+++ b/test/map_editor/automap_integration_test.dart
@@ -113,6 +113,31 @@ void main() {
       // No barriers → no shadows or trims.
       expect(state.objectLayerData.isEmpty, isTrue);
     });
+
+    test('re-apply preserves manual overwrite of automap cell', () {
+      // 1. Create a barrier and run automap — generates a shadow at (10, 6).
+      state.setTool(EditorTool.barrier);
+      state.paintTile(10, 5);
+      state.applyAutomapRules(allAutomapRules);
+      expect(state.objectLayerData.tileAt(10, 6), isNotNull);
+
+      // 2. User manually paints over the automap-generated shadow cell.
+      state.setActiveLayer(ActiveLayer.objects);
+      state.setTileBrush(
+        const TileRef(tilesetId: 'manual', tileIndex: 42),
+        columns: 16,
+      );
+      state.paintTileRef(10, 6);
+      expect(state.objectLayerData.tileAt(10, 6)!.tilesetId, 'manual');
+
+      // 3. Re-apply automap — the manual tile must survive because the user
+      //    overwrote the automap cell (pruned from _automappedCells).
+      state.applyAutomapRules(allAutomapRules);
+      final tile = state.objectLayerData.tileAt(10, 6);
+      expect(tile, isNotNull);
+      expect(tile!.tilesetId, 'manual');
+      expect(tile.tileIndex, 42);
+    });
   });
 
   group('clearAutomapTiles', () {


### PR DESCRIPTION
## Summary
- Add `AutomapRule` model with pattern matching (center + neighbor constraints) and replacement tile output
- Add `AutomapEngine` that applies rules to painted tiles and their neighbors, with priority-based conflict resolution
- Add `predefined_rules.dart` with initial rule sets for terrain automap transitions
- Integrate engine into `MapEditorState` — rules fire automatically on tile paint, with ephemeral tracking (`_automappedCells`) so engine-generated tiles are cleared and re-evaluated on each stroke

Stacked on #164 (tileset barrier metadata).

## Test plan
- [ ] `flutter test test/map_editor/automap_engine_test.dart` — engine logic (29 tests)
- [ ] `flutter test test/map_editor/automap_rule_test.dart` — rule matching
- [ ] `flutter test test/map_editor/automap_integration_test.dart` — end-to-end with editor state

🤖 Generated with [Claude Code](https://claude.com/claude-code)