### PR TITLE
fix: route canvas through video element to dodge Skia bug

### DIFF
--- a/lib/flame/components/video_bubble_component.dart
+++ b/lib/flame/components/video_bubble_component.dart
@@ -10,7 +10,6 @@ import 'package:logging/logging.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as webrtc;
 import 'package:livekit_client/livekit_client.dart';
 
-import '../../native/canvas_capture.dart';
 import '../../native/video_frame_capture.dart' as ffi;
 import '../../native/direct_track_capture.dart' as direct_capture;
 
@@ -45,7 +44,7 @@ class VideoBubbleComponent extends PositionComponent {
     required this.displayName,
     this.bubbleSize = 64,
     this.targetFps = 15,
-    this.externalCanvasCapture,
+    this.externalVideoCapture,
   }) : super(
           size: Vector2.all(bubbleSize),
           anchor: Anchor.bottomCenter,
@@ -56,10 +55,11 @@ class VideoBubbleComponent extends PositionComponent {
   final double bubbleSize;
   final int targetFps;
 
-  /// Optional external canvas capture (e.g., from Dreamfinder's 3D avatar).
+  /// Optional external video capture (e.g., from Dreamfinder's 3D avatar
+  /// routed through a <video> element via captureStream).
   /// When provided, bypasses participant video track discovery and uses this
   /// capture source directly for frame data.
-  final CanvasCapture? externalCanvasCapture;
+  final direct_capture.VideoElementCapture? externalVideoCapture;
 
   ui.Image? _currentFrame;
   VideoTrack? _videoTrack;
@@ -148,7 +148,7 @@ class VideoBubbleComponent extends PositionComponent {
   /// Notify that the video track is ready (called when track subscription event fires)
   /// This triggers immediate capture initialization instead of waiting for retry timer.
   void notifyTrackReady() {
-    if (!_captureInitialized && externalCanvasCapture == null) {
+    if (!_captureInitialized && externalVideoCapture == null) {
       _initializeCapture();
     }
   }
@@ -165,7 +165,7 @@ class VideoBubbleComponent extends PositionComponent {
 
     // Try to initialize capture if not yet done (with retry backoff).
     // Skip when using an external canvas capture — it manages its own lifecycle.
-    if (externalCanvasCapture == null &&
+    if (externalVideoCapture == null &&
         !_captureInitialized &&
         _captureRetryCount < _maxCaptureRetries) {
       _timeSinceLastRetry += dt;
@@ -357,8 +357,8 @@ class VideoBubbleComponent extends PositionComponent {
 
   void _checkForNewWebFrame() {
     // Check external canvas capture (e.g., Dreamfinder 3D avatar)
-    if (externalCanvasCapture != null && externalCanvasCapture!.hasNewFrame) {
-      _processWebFrame(externalCanvasCapture!.consumeFrame());
+    if (externalVideoCapture != null && externalVideoCapture!.hasNewFrame) {
+      _processWebFrame(externalVideoCapture!.consumeFrame());
       return;
     }
 

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -631,7 +631,7 @@ class TechWorld extends World with TapCallbacks {
       displayName: dreamfinderBot.displayName,
       bubbleSize: 64,
       targetFps: 10,
-      externalCanvasCapture: _dreamfinderAvatarBridge?.canvasCapture,
+      externalVideoCapture: _dreamfinderAvatarBridge?.videoCapture,
     );
     videoBubble.glowColor = const Color(0xFFDAA520); // gold
     videoBubble.glowIntensity = 0.7;
@@ -1051,7 +1051,7 @@ class TechWorld extends World with TapCallbacks {
       // - It's a VideoBubbleComponent without canvas capture but the bridge
       //   is now ready (bridge initialized after the bubble was created).
       final hasCanvasCapture = existingBubble is VideoBubbleComponent &&
-          existingBubble.externalCanvasCapture != null;
+          existingBubble.externalVideoCapture != null;
       final needsUpgrade = existingBubble is! VideoBubbleComponent ||
           (!hasCanvasCapture && _dreamfinderAvatarBridge?.isReady == true);
 

--- a/lib/livekit/dreamfinder_avatar_bridge_stub.dart
+++ b/lib/livekit/dreamfinder_avatar_bridge_stub.dart
@@ -1,6 +1,6 @@
 // Stub implementation for non-web platforms.
 
-import '../native/canvas_capture.dart';
+import '../native/direct_track_capture.dart';
 import 'livekit_service.dart';
 
 /// No-op bridge on non-web platforms. The 3D avatar requires a browser.
@@ -8,7 +8,7 @@ class DreamfinderAvatarBridge {
   DreamfinderAvatarBridge({required LiveKitService liveKitService});
 
   /// Always null on non-web platforms.
-  CanvasCapture? get canvasCapture => null;
+  VideoElementCapture? get videoCapture => null;
 
   /// Always false.
   bool get isReady => false;

--- a/lib/livekit/dreamfinder_avatar_bridge_web.dart
+++ b/lib/livekit/dreamfinder_avatar_bridge_web.dart
@@ -22,7 +22,7 @@ import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
 import '../bots/bot_config.dart';
-import '../native/canvas_capture_web.dart';
+import '../native/video_frame_web_v2.dart' show VideoElementCapture;
 import 'livekit_service.dart';
 
 final _log = Logger('DreamfinderAvatarBridge');
@@ -39,7 +39,7 @@ class DreamfinderAvatarBridge {
   final LiveKitService _liveKitService;
 
   web.HTMLIFrameElement? _iframe;
-  CanvasCapture? _canvasCapture;
+  VideoElementCapture? _videoCapture;
   bool _isReady = false;
 
   /// Download progress of the avatar GLB (0–100), or null if not loading.
@@ -48,8 +48,8 @@ class DreamfinderAvatarBridge {
   StreamSubscription<DataChannelMessage>? _moodSubscription;
   JSFunction? _messageListener;
 
-  /// The canvas capture instance, available after the iframe is ready.
-  CanvasCapture? get canvasCapture => _canvasCapture;
+  /// The video capture instance, available after the iframe is ready.
+  VideoElementCapture? get videoCapture => _videoCapture;
 
   /// Whether the iframe has loaded and the canvas is being captured.
   bool get isReady => _isReady;
@@ -113,8 +113,18 @@ class DreamfinderAvatarBridge {
     // Diagnostic: verify preserveDrawingBuffer and alpha settings.
     _logCanvasDiagnostics(canvas);
 
-    _canvasCapture = CanvasCapture.create(canvas, fps: 15);
-    _canvasCapture?.startCapture();
+    // Route canvas frames through a <video> element so that
+    // createImageBitmap(video) produces ImageBitmaps that CanvasKit's
+    // MakeLazyImageFromTextureSource can render. Canvas-sourced ImageBitmaps
+    // hit a Skia regression (issue 14637) and render black.
+    final stream = canvas.captureStream(15);
+    final capture = await VideoElementCapture.createFromStream(stream, null);
+    if (capture == null) {
+      _log.severe('Failed to create VideoElementCapture from canvas stream');
+      return;
+    }
+    _videoCapture = capture;
+    capture.startCapture();
     _isReady = true;
 
     // Start forwarding data channels to the iframe.
@@ -269,8 +279,8 @@ class DreamfinderAvatarBridge {
   void dispose() {
     _audioSubscription?.cancel();
     _moodSubscription?.cancel();
-    _canvasCapture?.dispose();
-    _canvasCapture = null;
+    _videoCapture?.dispose();
+    _videoCapture = null;
 
     if (_messageListener != null) {
       web.window.removeEventListener('message', _messageListener!);

--- a/lib/native/canvas_capture_web.dart
+++ b/lib/native/canvas_capture_web.dart
@@ -14,8 +14,8 @@ library;
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
 
 import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
@@ -108,20 +108,22 @@ class CanvasCapture {
       //   [239, 205, 180, 255] — skin tone from the 3D avatar.
       _offscreenCtx!.drawImage(_canvas as web.CanvasImageSource, 0, 0);
 
-      // Read raw RGBA pixels.
-      final imageData = _offscreenCtx!.getImageData(0, 0, w, h);
-      final pixels = Uint8List.fromList(imageData.data.toDart);
+      // Create ImageBitmap from the 2D offscreen canvas (CPU-backed).
+      // Unlike captureStream-sourced ImageBitmaps, these work correctly
+      // with CanvasKit's createImageFromImageBitmap.
+      final imageBitmap = await web.window
+          .createImageBitmap(_offscreen! as web.ImageBitmapSource)
+          .toDart;
 
-      // Create ui.Image from raw pixel data.
-      final completer = Completer<ui.Image>();
-      ui.decodeImageFromPixels(
-        pixels,
-        w,
-        h,
-        ui.PixelFormat.rgba8888,
-        completer.complete,
-      );
-      final newFrame = await completer.future;
+      ui.Image newFrame;
+      try {
+        newFrame = await ui_web.createImageFromImageBitmap(
+          imageBitmap as JSAny,
+        );
+      } catch (_) {
+        imageBitmap.close();
+        rethrow;
+      }
 
       final oldFrame = _currentFrame;
       _currentFrame = newFrame;


### PR DESCRIPTION
Skia issue 14637: MakeLazyImageFromTextureSource renders black for canvas ImageBitmaps. Video element ImageBitmaps work. Route through captureStream → video → existing pipeline.