### PR TITLE
fix(livekit): address screen share review feedback

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -277,9 +277,9 @@ class LiveKitService {
   /// Enable/disable local screen share.
   ///
   /// On web, the browser's built-in screen picker is shown automatically.
-  /// On desktop, use [ScreenSelectDialog] to pick a source first, then call
-  /// this — LiveKit's [setScreenShareEnabled] handles the native picker on
-  /// desktop as well.
+  /// On desktop, LiveKit's `setScreenShareEnabled` triggers the native picker.
+  ///
+  /// Rethrows exceptions so callers can update UI state correctly on failure.
   Future<void> setScreenShareEnabled(bool enabled,
       {ScreenShareCaptureOptions? options}) async {
     if (_room?.localParticipant == null) return;
@@ -292,6 +292,7 @@ class LiveKitService {
           'LiveKitService: Screen share ${enabled ? 'enabled' : 'disabled'}');
     } catch (e) {
       debugPrint('LiveKitService: Failed to set screen share: $e');
+      rethrow;
     }
   }
 

--- a/lib/livekit/widgets/screen_share_overlay.dart
+++ b/lib/livekit/widgets/screen_share_overlay.dart
@@ -42,23 +42,40 @@ class _ScreenShareOverlayState extends State<ScreenShareOverlay> {
   /// Active screen share panels, keyed by `'${identity}_${track.sid}'`.
   final Map<String, _ScreenShareEntry> _entries = {};
 
-  late final StreamSubscription<(Participant, VideoTrack)> _subscribedSub;
-  late final StreamSubscription<(Participant, VideoTrack)> _unsubscribedSub;
+  StreamSubscription<(Participant, VideoTrack)>? _subscribedSub;
+  StreamSubscription<(Participant, VideoTrack)>? _unsubscribedSub;
 
   @override
   void initState() {
     super.initState();
+    _subscribe();
+  }
 
+  @override
+  void didUpdateWidget(ScreenShareOverlay old) {
+    super.didUpdateWidget(old);
+    if (old.liveKitService != widget.liveKitService) {
+      _unsubscribe();
+      _entries.clear();
+      _subscribe();
+    }
+  }
+
+  void _subscribe() {
     _subscribedSub =
         widget.liveKitService.trackSubscribed.listen(_onTrackSubscribed);
     _unsubscribedSub =
         widget.liveKitService.trackUnsubscribed.listen(_onTrackUnsubscribed);
   }
 
+  void _unsubscribe() {
+    _subscribedSub?.cancel();
+    _unsubscribedSub?.cancel();
+  }
+
   @override
   void dispose() {
-    _subscribedSub.cancel();
-    _unsubscribedSub.cancel();
+    _unsubscribe();
     super.dispose();
   }
 

--- a/lib/livekit/widgets/screen_share_panel.dart
+++ b/lib/livekit/widgets/screen_share_panel.dart
@@ -37,6 +37,8 @@ class _ScreenSharePanelState extends State<ScreenSharePanel> {
   static const _defaultHeight = 400.0;
   static const _minWidth = 320.0;
   static const _minHeight = 200.0;
+  static const _maxWidth = 1920.0;
+  static const _maxHeight = 1080.0;
   static const _titleBarHeight = 36.0;
 
   late Offset _position;
@@ -174,8 +176,8 @@ class _ScreenSharePanelState extends State<ScreenSharePanel> {
       onPanUpdate: (details) {
         setState(() {
           _size = Size(
-            (_size.width + details.delta.dx).clamp(_minWidth, double.infinity),
-            (_size.height + details.delta.dy).clamp(_minHeight, double.infinity),
+            (_size.width + details.delta.dx).clamp(_minWidth, _maxWidth),
+            (_size.height + details.delta.dy).clamp(_minHeight, _maxHeight),
           );
         });
       },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1061,7 +1061,11 @@ class _ScreenShareButtonState extends State<_ScreenShareButton> {
     final service = widget.liveKitService;
     if (service == null || !service.isConnected) return;
 
-    await service.setScreenShareEnabled(!_sharing);
+    try {
+      await service.setScreenShareEnabled(!_sharing);
+    } catch (e) {
+      debugPrint('Screen share toggle failed: $e');
+    }
     // Rebuild to pick up the new isScreenShareEnabled state.
     if (mounted) setState(() {});
   }

--- a/test/livekit/widgets/screen_share_overlay_test.dart
+++ b/test/livekit/widgets/screen_share_overlay_test.dart
@@ -22,6 +22,14 @@ class FakeLiveKitService implements LiveKitService {
   Stream<(Participant, VideoTrack)> get trackUnsubscribed =>
       _trackUnsubscribedController.stream;
 
+  /// Whether the subscribed stream currently has listeners.
+  bool get hasSubscribedListeners =>
+      _trackSubscribedController.hasListener;
+
+  /// Whether the unsubscribed stream currently has listeners.
+  bool get hasUnsubscribedListeners =>
+      _trackUnsubscribedController.hasListener;
+
   void simulateTrackSubscribed(Participant participant, VideoTrack track) {
     _trackSubscribedController.add((participant, track));
   }
@@ -69,5 +77,86 @@ void main() {
       // Should render nothing visible.
       expect(find.byType(ScreenSharePanel), findsNothing);
     });
+
+    testWidgets('subscribes to both streams on init', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                ScreenShareOverlay(liveKitService: fakeLiveKit),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(fakeLiveKit.hasSubscribedListeners, isTrue);
+      expect(fakeLiveKit.hasUnsubscribedListeners, isTrue);
+    });
+
+    testWidgets('cancels subscriptions on dispose', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                ScreenShareOverlay(liveKitService: fakeLiveKit),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Dispose the widget by replacing it.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+      // Streams should no longer have listeners from the overlay.
+      expect(fakeLiveKit.hasSubscribedListeners, isFalse);
+      expect(fakeLiveKit.hasUnsubscribedListeners, isFalse);
+    });
+
+    testWidgets('resubscribes when liveKitService changes', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                ScreenShareOverlay(liveKitService: fakeLiveKit),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(fakeLiveKit.hasSubscribedListeners, isTrue);
+
+      // Swap to a new service.
+      final newService = FakeLiveKitService();
+      addTearDown(newService.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                ScreenShareOverlay(liveKitService: newService),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Old service should lose its listeners; new service should gain them.
+      expect(fakeLiveKit.hasSubscribedListeners, isFalse);
+      expect(newService.hasSubscribedListeners, isTrue);
+      expect(newService.hasUnsubscribedListeners, isTrue);
+    });
+
+    // Note: Testing subscribe/unsubscribe track flows would require mocking
+    // Participant.getTrackPublicationBySource(), which returns a
+    // TrackPublication whose track.sid must match. LiveKit's SDK classes
+    // don't have simple test constructors, so these flows are best verified
+    // via integration tests with a real LiveKit room.
   });
 }


### PR DESCRIPTION
## Summary
Follow-up to #175 addressing all 5 review suggestions from the cage match:

- **Max-size clamp**: Panel resize now capped at 1920x1080 to prevent overflow beyond viewport
- **didUpdateWidget**: `ScreenShareOverlay` resubscribes when `liveKitService` changes (room swap)
- **Exception rethrow**: `setScreenShareEnabled` rethrows so button UI stays correct on failure
- **Overlay test coverage**: 3 new tests for subscription lifecycle, dispose cleanup, service swap
- **Doc comment fix**: Removed misleading `ScreenSelectDialog` reference

## Test plan
- [x] 1010 tests pass (3 new)
- [x] `flutter analyze --fatal-infos` clean
- [x] All fixes are targeted — no behavioral changes to happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)