### PR TITLE
diag: pixel probe for black bubble investigation

### DIFF
--- a/lib/livekit/dreamfinder_avatar_bridge_web.dart
+++ b/lib/livekit/dreamfinder_avatar_bridge_web.dart
@@ -110,6 +110,9 @@ class DreamfinderAvatarBridge {
       return;
     }
 
+    // Diagnostic: verify preserveDrawingBuffer and alpha settings.
+    _logCanvasDiagnostics(canvas);
+
     _canvasCapture = CanvasCapture.create(canvas, fps: 15);
     _canvasCapture?.startCapture();
     _isReady = true;
@@ -154,6 +157,48 @@ class DreamfinderAvatarBridge {
     } catch (e) {
       _log.severe('Cannot access iframe canvas (cross-origin?): $e');
       return null;
+    }
+  }
+
+  /// Log WebGL context attributes and initial pixel state of the canvas.
+  void _logCanvasDiagnostics(web.HTMLCanvasElement canvas) {
+    try {
+      final contentWindow = _iframe?.contentWindow;
+      if (contentWindow == null) return;
+
+      // Read context attributes via iframe's window
+      final win = contentWindow as JSObject;
+      final attrs = win.getProperty('_attrs'.toJS);
+      if (attrs != null) {
+        final attrsObj = attrs as JSObject;
+        final pdb = attrsObj.getProperty('preserveDrawingBuffer'.toJS);
+        final alpha = attrsObj.getProperty('alpha'.toJS);
+        _log.info(
+          'DIAG canvas attrs: preserveDrawingBuffer=$pdb, alpha=$alpha, '
+          'size=${canvas.width}x${canvas.height}',
+        );
+      } else {
+        _log.info(
+          'DIAG canvas size=${canvas.width}x${canvas.height}, '
+          'attrs not exposed (no window._attrs)',
+        );
+      }
+
+      // Read pixels from canvas via 2D drawImage
+      final probe = web.document.createElement('canvas') as web.HTMLCanvasElement;
+      probe.width = canvas.width;
+      probe.height = canvas.height;
+      final ctx = probe.getContext('2d')! as web.CanvasRenderingContext2D;
+      ctx.drawImage(canvas as web.CanvasImageSource, 0, 0);
+      final px = ctx.getImageData(
+        canvas.width ~/ 2, canvas.height ~/ 2, 1, 1,
+      ).data.toDart;
+      _log.info(
+        'DIAG initial canvas pixels: center=[${px.join(",")}], '
+        'hasData=${px.any((v) => v > 0)}',
+      );
+    } catch (e) {
+      _log.warning('DIAG canvas diagnostics failed: $e');
     }
   }
 

--- a/lib/native/canvas_capture_web.dart
+++ b/lib/native/canvas_capture_web.dart
@@ -48,6 +48,42 @@ class CanvasCapture {
   MediaStreamTrackProcessor? _processor;
   web.ReadableStreamDefaultReader? _reader;
 
+  /// Diagnostic: read pixels from an ImageBitmap via 2D canvas and log them.
+  void _logImageBitmapPixels(web.ImageBitmap bmp, int w, int h) {
+    try {
+      final c = web.document.createElement('canvas') as web.HTMLCanvasElement;
+      c.width = w;
+      c.height = h;
+      final ctx = c.getContext('2d')! as web.CanvasRenderingContext2D;
+      ctx.drawImage(bmp as web.CanvasImageSource, 0, 0);
+      // Sample center pixel + corners
+      final center = ctx.getImageData(w ~/ 2, h ~/ 2, 1, 1).data.toDart;
+      final topLeft = ctx.getImageData(0, 0, 1, 1).data.toDart;
+      final hasData = center.any((v) => v > 0) || topLeft.any((v) => v > 0);
+      _log.info(
+        'DIAG frame#$_frameNumber: ImageBitmap ${bmp.width}x${bmp.height}, '
+        'center=[${center.join(",")}], topLeft=[${topLeft.join(",")}], '
+        'hasData=$hasData',
+      );
+
+      // Also probe source canvas directly
+      final srcC = web.document.createElement('canvas') as web.HTMLCanvasElement;
+      srcC.width = _canvas.width;
+      srcC.height = _canvas.height;
+      final srcCtx = srcC.getContext('2d')! as web.CanvasRenderingContext2D;
+      srcCtx.drawImage(_canvas as web.CanvasImageSource, 0, 0);
+      final srcPx = srcCtx.getImageData(
+        _canvas.width ~/ 2, _canvas.height ~/ 2, 1, 1,
+      ).data.toDart;
+      _log.info(
+        'DIAG frame#$_frameNumber: Source canvas ${_canvas.width}x${_canvas.height}, '
+        'center=[${srcPx.join(",")}], hasData=${srcPx.any((v) => v > 0)}',
+      );
+    } catch (e) {
+      _log.warning('DIAG pixel probe failed: $e');
+    }
+  }
+
   /// Create a capture from an HTMLCanvasElement.
   static CanvasCapture? create(
     web.HTMLCanvasElement canvas, {
@@ -154,6 +190,12 @@ class CanvasCapture {
 
       // Close VideoFrame immediately to release decoder resources.
       videoFrame.close();
+
+      // Diagnostic: on first few frames, read ImageBitmap pixels via 2D
+      // canvas to verify data BEFORE it enters createImageFromImageBitmap.
+      if (_frameNumber < 3) {
+        _logImageBitmapPixels(imageBitmap, vw, vh);
+      }
 
       ui.Image newFrame;
       try {


### PR DESCRIPTION
## Summary
- Adds diagnostic logging at bridge init and first 3 captured frames
- Logs WebGL context attributes (preserveDrawingBuffer, alpha) to verify monkey-patch
- Reads pixels via 2D canvas at two points: source canvas AND ImageBitmap
- Will show definitively whether pixels exist before `createImageFromImageBitmap`

## Context
Browser-level testing confirms the entire capture pipeline works with simple WebGL. The black bubble is specific to the TalkingHead/Three.js renderer. These diagnostics will pinpoint exactly where pixels are lost.

## Test plan
- [x] `flutter analyze` passes
- [ ] Deploy to world.imagineering.cc
- [ ] Sign in, wait for Dreamfinder, check console for DIAG messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)