### PR TITLE
fix(editor,chat): restrict map editor to owners and fix DM thread rendering

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -94,6 +94,14 @@ class ChatService {
     return _dmStreamControllers[convId]!.stream;
   }
 
+  /// Returns the current message list for a DM conversation, for use as
+  /// [StreamBuilder.initialData] so the thread view renders immediately.
+  List<ChatMessage> dmMessagesSnapshot(String peerId) {
+    final convId =
+        Conversation.conversationIdFor(_liveKitService.userId, peerId);
+    return List.from(_dmMessagesByConversation[convId] ?? []);
+  }
+
   /// The local user's ID, exposed for computing DM conversation IDs.
   String get localUserId => _liveKitService.userId;
 

--- a/lib/chat/dm_thread_view.dart
+++ b/lib/chat/dm_thread_view.dart
@@ -147,6 +147,10 @@ class _DmThreadViewState extends State<DmThreadView> {
                 ? widget.chatService
                     .dmMessages(widget.conversation.peerId!)
                 : const Stream.empty(),
+            initialData: widget.conversation.peerId != null
+                ? widget.chatService
+                    .dmMessagesSnapshot(widget.conversation.peerId!)
+                : null,
             builder: (context, snapshot) {
               final messages = snapshot.data ?? [];
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -925,11 +925,13 @@ class _MyAppState extends State<MyApp> {
                               onLoadRoom: _loadSavedRoom,
                               onDeleteRoom: _deleteSavedRoom,
                             ),
-                            const SizedBox(width: 8),
-                            _MapEditorButton(
-                              mapEditorState: _mapEditorState,
-                              techWorld: locate<TechWorld>(),
-                            ),
+                            if (_currentRoom!.canEdit(_currentUserId!)) ...[
+                              const SizedBox(width: 8),
+                              _MapEditorButton(
+                                mapEditorState: _mapEditorState,
+                                techWorld: locate<TechWorld>(),
+                              ),
+                            ],
                             if (kIsWeb || lkPlatformIsDesktop()) ...[
                               const SizedBox(width: 8),
                               _ScreenShareButton(


### PR DESCRIPTION
## Summary
- **Map editor auth**: Hide the editor button for non-owners/non-editors using the existing `canEdit()` check. The `editorIds` infrastructure is already in place for granting edit permissions later.
- **DM thread rendering**: Fix the "No messages yet" bug when opening a DM conversation that already has messages. The `StreamBuilder` now gets `initialData` via a new `dmMessagesSnapshot()` method, so existing messages render on the first frame.

## Changes
| File | Change |
|------|--------|
| `lib/main.dart` | Wrap `_MapEditorButton` in `canEdit()` conditional |
| `lib/chat/chat_service.dart` | Add `dmMessagesSnapshot()` for synchronous message access |
| `lib/chat/dm_thread_view.dart` | Add `initialData` to DM thread `StreamBuilder` |

## Test plan
- [x] All 1115 existing tests pass
- [x] Manual testing: sent DMs via `lk` CLI, verified messages appear immediately in thread view
- [x] Manual testing: verified editor button hidden for non-owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)