### PR TITLE
feat(map-editor): add TMX file import support

### DIFF
--- a/lib/flame/maps/tmx_importer.dart
+++ b/lib/flame/maps/tmx_importer.dart
@@ -1,0 +1,479 @@
+import 'dart:math';
+
+import 'package:tiled/tiled.dart' as tiled;
+
+import 'package:tech_world/flame/maps/game_map.dart';
+import 'package:tech_world/flame/shared/constants.dart';
+import 'package:tech_world/flame/tiles/predefined_tilesets.dart'
+    show allTilesets, isTileRefBarrier;
+import 'package:tech_world/flame/tiles/tile_layer_data.dart';
+import 'package:tech_world/flame/tiles/tile_ref.dart';
+import 'package:tech_world/flame/tiles/tileset.dart';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of a TMX import: the converted [GameMap] plus any warnings.
+class TmxImportResult {
+  const TmxImportResult({required this.gameMap, required this.warnings});
+
+  final GameMap gameMap;
+  final List<TmxImportWarning> warnings;
+}
+
+/// A non-fatal issue encountered during TMX import.
+class TmxImportWarning {
+  const TmxImportWarning({required this.kind, required this.message});
+
+  final TmxWarningKind kind;
+  final String message;
+
+  @override
+  String toString() => '${kind.name}: $message';
+}
+
+/// Categories of TMX import warnings.
+enum TmxWarningKind {
+  unmatchedTileset,
+  mapCropped,
+  mapPadded,
+  tilesDropped,
+  flipIgnored,
+  noSpawnFound,
+  wrongTileSize,
+}
+
+/// Fatal error during TMX import.
+class TmxImportException implements Exception {
+  const TmxImportException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'TmxImportException: $message';
+}
+
+// ---------------------------------------------------------------------------
+// Layer name keywords for classification
+// ---------------------------------------------------------------------------
+
+const _floorKeywords = ['floor', 'ground', 'terrain', 'base'];
+const _objectKeywords = ['object', 'furniture', 'wall', 'decor', 'prop'];
+
+// ---------------------------------------------------------------------------
+// Importer
+// ---------------------------------------------------------------------------
+
+/// Converts Tiled `.tmx` XML into a [GameMap] using the project's native
+/// tile system.
+///
+/// Uses the `tiled` package for XML parsing and maps TMX tilesets to the
+/// predefined tilesets registered in [allTilesets] by matching image
+/// filenames.
+class TmxImporter {
+  TmxImporter._();
+
+  /// Parse [tmxXml] and convert it to a [TmxImportResult].
+  ///
+  /// Optionally override the map's [mapId] and [mapName]. If [mapName] is
+  /// provided without [mapId], the ID is derived from the name by
+  /// lowercasing and replacing spaces with underscores.
+  static TmxImportResult import(
+    String tmxXml, {
+    String? mapId,
+    String? mapName,
+  }) {
+    final warnings = <TmxImportWarning>[];
+
+    // 1. Parse XML.
+    final tiled.TiledMap tiledMap;
+    try {
+      tiledMap = tiled.TileMapParser.parseTmx(tmxXml);
+    } catch (e) {
+      throw TmxImportException('Failed to parse TMX XML: $e');
+    }
+
+    // 2. Validate orientation.
+    if (tiledMap.orientation != null &&
+        tiledMap.orientation != tiled.MapOrientation.orthogonal) {
+      throw TmxImportException(
+        'Only orthogonal maps are supported, '
+        'got ${tiledMap.orientation}.',
+      );
+    }
+
+    // 3. Check tile size.
+    if (tiledMap.tileWidth != gridSquareSize ||
+        tiledMap.tileHeight != gridSquareSize) {
+      warnings.add(TmxImportWarning(
+        kind: TmxWarningKind.wrongTileSize,
+        message:
+            'TMX tile size is ${tiledMap.tileWidth}x${tiledMap.tileHeight}, '
+            'expected ${gridSquareSize}x$gridSquareSize. '
+            'Tiles will be mapped by index regardless.',
+      ));
+    }
+
+    // 4. Build tileset mapping: TMX tileset → predefined Tileset.
+    final tilesetMapping = _buildTilesetMapping(tiledMap.tilesets, warnings);
+    if (tilesetMapping.isEmpty) {
+      throw TmxImportException(
+        'No TMX tilesets matched any predefined tileset. '
+        'Ensure TMX tileset image filenames match those in assets/images/tilesets/.',
+      );
+    }
+
+    // 5. Find tile layers.
+    final tileLayers = tiledMap.layers
+        .whereType<tiled.TileLayer>()
+        .toList();
+    if (tileLayers.isEmpty) {
+      throw TmxImportException(
+        'TMX file has no tile layers. At least one tile layer is required.',
+      );
+    }
+
+    // 6. Classify tile layers into floor vs. object.
+    final classified = _classifyLayers(tileLayers);
+
+    // 7. Compute grid offset for centering / cropping.
+    final mapW = tiledMap.width;
+    final mapH = tiledMap.height;
+    final (ox, oy, cropW, cropH) = _computeGridTransform(mapW, mapH, warnings);
+
+    // 8. Convert tile layers.
+    var hasFlippedTiles = false;
+    var droppedTileCount = 0;
+
+    TileLayerData? convertLayers(List<tiled.TileLayer> layers) {
+      if (layers.isEmpty) return null;
+      final layerData = TileLayerData();
+      for (final layer in layers) {
+        final tileData = layer.tileData;
+        if (tileData == null) continue;
+        for (var row = 0; row < cropH && row < tileData.length; row++) {
+          final rowData = tileData[row];
+          for (var col = 0; col < cropW && col < rowData.length; col++) {
+            final gid = rowData[col];
+            if (gid.tile == 0) continue; // Empty cell.
+
+            // Check flips.
+            if (gid.flips.horizontally ||
+                gid.flips.vertically ||
+                gid.flips.diagonally ||
+                gid.flips.antiDiagonally) {
+              hasFlippedTiles = true;
+            }
+
+            // Resolve tileset.
+            final resolved = _resolveGid(gid.tile, tilesetMapping);
+            if (resolved == null) {
+              droppedTileCount++;
+              continue;
+            }
+
+            final destX = ox + col;
+            final destY = oy + row;
+            if (destX >= 0 &&
+                destX < gridSize &&
+                destY >= 0 &&
+                destY < gridSize) {
+              layerData.setTile(destX, destY, resolved);
+            }
+          }
+        }
+      }
+      return layerData.isEmpty ? null : layerData;
+    }
+
+    final floorLayer = convertLayers(classified.floor);
+    final objectLayer = convertLayers(classified.objects);
+
+    if (hasFlippedTiles) {
+      warnings.add(const TmxImportWarning(
+        kind: TmxWarningKind.flipIgnored,
+        message: 'Some tiles have flip/rotation flags set. '
+            'Flips are not supported and were ignored.',
+      ));
+    }
+    if (droppedTileCount > 0) {
+      warnings.add(TmxImportWarning(
+        kind: TmxWarningKind.tilesDropped,
+        message: '$droppedTileCount tile(s) from unmatched tilesets '
+            'were dropped.',
+      ));
+    }
+
+    // 9. Extract spawn/terminals from object groups.
+    final objectGroups = tiledMap.layers
+        .whereType<tiled.ObjectGroup>()
+        .toList();
+
+    Point<int>? spawnPoint;
+    final terminals = <Point<int>>[];
+
+    for (final group in objectGroups) {
+      for (final obj in group.objects) {
+        final type = obj.type.toLowerCase();
+        final gridX = ox + (obj.x ~/ tiledMap.tileWidth);
+        final gridY = oy + (obj.y ~/ tiledMap.tileHeight);
+
+        if (type == 'spawn') {
+          if (gridX >= 0 &&
+              gridX < gridSize &&
+              gridY >= 0 &&
+              gridY < gridSize) {
+            spawnPoint = Point(gridX, gridY);
+          }
+        } else if (type == 'terminal') {
+          if (gridX >= 0 &&
+              gridX < gridSize &&
+              gridY >= 0 &&
+              gridY < gridSize) {
+            terminals.add(Point(gridX, gridY));
+          }
+        }
+      }
+    }
+
+    if (spawnPoint == null) {
+      warnings.add(const TmxImportWarning(
+        kind: TmxWarningKind.noSpawnFound,
+        message: 'No object with type "spawn" found. '
+            'Using default spawn point (25, 25).',
+      ));
+    }
+
+    // 10. Auto-detect barriers from tile metadata.
+    final barriers = <Point<int>>[];
+    _collectBarriers(floorLayer, barriers);
+    _collectBarriers(objectLayer, barriers);
+
+    // 11. Collect tileset IDs.
+    final tilesetIds = <String>{
+      if (floorLayer != null) ...floorLayer.referencedTilesetIds,
+      if (objectLayer != null) ...objectLayer.referencedTilesetIds,
+    }.toList();
+
+    // 12. Resolve map name and ID.
+    final name = mapName ?? 'Imported Map';
+    final id = mapId ?? _nameToId(name);
+
+    return TmxImportResult(
+      gameMap: GameMap(
+        id: id,
+        name: name,
+        barriers: barriers,
+        spawnPoint: spawnPoint ?? const Point(25, 25),
+        terminals: terminals,
+        floorLayer: floorLayer,
+        objectLayer: objectLayer,
+        tilesetIds: tilesetIds,
+      ),
+      warnings: warnings,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tileset mapping
+// ---------------------------------------------------------------------------
+
+/// Maps TMX tileset firstGid ranges to our predefined [Tileset] objects.
+///
+/// Each entry records the TMX firstGid and the matched predefined tileset.
+class _TilesetEntry {
+  const _TilesetEntry({
+    required this.firstGid,
+    required this.tileCount,
+    required this.tileset,
+  });
+
+  final int firstGid;
+  final int tileCount;
+  final Tileset tileset;
+}
+
+/// Build a sorted list of tileset mappings from TMX tilesets to predefined
+/// tilesets, matched by image filename.
+List<_TilesetEntry> _buildTilesetMapping(
+  List<tiled.Tileset> tmxTilesets,
+  List<TmxImportWarning> warnings,
+) {
+  // Build a lookup: image basename → predefined tileset.
+  final lookup = <String, Tileset>{};
+  for (final ts in allTilesets) {
+    // imagePath is like 'tilesets/ext_terrains.png' — extract filename.
+    final basename = ts.imagePath.split('/').last;
+    lookup[basename] = ts;
+  }
+
+  final entries = <_TilesetEntry>[];
+  for (final tmxTs in tmxTilesets) {
+    final firstGid = tmxTs.firstGid;
+    if (firstGid == null) continue;
+
+    final imageSource = tmxTs.image?.source;
+    if (imageSource == null) {
+      warnings.add(TmxImportWarning(
+        kind: TmxWarningKind.unmatchedTileset,
+        message: 'TMX tileset "${tmxTs.name}" has no image (collection '
+            'tilesets are not supported). Its tiles will be dropped.',
+      ));
+      continue;
+    }
+
+    final basename = imageSource.split('/').last;
+    final matched = lookup[basename];
+    if (matched == null) {
+      warnings.add(TmxImportWarning(
+        kind: TmxWarningKind.unmatchedTileset,
+        message: 'TMX tileset "$basename" does not match any predefined '
+            'tileset. Its tiles will be dropped.',
+      ));
+      continue;
+    }
+
+    entries.add(_TilesetEntry(
+      firstGid: firstGid,
+      tileCount: tmxTs.tileCount ?? matched.tileCount,
+      tileset: matched,
+    ));
+  }
+
+  // Sort by firstGid ascending for binary-search-style lookup.
+  entries.sort((a, b) => a.firstGid.compareTo(b.firstGid));
+  return entries;
+}
+
+/// Resolve a global tile ID to a [TileRef] using the tileset mapping.
+///
+/// Returns null if the GID doesn't belong to any matched tileset.
+TileRef? _resolveGid(int globalId, List<_TilesetEntry> mapping) {
+  // Find the tileset whose range contains this GID.
+  // Tilesets are sorted by firstGid; we want the last one where
+  // firstGid <= globalId.
+  _TilesetEntry? matched;
+  for (final entry in mapping) {
+    if (entry.firstGid <= globalId) {
+      matched = entry;
+    } else {
+      break;
+    }
+  }
+
+  if (matched == null) return null;
+
+  final localIndex = globalId - matched.firstGid;
+  if (localIndex < 0 || localIndex >= matched.tileCount) return null;
+
+  return TileRef(tilesetId: matched.tileset.id, tileIndex: localIndex);
+}
+
+// ---------------------------------------------------------------------------
+// Layer classification
+// ---------------------------------------------------------------------------
+
+class _ClassifiedLayers {
+  const _ClassifiedLayers({required this.floor, required this.objects});
+
+  final List<tiled.TileLayer> floor;
+  final List<tiled.TileLayer> objects;
+}
+
+/// Classify tile layers as floor or object by name heuristics.
+_ClassifiedLayers _classifyLayers(List<tiled.TileLayer> layers) {
+  final floor = <tiled.TileLayer>[];
+  final objects = <tiled.TileLayer>[];
+  final unclassified = <tiled.TileLayer>[];
+
+  for (final layer in layers) {
+    final nameLower = layer.name.toLowerCase();
+    if (_floorKeywords.any((kw) => nameLower.contains(kw))) {
+      floor.add(layer);
+    } else if (_objectKeywords.any((kw) => nameLower.contains(kw))) {
+      objects.add(layer);
+    } else {
+      unclassified.add(layer);
+    }
+  }
+
+  // Fallback: first unclassified → floor, rest → objects.
+  if (unclassified.isNotEmpty) {
+    if (floor.isEmpty) {
+      floor.add(unclassified.removeAt(0));
+    }
+    objects.addAll(unclassified);
+  }
+
+  return _ClassifiedLayers(floor: floor, objects: objects);
+}
+
+// ---------------------------------------------------------------------------
+// Grid transform (centering / cropping)
+// ---------------------------------------------------------------------------
+
+/// Returns `(offsetX, offsetY, cropWidth, cropHeight)`.
+(int, int, int, int) _computeGridTransform(
+  int mapW,
+  int mapH,
+  List<TmxImportWarning> warnings,
+) {
+  int ox = 0;
+  int oy = 0;
+  int cropW = mapW;
+  int cropH = mapH;
+
+  if (mapW < gridSize || mapH < gridSize) {
+    ox = (gridSize - mapW) ~/ 2;
+    oy = (gridSize - mapH) ~/ 2;
+    warnings.add(TmxImportWarning(
+      kind: TmxWarningKind.mapPadded,
+      message: 'Map is $mapW×$mapH, padded to '
+          '$gridSize×$gridSize (offset $ox,$oy).',
+    ));
+  }
+
+  if (mapW > gridSize || mapH > gridSize) {
+    cropW = min(mapW, gridSize);
+    cropH = min(mapH, gridSize);
+    warnings.add(TmxImportWarning(
+      kind: TmxWarningKind.mapCropped,
+      message: 'Map is $mapW×$mapH, cropped to '
+          '$gridSize×$gridSize.',
+    ));
+  }
+
+  return (ox, oy, cropW, cropH);
+}
+
+// ---------------------------------------------------------------------------
+// Barrier collection
+// ---------------------------------------------------------------------------
+
+/// Scan a tile layer and add barrier points for tiles tagged as barriers
+/// in their predefined tileset.
+void _collectBarriers(TileLayerData? layer, List<Point<int>> barriers) {
+  if (layer == null) return;
+  for (var y = 0; y < gridSize; y++) {
+    for (var x = 0; x < gridSize; x++) {
+      final ref = layer.tileAt(x, y);
+      if (ref != null && isTileRefBarrier(ref)) {
+        barriers.add(Point(x, y));
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a display name to a snake_case ID.
+String _nameToId(String name) {
+  return name
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+      .replaceAll(RegExp(r'^_|_$'), '');
+}

--- a/lib/map_editor/import_dialog.dart
+++ b/lib/map_editor/import_dialog.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:tech_world/flame/maps/tmx_importer.dart';
+import 'package:tech_world/map_editor/map_editor_state.dart';
+
+/// Tabbed import dialog with ASCII and TMX tabs.
+///
+/// The ASCII tab pastes `.#ST` grid art (existing flow).
+/// The TMX tab pastes Tiled `.tmx` XML and converts it to a [GameMap] via
+/// [TmxImporter].
+class ImportDialog extends StatefulWidget {
+  const ImportDialog({required this.state, super.key});
+
+  final MapEditorState state;
+
+  static const _headerBg = Color(0xFF2D2D2D);
+
+  @override
+  State<ImportDialog> createState() => _ImportDialogState();
+}
+
+class _ImportDialogState extends State<ImportDialog>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  final _asciiController = TextEditingController();
+  final _tmxController = TextEditingController();
+  final _nameController = TextEditingController();
+  final _idController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _asciiController.dispose();
+    _tmxController.dispose();
+    _nameController.dispose();
+    _idController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: ImportDialog._headerBg,
+      title: const Text('Import Map', style: TextStyle(color: Colors.white)),
+      contentPadding: const EdgeInsets.fromLTRB(24, 12, 24, 0),
+      content: SizedBox(
+        width: 520,
+        height: 460,
+        child: Column(
+          children: [
+            TabBar(
+              controller: _tabController,
+              indicatorColor: const Color(0xFF4FC3F7),
+              labelColor: Colors.white,
+              unselectedLabelColor: Colors.grey,
+              tabs: const [
+                Tab(text: 'ASCII'),
+                Tab(text: 'TMX'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  _buildAsciiTab(),
+                  _buildTmxTab(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: _handleImport,
+          child: const Text('Import'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAsciiTab() {
+    return TextField(
+      controller: _asciiController,
+      maxLines: null,
+      expands: true,
+      style: const TextStyle(
+        color: Colors.white,
+        fontFamily: 'monospace',
+        fontSize: 10,
+      ),
+      decoration: InputDecoration(
+        hintText: 'Paste ASCII art here (50x50, .#ST)...',
+        hintStyle: TextStyle(color: Colors.grey.shade600),
+        border: OutlineInputBorder(
+          borderSide: BorderSide(color: Colors.grey.shade700),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTmxTab() {
+    return Column(
+      children: [
+        // Optional map name & ID fields
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _nameController,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                decoration: InputDecoration(
+                  labelText: 'Map Name (optional)',
+                  labelStyle:
+                      TextStyle(color: Colors.grey.shade500, fontSize: 11),
+                  isDense: true,
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                  enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey.shade700),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: const BorderSide(color: Color(0xFF4FC3F7)),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: TextField(
+                controller: _idController,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                decoration: InputDecoration(
+                  labelText: 'Map ID (optional)',
+                  labelStyle:
+                      TextStyle(color: Colors.grey.shade500, fontSize: 11),
+                  isDense: true,
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                  enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey.shade700),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: const BorderSide(color: Color(0xFF4FC3F7)),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        // TMX XML paste area
+        Expanded(
+          child: TextField(
+            controller: _tmxController,
+            maxLines: null,
+            expands: true,
+            style: const TextStyle(
+              color: Colors.white,
+              fontFamily: 'monospace',
+              fontSize: 10,
+            ),
+            decoration: InputDecoration(
+              hintText: 'Paste TMX XML here...',
+              hintStyle: TextStyle(color: Colors.grey.shade600),
+              border: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.grey.shade700),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _handleImport() {
+    if (_tabController.index == 0) {
+      // ASCII import
+      widget.state.loadFromAscii(_asciiController.text);
+      Navigator.pop(context);
+    } else {
+      // TMX import
+      _importTmx();
+    }
+  }
+
+  void _importTmx() {
+    final tmxXml = _tmxController.text.trim();
+    if (tmxXml.isEmpty) return;
+
+    final mapName =
+        _nameController.text.trim().isEmpty ? null : _nameController.text.trim();
+    final mapId =
+        _idController.text.trim().isEmpty ? null : _idController.text.trim();
+
+    try {
+      final warnings = widget.state.loadFromTmx(
+        tmxXml,
+        mapName: mapName,
+        mapId: mapId,
+      );
+      Navigator.pop(context);
+
+      if (warnings.isNotEmpty) {
+        // Show warnings in a snackbar after the dialog closes.
+        final message = warnings.map((w) => w.message).join('\n');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Import succeeded with ${warnings.length} warning(s):\n$message',
+              style: const TextStyle(fontSize: 12),
+            ),
+            duration: const Duration(seconds: 6),
+            backgroundColor: Colors.orange.shade800,
+          ),
+        );
+      }
+    } on TmxImportException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Import failed: ${e.message}'),
+          backgroundColor: Colors.red.shade700,
+        ),
+      );
+    }
+  }
+}

--- a/lib/map_editor/map_editor_panel.dart
+++ b/lib/map_editor/map_editor_panel.dart
@@ -10,6 +10,7 @@ import 'package:tech_world/flame/shared/constants.dart';
 import 'package:tech_world/flame/tiles/predefined_terrains.dart';
 import 'package:tech_world/flame/tiles/tile_brush.dart';
 import 'package:tech_world/map_editor/available_backgrounds.dart';
+import 'package:tech_world/map_editor/import_dialog.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
 import 'package:tech_world/map_editor/predefined_rules.dart';
 import 'package:tech_world/map_editor/tile_colors.dart';
@@ -319,44 +320,9 @@ class MapEditorPanel extends StatelessWidget {
   }
 
   void _showImportDialog(BuildContext context) {
-    final controller = TextEditingController();
     showDialog(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: _headerBg,
-        title: const Text('Import ASCII Map',
-            style: TextStyle(color: Colors.white)),
-        content: SizedBox(
-          width: 500,
-          height: 400,
-          child: TextField(
-            controller: controller,
-            maxLines: null,
-            expands: true,
-            style: const TextStyle(
-                color: Colors.white, fontFamily: 'monospace', fontSize: 10),
-            decoration: InputDecoration(
-              hintText: 'Paste ASCII art here (50x50, .#ST)...',
-              hintStyle: TextStyle(color: Colors.grey.shade600),
-              border: OutlineInputBorder(
-                  borderSide: BorderSide(color: Colors.grey.shade700)),
-            ),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Cancel'),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              state.loadFromAscii(controller.text);
-              Navigator.pop(ctx);
-            },
-            child: const Text('Import'),
-          ),
-        ],
-      ),
+      builder: (ctx) => ImportDialog(state: state),
     );
   }
 

--- a/lib/map_editor/map_editor_state.dart
+++ b/lib/map_editor/map_editor_state.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/maps/map_parser.dart';
+import 'package:tech_world/flame/maps/tmx_importer.dart';
 import 'package:tech_world/flame/shared/constants.dart';
 import 'package:tech_world/flame/tiles/predefined_tilesets.dart'
     show allTilesets;
@@ -470,6 +471,24 @@ class MapEditorState extends ChangeNotifier {
     }
 
     notifyListeners();
+  }
+
+  /// Import a Tiled `.tmx` XML string into the editor.
+  ///
+  /// Parses the TMX via [TmxImporter], loads the resulting [GameMap], and
+  /// returns any non-fatal warnings for the caller to display.
+  List<TmxImportWarning> loadFromTmx(
+    String tmxXml, {
+    String? mapId,
+    String? mapName,
+  }) {
+    final result = TmxImporter.import(
+      tmxXml,
+      mapId: mapId,
+      mapName: mapName,
+    );
+    loadFromGameMap(result.gameMap);
+    return result.warnings;
   }
 
   /// Load grid state from an ASCII art string (same format as [parseAsciiMap]).

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1221,6 +1221,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.15"
+  tiled:
+    dependency: "direct main"
+    description:
+      name: tiled
+      sha256: f321ce0f27d103527b0d66878c60d9b000ce16c4ef4ae3ce77ce6f5ba4cf5db0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   tuple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
       url: https://github.com/nickmeinhold/code_forge_web.git
       ref: 51f0e2b
   re_highlight: ^0.0.3
+  tiled: ^0.11.1 # TMX/TSX parser only — no rendering
 
 dev_dependencies:
   flutter_test:

--- a/test/flame/maps/tmx_importer_test.dart
+++ b/test/flame/maps/tmx_importer_test.dart
@@ -1,0 +1,940 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/maps/tmx_importer.dart';
+import 'package:tech_world/flame/shared/constants.dart';
+import 'package:tech_world/flame/tiles/tile_ref.dart';
+
+// ---------------------------------------------------------------------------
+// TMX XML helpers — build valid TMX strings for testing.
+// ---------------------------------------------------------------------------
+
+/// Build a minimal TMX XML string.
+///
+/// [width] and [height] are in tiles. [tileWidth] and [tileHeight] in pixels.
+/// [tilesets] is a list of `(name, firstGid, imageSource, columns, tileCount)`.
+/// [layers] is a list of `(name, csv)` where csv is comma-separated GIDs.
+/// [objectGroups] is a list of `(name, objects)` where objects is XML string.
+String buildTmx({
+  int width = 3,
+  int height = 3,
+  int tileWidth = 32,
+  int tileHeight = 32,
+  String orientation = 'orthogonal',
+  List<({String name, int firstGid, String image, int columns, int tileCount})>
+      tilesets = const [],
+  List<({String name, String csv})> layers = const [],
+  List<({String name, String objectsXml})> objectGroups = const [],
+}) {
+  final sb = StringBuffer();
+  sb.writeln('<?xml version="1.0" encoding="UTF-8"?>');
+  sb.write('<map version="1.10" tiledversion="1.11.2" ');
+  sb.write('orientation="$orientation" ');
+  sb.write('renderorder="right-down" ');
+  sb.write('width="$width" height="$height" ');
+  sb.write('tilewidth="$tileWidth" tileheight="$tileHeight" ');
+  sb.writeln('infinite="0">');
+
+  for (final ts in tilesets) {
+    sb.write(' <tileset firstgid="${ts.firstGid}" name="${ts.name}" ');
+    sb.write('tilewidth="$tileWidth" tileheight="$tileHeight" ');
+    sb.write('tilecount="${ts.tileCount}" columns="${ts.columns}">');
+    sb.write('<image source="${ts.image}" ');
+    sb.write('width="${ts.columns * tileWidth}" ');
+    sb.writeln('height="${(ts.tileCount ~/ ts.columns) * tileHeight}"/>');
+    sb.writeln(' </tileset>');
+  }
+
+  for (final layer in layers) {
+    sb.writeln(
+        ' <layer name="${layer.name}" width="$width" height="$height">');
+    sb.writeln('  <data encoding="csv">');
+    sb.writeln(layer.csv);
+    sb.writeln('  </data>');
+    sb.writeln(' </layer>');
+  }
+
+  for (final og in objectGroups) {
+    sb.writeln(' <objectgroup name="${og.name}">');
+    sb.writeln(og.objectsXml);
+    sb.writeln(' </objectgroup>');
+  }
+
+  sb.writeln('</map>');
+  return sb.toString();
+}
+
+void main() {
+  group('TmxImporter', () {
+    // -----------------------------------------------------------------------
+    // Basic conversion
+    // -----------------------------------------------------------------------
+
+    group('basic conversion', () {
+      test('converts a 3×3 map with a single floor layer', () {
+        // 3×3 map using test_tileset.png (4 columns, 16 tiles).
+        // GIDs: 1=tile0, 2=tile1, ... (firstGid=1)
+        final tmx = buildTmx(
+          width: 3,
+          height: 3,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (
+              name: 'Ground',
+              csv: '1,2,3,\n4,5,6,\n7,8,9',
+            ),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx, mapId: 'test', mapName: 'Test');
+        final map = result.gameMap;
+
+        expect(map.id, 'test');
+        expect(map.name, 'Test');
+        expect(map.floorLayer, isNotNull);
+
+        // 3×3 map is padded to 50×50 — centered with offset (23, 23).
+        final ox = (gridSize - 3) ~/ 2; // 23
+        final oy = (gridSize - 3) ~/ 2; // 23
+
+        // Top-left corner: GID 1 → tileIndex 0
+        expect(
+          map.floorLayer!.tileAt(ox, oy),
+          const TileRef(tilesetId: 'test', tileIndex: 0),
+        );
+        // Center: GID 5 → tileIndex 4
+        expect(
+          map.floorLayer!.tileAt(ox + 1, oy + 1),
+          const TileRef(tilesetId: 'test', tileIndex: 4),
+        );
+        // Bottom-right: GID 9 → tileIndex 8
+        expect(
+          map.floorLayer!.tileAt(ox + 2, oy + 2),
+          const TileRef(tilesetId: 'test', tileIndex: 8),
+        );
+      });
+
+      test('converts an exact 50×50 map without padding or cropping', () {
+        // Build a 50×50 CSV where every cell is GID 1 (tileIndex 0).
+        final row = List.filled(50, '1').join(',');
+        final csv = List.filled(50, row).join(',\n');
+
+        final tmx = buildTmx(
+          width: 50,
+          height: 50,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: csv),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+
+        // No padding/cropping warnings.
+        expect(result.warnings.where((w) =>
+            w.kind == TmxWarningKind.mapPadded ||
+            w.kind == TmxWarningKind.mapCropped), isEmpty);
+
+        // Tile at (0,0) should be set (no offset).
+        expect(
+          result.gameMap.floorLayer!.tileAt(0, 0),
+          const TileRef(tilesetId: 'test', tileIndex: 0),
+        );
+        // Tile at (49,49) should also be set.
+        expect(
+          result.gameMap.floorLayer!.tileAt(49, 49),
+          const TileRef(tilesetId: 'test', tileIndex: 0),
+        );
+      });
+
+      test('handles empty cells (GID 0) correctly', () {
+        final tmx = buildTmx(
+          width: 3,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1,0,3'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 3) ~/ 2;
+        final oy = (gridSize - 1) ~/ 2;
+
+        // GID 0 = empty cell.
+        expect(result.gameMap.floorLayer!.tileAt(ox, oy), isNotNull);
+        expect(result.gameMap.floorLayer!.tileAt(ox + 1, oy), isNull);
+        expect(result.gameMap.floorLayer!.tileAt(ox + 2, oy), isNotNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Tileset matching
+    // -----------------------------------------------------------------------
+
+    group('tileset matching', () {
+      test('matches TMX tileset to predefined tileset by image basename', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'AnyName',
+              firstGid: 1,
+              image: '../images/tilesets/ext_terrains.png',
+              columns: 32,
+              tileCount: 2368,
+            ),
+          ],
+          layers: [
+            (name: 'Ground', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 1) ~/ 2;
+        final oy = ox;
+
+        // Should match 'ext_terrains' tileset by filename.
+        expect(
+          result.gameMap.floorLayer!.tileAt(ox, oy)!.tilesetId,
+          'ext_terrains',
+        );
+      });
+
+      test('warns on unmatched tileset and drops those tiles', () {
+        // Include one known tileset so the import succeeds (doesn't throw),
+        // plus one unknown tileset whose tiles get dropped.
+        final tmx = buildTmx(
+          width: 2,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+            (
+              name: 'Unknown',
+              firstGid: 17,
+              image: 'unknown_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            // GID 1 → known tileset, GID 17 → unknown tileset.
+            (name: 'Floor', csv: '1,17'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+
+        expect(
+          result.warnings
+              .any((w) => w.kind == TmxWarningKind.unmatchedTileset),
+          isTrue,
+        );
+        // Tile from unknown tileset should be dropped.
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.tilesDropped),
+          isTrue,
+        );
+      });
+
+      test('resolves GIDs across multiple tilesets', () {
+        // Two tilesets: test_tileset (firstGid=1, 16 tiles)
+        //               room_builder_office (firstGid=17, 224 tiles).
+        final tmx = buildTmx(
+          width: 2,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+            (
+              name: 'RoomBuilder',
+              firstGid: 17,
+              image: '../tilesets/room_builder_office.png',
+              columns: 16,
+              tileCount: 224,
+            ),
+          ],
+          layers: [
+            // GID 5 → test_tileset tile 4; GID 17 → room_builder_office tile 0
+            (name: 'Objects', csv: '5,17'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 2) ~/ 2;
+        final oy = (gridSize - 1) ~/ 2;
+
+        expect(
+          result.gameMap.objectLayer!.tileAt(ox, oy),
+          const TileRef(tilesetId: 'test', tileIndex: 4),
+        );
+        expect(
+          result.gameMap.objectLayer!.tileAt(ox + 1, oy),
+          const TileRef(tilesetId: 'room_builder_office', tileIndex: 0),
+        );
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // GID resolution
+    // -----------------------------------------------------------------------
+
+    group('GID resolution', () {
+      test('correctly subtracts firstGid to get local tile index', () {
+        // firstGid=1, GID=10 → tileIndex=9
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '10'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        // 1×1 map centered: offset = (50-1)~/2 = 24
+        final c = (gridSize - 1) ~/ 2;
+
+        expect(result.gameMap.floorLayer!.tileAt(c, c)!.tileIndex, 9);
+      });
+
+      test('warns when tiles have flip bits set', () {
+        // Horizontal flip flag: 0x80000000. GID 1 with h-flip = 0x80000001.
+        const flippedGid = 0x80000000 | 1; // 2147483649
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '$flippedGid'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.flipIgnored),
+          isTrue,
+        );
+        // Should still place the tile (ignoring flip).
+        final c = (gridSize - 1) ~/ 2;
+        expect(
+          result.gameMap.floorLayer!.tileAt(c, c),
+          const TileRef(tilesetId: 'test', tileIndex: 0),
+        );
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Layer classification
+    // -----------------------------------------------------------------------
+
+    group('layer classification', () {
+      test('classifies layers by name — floor keywords → floor layer', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'terrain_base', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(result.gameMap.floorLayer, isNotNull);
+        expect(result.gameMap.objectLayer, isNull);
+      });
+
+      test('classifies layers by name — object keywords → object layer', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Furniture', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(result.gameMap.floorLayer, isNull);
+        expect(result.gameMap.objectLayer, isNotNull);
+      });
+
+      test('fallback: first tile layer → floor, rest → objects', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Layer1', csv: '1'),
+            (name: 'Layer2', csv: '2'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        // 1×1 map centered: offset = (50-1)~/2 = 24
+        final c = (gridSize - 1) ~/ 2;
+
+        expect(result.gameMap.floorLayer, isNotNull);
+        expect(result.gameMap.objectLayer, isNotNull);
+
+        // Layer1 → floor (tileIndex 0), Layer2 → objects (tileIndex 1).
+        expect(result.gameMap.floorLayer!.tileAt(c, c)!.tileIndex, 0);
+        expect(result.gameMap.objectLayer!.tileAt(c, c)!.tileIndex, 1);
+      });
+
+      test('composites multiple floor layers (later overwrites earlier)', () {
+        final tmx = buildTmx(
+          width: 2,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Ground', csv: '1,2'),
+            (name: 'Base overlay', csv: '0,5'), // only second cell overwritten
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 2) ~/ 2;
+        final oy = (gridSize - 1) ~/ 2;
+
+        // (ox, oy): Ground=1 → 0, overlay=0 (empty) → kept from Ground.
+        expect(result.gameMap.floorLayer!.tileAt(ox, oy)!.tileIndex, 0);
+        // (ox+1, oy): Ground=2 → 1, overlay=5 → 4. Overlay overwrites.
+        expect(result.gameMap.floorLayer!.tileAt(ox + 1, oy)!.tileIndex, 4);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Grid size handling
+    // -----------------------------------------------------------------------
+
+    group('grid size handling', () {
+      test('pads small maps to 50×50 centered and warns', () {
+        final tmx = buildTmx(
+          width: 4,
+          height: 4,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1,1,1,1,\n1,1,1,1,\n1,1,1,1,\n1,1,1,1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.mapPadded),
+          isTrue,
+        );
+
+        final ox = (gridSize - 4) ~/ 2; // 23
+        final oy = (gridSize - 4) ~/ 2;
+
+        // Cell before offset should be empty.
+        expect(result.gameMap.floorLayer!.tileAt(ox - 1, oy), isNull);
+        // Cell at offset should have data.
+        expect(result.gameMap.floorLayer!.tileAt(ox, oy), isNotNull);
+        // Cell after content should be empty.
+        expect(result.gameMap.floorLayer!.tileAt(ox + 4, oy), isNull);
+      });
+
+      test('crops maps larger than 50×50 and warns', () {
+        final row = List.filled(60, '1').join(',');
+        final csv = List.filled(60, row).join(',\n');
+
+        final tmx = buildTmx(
+          width: 60,
+          height: 60,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: csv),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.mapCropped),
+          isTrue,
+        );
+
+        // Should still have valid data at edges.
+        expect(result.gameMap.floorLayer!.tileAt(0, 0), isNotNull);
+        expect(result.gameMap.floorLayer!.tileAt(49, 49), isNotNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Barrier extraction
+    // -----------------------------------------------------------------------
+
+    group('barrier extraction', () {
+      test('auto-detects barriers from tileset barrier metadata', () {
+        // room_builder_office: tile indices 0–79 are barriers.
+        // firstGid=1, so GID 1 → tileIndex 0 (barrier), GID 81 → tileIndex 80
+        // (not barrier).
+        final tmx = buildTmx(
+          width: 2,
+          height: 1,
+          tilesets: [
+            (
+              name: 'RoomBuilder',
+              firstGid: 1,
+              image: '../tilesets/room_builder_office.png',
+              columns: 16,
+              tileCount: 224,
+            ),
+          ],
+          layers: [
+            // GID 1 = barrier tile, GID 81 = non-barrier tile
+            (name: 'Objects', csv: '1,81'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 2) ~/ 2;
+        final oy = (gridSize - 1) ~/ 2;
+
+        // First tile is a barrier (tileIndex 0, which is in barrierTileIndices).
+        expect(result.gameMap.barriers, contains(Point(ox, oy)));
+        // Second tile is not a barrier.
+        expect(result.gameMap.barriers, isNot(contains(Point(ox + 1, oy))));
+      });
+
+      test('does not create barriers for floor-layer tiles unless tagged', () {
+        // ext_terrains: barrier tiles are only at indices 2262+ (fences).
+        // GID 1 → tileIndex 0 → not a barrier.
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Terrains',
+              firstGid: 1,
+              image: '../tilesets/ext_terrains.png',
+              columns: 32,
+              tileCount: 2368,
+            ),
+          ],
+          layers: [
+            (name: 'Ground', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(result.gameMap.barriers, isEmpty);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Spawn and terminal extraction
+    // -----------------------------------------------------------------------
+
+    group('spawn/terminal extraction', () {
+      test('extracts spawn from object group', () {
+        final tmx = buildTmx(
+          width: 10,
+          height: 10,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (
+              name: 'Floor',
+              csv: List.filled(10, List.filled(10, '1').join(',')).join(',\n'),
+            ),
+          ],
+          objectGroups: [
+            (
+              name: 'Objects',
+              objectsXml:
+                  '<object id="1" name="Spawn" type="spawn" x="160" y="160" width="32" height="32"/>',
+            ),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 10) ~/ 2; // 20
+        final oy = (gridSize - 10) ~/ 2;
+
+        // x=160, y=160 → grid (160/32, 160/32) = (5, 5) + offset (20, 20)
+        expect(result.gameMap.spawnPoint, Point(ox + 5, oy + 5));
+      });
+
+      test('extracts terminals from object group', () {
+        final tmx = buildTmx(
+          width: 10,
+          height: 10,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (
+              name: 'Floor',
+              csv: List.filled(10, List.filled(10, '1').join(',')).join(',\n'),
+            ),
+          ],
+          objectGroups: [
+            (
+              name: 'Objects',
+              objectsXml: '''
+<object id="1" name="Terminal1" type="terminal" x="64" y="96" width="32" height="32"/>
+<object id="2" name="Terminal2" type="terminal" x="192" y="128" width="32" height="32"/>''',
+            ),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        final ox = (gridSize - 10) ~/ 2;
+        final oy = (gridSize - 10) ~/ 2;
+
+        expect(result.gameMap.terminals, hasLength(2));
+        expect(result.gameMap.terminals, contains(Point(ox + 2, oy + 3)));
+        expect(result.gameMap.terminals, contains(Point(ox + 6, oy + 4)));
+      });
+
+      test('defaults spawn to center when no spawn object found', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.noSpawnFound),
+          isTrue,
+        );
+        expect(result.gameMap.spawnPoint, const Point(25, 25));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    group('error cases', () {
+      test('throws on non-orthogonal orientation', () {
+        final tmx = buildTmx(
+          orientation: 'isometric',
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        expect(
+          () => TmxImporter.import(tmx),
+          throwsA(isA<TmxImportException>()),
+        );
+      });
+
+      test('throws when all tilesets are unrecognized', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Unknown',
+              firstGid: 1,
+              image: 'unknown.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        expect(
+          () => TmxImporter.import(tmx),
+          throwsA(isA<TmxImportException>()),
+        );
+      });
+
+      test('throws on invalid XML', () {
+        expect(
+          () => TmxImporter.import('not valid xml at all'),
+          throwsA(anything),
+        );
+      });
+
+      test('throws when no tile layers exist', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          // No tile layers, only object groups.
+          objectGroups: [
+            (
+              name: 'Objects',
+              objectsXml:
+                  '<object id="1" name="Spawn" type="spawn" x="0" y="0"/>',
+            ),
+          ],
+        );
+
+        expect(
+          () => TmxImporter.import(tmx),
+          throwsA(isA<TmxImportException>()),
+        );
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Tile size warning
+    // -----------------------------------------------------------------------
+
+    group('tile size', () {
+      test('warns when TMX tile size differs from game tile size', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tileWidth: 16, // Game expects 32
+          tileHeight: 16,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(
+          result.warnings.any((w) => w.kind == TmxWarningKind.wrongTileSize),
+          isTrue,
+        );
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Tileset IDs in output
+    // -----------------------------------------------------------------------
+
+    group('output metadata', () {
+      test('populates tilesetIds with all matched tilesets', () {
+        final tmx = buildTmx(
+          width: 2,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+            (
+              name: 'RoomBuilder',
+              firstGid: 17,
+              image: '../tilesets/room_builder_office.png',
+              columns: 16,
+              tileCount: 224,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1,17'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(result.gameMap.tilesetIds, containsAll(['test', 'room_builder_office']));
+      });
+
+      test('generates mapId from mapName when not provided', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        final result =
+            TmxImporter.import(tmx, mapName: 'My Cool Map');
+        expect(result.gameMap.name, 'My Cool Map');
+        expect(result.gameMap.id, 'my_cool_map');
+      });
+
+      test('uses default name when none provided', () {
+        final tmx = buildTmx(
+          width: 1,
+          height: 1,
+          tilesets: [
+            (
+              name: 'Test',
+              firstGid: 1,
+              image: '../tilesets/test_tileset.png',
+              columns: 4,
+              tileCount: 16,
+            ),
+          ],
+          layers: [
+            (name: 'Floor', csv: '1'),
+          ],
+        );
+
+        final result = TmxImporter.import(tmx);
+        expect(result.gameMap.name, 'Imported Map');
+        expect(result.gameMap.id, 'imported_map');
+      });
+    });
+  });
+}

--- a/test/map_editor/tmx_import_integration_test.dart
+++ b/test/map_editor/tmx_import_integration_test.dart
@@ -1,0 +1,233 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/maps/tmx_importer.dart';
+import 'package:tech_world/flame/shared/constants.dart';
+import 'package:tech_world/flame/tiles/tile_ref.dart';
+import 'package:tech_world/map_editor/map_editor_state.dart';
+
+/// Build a minimal TMX XML string for integration testing.
+String _buildTmx({
+  int width = 3,
+  int height = 3,
+  List<({String name, int firstGid, String image, int columns, int tileCount})>
+      tilesets = const [],
+  List<({String name, String csv})> layers = const [],
+  List<({String name, String objectsXml})> objectGroups = const [],
+}) {
+  final sb = StringBuffer();
+  sb.writeln('<?xml version="1.0" encoding="UTF-8"?>');
+  sb.write('<map version="1.10" tiledversion="1.11.2" ');
+  sb.write('orientation="orthogonal" renderorder="right-down" ');
+  sb.write('width="$width" height="$height" ');
+  sb.writeln('tilewidth="32" tileheight="32" infinite="0">');
+
+  for (final ts in tilesets) {
+    sb.write(' <tileset firstgid="${ts.firstGid}" name="${ts.name}" ');
+    sb.write('tilewidth="32" tileheight="32" ');
+    sb.write('tilecount="${ts.tileCount}" columns="${ts.columns}">');
+    sb.write('<image source="${ts.image}" ');
+    sb.write('width="${ts.columns * 32}" ');
+    sb.writeln('height="${(ts.tileCount ~/ ts.columns) * 32}"/>');
+    sb.writeln(' </tileset>');
+  }
+
+  for (final layer in layers) {
+    sb.writeln(
+        ' <layer name="${layer.name}" width="$width" height="$height">');
+    sb.writeln('  <data encoding="csv">');
+    sb.writeln(layer.csv);
+    sb.writeln('  </data>');
+    sb.writeln(' </layer>');
+  }
+
+  for (final og in objectGroups) {
+    sb.writeln(' <objectgroup name="${og.name}">');
+    sb.writeln(og.objectsXml);
+    sb.writeln(' </objectgroup>');
+  }
+
+  sb.writeln('</map>');
+  return sb.toString();
+}
+
+void main() {
+  group('MapEditorState.loadFromTmx', () {
+    late MapEditorState state;
+
+    setUp(() {
+      state = MapEditorState();
+    });
+
+    test('loads TMX data into editor state and returns warnings', () {
+      final tmx = _buildTmx(
+        width: 4,
+        height: 4,
+        tilesets: [
+          (
+            name: 'Test',
+            firstGid: 1,
+            image: '../tilesets/test_tileset.png',
+            columns: 4,
+            tileCount: 16,
+          ),
+        ],
+        layers: [
+          (name: 'Ground', csv: '1,2,3,4,\n5,6,7,8,\n9,10,11,12,\n13,14,15,16'),
+        ],
+        objectGroups: [
+          (
+            name: 'Objects',
+            objectsXml:
+                '<object id="1" name="Spawn" type="spawn" x="32" y="32" width="32" height="32"/>',
+          ),
+        ],
+      );
+
+      final warnings = state.loadFromTmx(
+        tmx,
+        mapName: 'Test Map',
+        mapId: 'test_map',
+      );
+
+      // Should have a padding warning (4×4 < 50×50).
+      expect(
+        warnings.any((w) => w.kind == TmxWarningKind.mapPadded),
+        isTrue,
+      );
+
+      // Map name and ID should be set.
+      expect(state.mapName, 'Test Map');
+      expect(state.mapId, 'test_map');
+
+      // Floor layer should have data at the centered offset.
+      final ox = (gridSize - 4) ~/ 2;
+      final oy = (gridSize - 4) ~/ 2;
+
+      expect(
+        state.floorLayerData.tileAt(ox, oy),
+        const TileRef(tilesetId: 'test', tileIndex: 0),
+      );
+      expect(
+        state.floorLayerData.tileAt(ox + 3, oy + 3),
+        const TileRef(tilesetId: 'test', tileIndex: 15),
+      );
+
+      // Spawn should be set in structure grid.
+      expect(state.tileAt(ox + 1, oy + 1), TileType.spawn);
+    });
+
+    test('loads barriers from tileset metadata', () {
+      // room_builder_office: tile indices 0–79 are barriers.
+      final tmx = _buildTmx(
+        width: 2,
+        height: 1,
+        tilesets: [
+          (
+            name: 'RoomBuilder',
+            firstGid: 1,
+            image: '../tilesets/room_builder_office.png',
+            columns: 16,
+            tileCount: 224,
+          ),
+        ],
+        layers: [
+          // GID 1 = barrier (tileIndex 0), GID 81 = non-barrier (tileIndex 80)
+          (name: 'Wall Layer', csv: '1,81'),
+        ],
+      );
+
+      state.loadFromTmx(tmx);
+      final ox = (gridSize - 2) ~/ 2;
+      final oy = (gridSize - 1) ~/ 2;
+
+      // First cell should be a barrier in structure grid.
+      expect(state.tileAt(ox, oy), TileType.barrier);
+      // Second cell should be open (tileIndex 80 is not in barrierTileIndices).
+      expect(state.tileAt(ox + 1, oy), TileType.open);
+    });
+
+    test('throws TmxImportException on invalid TMX', () {
+      expect(
+        () => state.loadFromTmx('not valid xml'),
+        throwsA(isA<TmxImportException>()),
+      );
+    });
+
+    test('round-trips through toGameMap()', () {
+      final tmx = _buildTmx(
+        width: 5,
+        height: 5,
+        tilesets: [
+          (
+            name: 'Test',
+            firstGid: 1,
+            image: '../tilesets/test_tileset.png',
+            columns: 4,
+            tileCount: 16,
+          ),
+        ],
+        layers: [
+          (
+            name: 'Floor',
+            csv: '1,2,3,4,5,\n6,7,8,9,10,\n11,12,13,14,15,\n16,1,2,3,4,\n5,6,7,8,9',
+          ),
+        ],
+        objectGroups: [
+          (
+            name: 'Objects',
+            objectsXml: '''
+<object id="1" name="Spawn" type="spawn" x="64" y="64" width="32" height="32"/>
+<object id="2" name="T1" type="terminal" x="128" y="128" width="32" height="32"/>''',
+          ),
+        ],
+      );
+
+      state.loadFromTmx(tmx, mapName: 'Round Trip', mapId: 'round_trip');
+      final exported = state.toGameMap();
+
+      expect(exported.id, 'round_trip');
+      expect(exported.name, 'Round Trip');
+      expect(exported.floorLayer, isNotNull);
+      expect(exported.tilesetIds, contains('test'));
+
+      // Spawn point should be set.
+      final ox = (gridSize - 5) ~/ 2;
+      final oy = (gridSize - 5) ~/ 2;
+      expect(exported.spawnPoint, Point(ox + 2, oy + 2));
+
+      // Terminal should be set.
+      expect(exported.terminals, contains(Point(ox + 4, oy + 4)));
+    });
+
+    test('clears previous state before loading TMX', () {
+      // Load ASCII first to populate structure grid.
+      state.loadFromAscii('####\n#S.#\n#..#\n####');
+      expect(state.tileAt(0, 0), TileType.barrier);
+
+      // Now load TMX — previous state should be cleared.
+      final tmx = _buildTmx(
+        width: 1,
+        height: 1,
+        tilesets: [
+          (
+            name: 'Test',
+            firstGid: 1,
+            image: '../tilesets/test_tileset.png',
+            columns: 4,
+            tileCount: 16,
+          ),
+        ],
+        layers: [
+          (name: 'Floor', csv: '1'),
+        ],
+      );
+
+      state.loadFromTmx(tmx, mapName: 'Fresh');
+
+      // Old barrier at (0,0) should be cleared.
+      expect(state.tileAt(0, 0), TileType.open);
+      expect(state.mapName, 'Fresh');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `tiled` package (v0.11.1) for parsing Tiled `.tmx` XML files
- New `TmxImporter` converter: TMX XML → native `GameMap` with tileset matching by image filename, layer classification, spawn/terminal extraction, and auto-barrier detection
- Tabbed import dialog (ASCII + TMX) replaces the old ASCII-only dialog
- `MapEditorState.loadFromTmx()` convenience method for editor integration
- Grid handling: centers small maps (<50×50), crops large ones (>50×50), with user-facing warnings

## Architecture
The importer is a pure-function converter (`TmxImporter.import()`) that takes TMX XML and returns a `TmxImportResult` containing the `GameMap` and any `TmxImportWarning` objects. Fatal errors throw `TmxImportException`. Tilesets are matched by comparing TMX image filenames against the project's predefined tilesets (`allTilesets`).

## Test plan
- [x] 27 unit tests covering: basic conversion, tileset matching, GID resolution, layer classification, grid size handling, barrier extraction, spawn/terminal extraction, error cases, tile size warnings, output metadata
- [x] 5 integration tests covering: full editor load, barrier metadata, error handling, round-trip export, state clearing
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Full test suite: 972/972 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)