### PR TITLE
refactor: typed PromptChallengeId + CodeChallengeId end-to-end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,30 @@ Closed sets of identifiers — words of power, schools, elements, avatars, room 
 
 Why: Dart's exhaustive `switch` over enums catches every consumer of a closed set the moment it grows. The bijection between two const sets reduces to one length assertion. Typos can't compile.
 
-When you arrive in this codebase: sweep `lib/` for `String` fields whose values are drawn from a closed set. Each one is a refactoring opportunity. Examples already done: `WordId` (the spellbook). Examples still pending: `ChallengeId` (challenges live in `lib/prompt/`), `AvatarId`, `MapId`, `TilesetId`, `RoomType`. Don't refactor speculatively — refactor when you're already touching the code for another reason.
+When you arrive in this codebase: sweep `lib/` for `String` fields whose values are drawn from a closed set. Each one is a refactoring opportunity. Examples already done:
+
+- `WordId` (the spellbook 18 — `lib/spellbook/word_of_power.dart`).
+- `PromptChallengeId` (the 18 prompt challenges — `lib/prompt/prompt_challenge.dart`).
+- `CodeChallengeId` (the 23 code-editor challenges — `lib/editor/challenge.dart`).
+
+Examples still pending: `AvatarId`, `MapId`, `TilesetId`, `RoomType`. Don't refactor speculatively — refactor when you're already touching the code for another reason.
+
+When the wire format is multi-word (snake_case), use the **enhanced enum** form so the in-language identifier stays camelCase but the `wireName` is preserved verbatim:
+
+```dart
+enum PromptChallengeId {
+  evocationFizzbuzz('evocation_fizzbuzz'),
+  // …
+  ;
+  const PromptChallengeId(this.wireName);
+  final String wireName;
+  static PromptChallengeId? parse(String wire) { /* … */ }
+}
+```
+
+`enum.name` only matches the wire when each value is a single token — for everything else, store the wire form explicitly.
+
+When two typed-id namespaces share the same persistence boundary (here: `ProgressService.completedChallenges` mixes `CodeChallengeId.wireName` and `PromptChallengeId.wireName` in one Firestore array), keep wire forms **disjoint by construction** and pin the disjointness with a runtime test (see `test/editor/code_challenge_id_test.dart`).
 
 ### Use Dart 3 features
 

--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -322,7 +322,12 @@ class ChatService {
   /// timeout or error. The caller can inspect fields like `challengeResult`.
   ///
   /// Optional [metadata] fields are merged into the published JSON payload
-  /// (e.g. `{'challengeId': 'fizzbuzz'}` for challenge evaluations).
+  /// (e.g. `{'promptChallengeId': 'evocation_fizzbuzz'}` for cast
+  /// evaluations). All values must be JSON-serializable — the
+  /// `Map<String, dynamic>` signature accepts anything at compile time,
+  /// but typed enums and other non-primitives must be converted to their
+  /// wire form (e.g. `PromptChallengeId.evocationFizzbuzz.wireName`)
+  /// before being put into this map.
   ///
   /// Reserved keys (`type`, `id`, `text`, `senderName`, `timestamp`) are
   /// silently stripped from [metadata] to prevent protocol corruption.

--- a/lib/editor/challenge.dart
+++ b/lib/editor/challenge.dart
@@ -1,5 +1,65 @@
 enum Difficulty { beginner, intermediate, advanced }
 
+/// The closed set of code-editor coding challenges.
+///
+/// `CodeChallengeId` is the **domain type** for code challenges across the
+/// editor flow, ChatService help requests, and ProgressService completions
+/// originating from the code editor. Strings only appear at boundaries —
+/// Firestore on-disk format, chat metadata payloads — and parse via
+/// [CodeChallengeId.parse].
+///
+/// This is a sibling type to `PromptChallengeId` (in `lib/prompt/`). Both
+/// share `ProgressService` as the persistence layer, where they convert
+/// to [String] via [wireName] at the call site. The two namespaces are
+/// disjoint by construction (every `CodeChallengeId.wireName` differs
+/// from every `PromptChallengeId.wireName`) so the shared Firestore array
+/// is unambiguous.
+///
+/// Wire format: each value owns its [wireName] (e.g.
+/// `CodeChallengeId.helloDart.wireName == 'hello_dart'`). Existing
+/// Firestore data parses unchanged.
+enum CodeChallengeId {
+  helloDart('hello_dart'),
+  sumList('sum_list'),
+  fizzbuzz('fizzbuzz'),
+  stringReversal('string_reversal'),
+  evenNumbers('even_numbers'),
+  palindromeCheck('palindrome_check'),
+  wordCounter('word_counter'),
+  temperatureConverter('temperature_converter'),
+  findMaximum('find_maximum'),
+  removeDuplicates('remove_duplicates'),
+  binarySearch('binary_search'),
+  fibonacciSequence('fibonacci_sequence'),
+  caesarCipher('caesar_cipher'),
+  anagramChecker('anagram_checker'),
+  flattenList('flatten_list'),
+  matrixSum('matrix_sum'),
+  bracketMatching('bracket_matching'),
+  mergeSort('merge_sort'),
+  stackImplementation('stack_implementation'),
+  romanNumerals('roman_numerals'),
+  runLengthEncoding('run_length_encoding'),
+  longestCommonSubsequence('longest_common_subsequence'),
+  asyncDataPipeline('async_data_pipeline');
+
+  const CodeChallengeId(this.wireName);
+
+  /// On-disk / wire identifier. Stable across refactors of the Dart
+  /// identifier — this is what Firestore stores.
+  final String wireName;
+
+  /// Parse a wire-format string into a [CodeChallengeId], or `null` if
+  /// unknown. Use at boundaries (Firestore reads, chat metadata) and
+  /// decide what to do with `null` at the call site.
+  static CodeChallengeId? parse(String wire) {
+    for (final c in CodeChallengeId.values) {
+      if (c.wireName == wire) return c;
+    }
+    return null;
+  }
+}
+
 class Challenge {
   const Challenge({
     required this.id,
@@ -9,7 +69,8 @@ class Challenge {
     this.difficulty = Difficulty.beginner,
   });
 
-  final String id;
+  /// Strongly-typed identifier — see [CodeChallengeId].
+  final CodeChallengeId id;
   final String title;
   final String description;
   final String starterCode;

--- a/lib/editor/code_editor_panel.dart
+++ b/lib/editor/code_editor_panel.dart
@@ -57,8 +57,12 @@ class _CodeEditorPanelState extends State<CodeEditorPanel> {
     super.initState();
 
     final timestamp = DateTime.now().millisecondsSinceEpoch;
+    // `wireName` (snake_case) keeps the file path stable across refactors
+    // of the Dart identifier; interpolating `widget.challenge.id` directly
+    // would yield `CodeChallengeId.helloDart_<ts>.dart` because Dart's
+    // enum `toString()` returns the type-prefixed form.
     _fileUri =
-        '${LspConstants.fileBasePath}/${widget.challenge.id}_$timestamp.dart';
+        '${LspConstants.fileBasePath}/${widget.challenge.id.wireName}_$timestamp.dart';
 
     LspSocketConfig? lspConfig;
     try {

--- a/lib/editor/predefined_challenges.dart
+++ b/lib/editor/predefined_challenges.dart
@@ -5,7 +5,7 @@ import 'challenge.dart';
 // ---------------------------------------------------------------------------
 
 const helloDart = Challenge(
-  id: 'hello_dart',
+  id: CodeChallengeId.helloDart,
   title: 'Hello Dart',
 
   description: 'Write a function that returns a greeting string.\n'
@@ -22,7 +22,7 @@ void main() {
 );
 
 const sumList = Challenge(
-  id: 'sum_list',
+  id: CodeChallengeId.sumList,
   title: 'Sum a List',
 
   description: 'Write a function that returns the sum of all integers '
@@ -40,7 +40,7 @@ void main() {
 );
 
 const fizzbuzz = Challenge(
-  id: 'fizzbuzz',
+  id: CodeChallengeId.fizzbuzz,
   title: 'FizzBuzz',
 
   description: 'Write a function that returns a list of strings from 1 to n.\n'
@@ -60,7 +60,7 @@ void main() {
 );
 
 const stringReversal = Challenge(
-  id: 'string_reversal',
+  id: CodeChallengeId.stringReversal,
   title: 'String Reversal',
 
   description: 'Write a function that reverses a string.\n'
@@ -79,7 +79,7 @@ void main() {
 );
 
 const evenNumbers = Challenge(
-  id: 'even_numbers',
+  id: CodeChallengeId.evenNumbers,
   title: 'Even Numbers',
 
   description: 'Write a function that takes a list of integers and returns '
@@ -100,7 +100,7 @@ void main() {
 );
 
 const palindromeCheck = Challenge(
-  id: 'palindrome_check',
+  id: CodeChallengeId.palindromeCheck,
   title: 'Palindrome Check',
 
   description: 'Write a function that checks whether a string is a palindrome.\n'
@@ -121,7 +121,7 @@ void main() {
 );
 
 const wordCounter = Challenge(
-  id: 'word_counter',
+  id: CodeChallengeId.wordCounter,
   title: 'Word Counter',
 
   description: 'Write a function that counts the number of words in a string.\n'
@@ -142,7 +142,7 @@ void main() {
 );
 
 const temperatureConverter = Challenge(
-  id: 'temperature_converter',
+  id: CodeChallengeId.temperatureConverter,
   title: 'Temperature Converter',
 
   description: 'Write a function that converts a temperature from Celsius '
@@ -164,7 +164,7 @@ void main() {
 );
 
 const findMaximum = Challenge(
-  id: 'find_maximum',
+  id: CodeChallengeId.findMaximum,
   title: 'Find Maximum',
 
   description: 'Write a function that finds the largest number in a list '
@@ -185,7 +185,7 @@ void main() {
 );
 
 const removeDuplicates = Challenge(
-  id: 'remove_duplicates',
+  id: CodeChallengeId.removeDuplicates,
   title: 'Remove Duplicates',
 
   description: 'Write a function that removes duplicate items from a list, '
@@ -209,7 +209,7 @@ void main() {
 // ---------------------------------------------------------------------------
 
 const binarySearch = Challenge(
-  id: 'binary_search',
+  id: CodeChallengeId.binarySearch,
   title: 'Binary Search',
   difficulty: Difficulty.intermediate,
   description: 'Implement binary search on a sorted list of integers.\n'
@@ -232,7 +232,7 @@ void main() {
 );
 
 const fibonacciSequence = Challenge(
-  id: 'fibonacci_sequence',
+  id: CodeChallengeId.fibonacciSequence,
   title: 'Fibonacci Sequence',
   difficulty: Difficulty.intermediate,
   description: 'Write a function that generates the first n numbers of the '
@@ -254,7 +254,7 @@ void main() {
 );
 
 const caesarCipher = Challenge(
-  id: 'caesar_cipher',
+  id: CodeChallengeId.caesarCipher,
   title: 'Caesar Cipher',
   difficulty: Difficulty.intermediate,
   description: 'Implement a Caesar cipher that shifts each letter by a '
@@ -276,7 +276,7 @@ void main() {
 );
 
 const anagramChecker = Challenge(
-  id: 'anagram_checker',
+  id: CodeChallengeId.anagramChecker,
   title: 'Anagram Checker',
   difficulty: Difficulty.intermediate,
   description: 'Write a function that checks whether two strings are anagrams '
@@ -299,7 +299,7 @@ void main() {
 );
 
 const flattenList = Challenge(
-  id: 'flatten_list',
+  id: CodeChallengeId.flattenList,
   title: 'Flatten List',
   difficulty: Difficulty.intermediate,
   description: 'Write a function that flattens a nested list of integers '
@@ -322,7 +322,7 @@ void main() {
 );
 
 const matrixSum = Challenge(
-  id: 'matrix_sum',
+  id: CodeChallengeId.matrixSum,
   title: 'Matrix Sum',
   difficulty: Difficulty.intermediate,
   description: 'Write a function that computes the sum of all elements in '
@@ -352,7 +352,7 @@ void main() {
 );
 
 const bracketMatching = Challenge(
-  id: 'bracket_matching',
+  id: CodeChallengeId.bracketMatching,
   title: 'Bracket Matching',
   difficulty: Difficulty.intermediate,
   description: 'Write a function that checks whether a string of brackets '
@@ -381,7 +381,7 @@ void main() {
 // ---------------------------------------------------------------------------
 
 const mergeSort = Challenge(
-  id: 'merge_sort',
+  id: CodeChallengeId.mergeSort,
   title: 'Merge Sort',
   difficulty: Difficulty.advanced,
   description: 'Implement the merge sort algorithm.\n'
@@ -407,7 +407,7 @@ void main() {
 );
 
 const stackImplementation = Challenge(
-  id: 'stack_implementation',
+  id: CodeChallengeId.stackImplementation,
   title: 'Stack Implementation',
   difficulty: Difficulty.advanced,
   description: 'Implement a generic Stack data structure with the following '
@@ -459,7 +459,7 @@ void main() {
 );
 
 const romanNumerals = Challenge(
-  id: 'roman_numerals',
+  id: CodeChallengeId.romanNumerals,
   title: 'Roman Numerals',
   difficulty: Difficulty.advanced,
   description: 'Write a function that converts a positive integer to its '
@@ -486,7 +486,7 @@ void main() {
 );
 
 const runLengthEncoding = Challenge(
-  id: 'run_length_encoding',
+  id: CodeChallengeId.runLengthEncoding,
   title: 'Run Length Encoding',
   difficulty: Difficulty.advanced,
   description: 'Implement run-length encoding (RLE) compression and '
@@ -520,7 +520,7 @@ void main() {
 );
 
 const longestCommonSubsequence = Challenge(
-  id: 'longest_common_subsequence',
+  id: CodeChallengeId.longestCommonSubsequence,
   title: 'Longest Common Subsequence',
   difficulty: Difficulty.advanced,
   description: 'Write a function that finds the longest common subsequence '
@@ -545,7 +545,7 @@ void main() {
 );
 
 const asyncDataPipeline = Challenge(
-  id: 'async_data_pipeline',
+  id: CodeChallengeId.asyncDataPipeline,
   title: 'Async Data Pipeline',
   difficulty: Difficulty.advanced,
   description: 'Build an asynchronous data pipeline that chains Future '

--- a/lib/flame/maps/door_data.dart
+++ b/lib/flame/maps/door_data.dart
@@ -1,12 +1,17 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
+
+final _log = Logger('DoorData');
 
 /// Data model for a door in the game world.
 ///
-/// Doors are barriers that can be unlocked by completing specific challenges.
-/// When locked, they block movement like any other barrier. When unlocked,
-/// they become passable.
+/// Doors are barriers that can be unlocked by completing specific
+/// prompt-engineering challenges (the spellbook 18). When locked, they
+/// block movement like any other barrier. When unlocked, they become
+/// passable.
 class DoorData {
   DoorData({
     required this.position,
@@ -17,32 +22,52 @@ class DoorData {
   /// Grid position of the door.
   final Point<int> position;
 
-  /// IDs of challenges that must be completed to unlock this door.
+  /// Prompt challenges that must all be completed to unlock this door.
   ///
   /// An empty list means the door can be unlocked without solving anything
   /// (e.g. via a switch or event trigger).
-  final List<String> requiredChallengeIds;
+  final List<PromptChallengeId> requiredChallengeIds;
 
   /// Whether the door is currently unlocked (passable).
   bool isUnlocked;
 
-  /// Serialize to JSON.
+  /// Serialize to JSON. Each challenge is stored as its
+  /// [PromptChallengeId.wireName] (snake_case), preserving the existing
+  /// on-disk format so older saves keep loading.
   Map<String, dynamic> toJson() => {
         'x': position.x,
         'y': position.y,
-        if (requiredChallengeIds.isNotEmpty) 'challenges': requiredChallengeIds,
+        if (requiredChallengeIds.isNotEmpty)
+          'challenges': [
+            for (final id in requiredChallengeIds) id.wireName,
+          ],
       };
 
-  /// Deserialize from JSON.
-  factory DoorData.fromJson(Map<String, dynamic> json) => DoorData(
-        position: Point(json['x'] as int, json['y'] as int),
-        requiredChallengeIds: (json['challenges'] as List<dynamic>?)
-                ?.cast<String>()
-                .toList() ??
-            const [],
-      );
+  /// Deserialize from JSON. Unknown challenge wire forms are logged and
+  /// skipped — older clients can still load saves that name challenges
+  /// they don't recognise yet (forward-compat).
+  factory DoorData.fromJson(Map<String, dynamic> json) {
+    final raw = json['challenges'] as List<dynamic>?;
+    final ids = <PromptChallengeId>[];
+    if (raw != null) {
+      for (final wire in raw) {
+        final parsed = PromptChallengeId.parse(wire as String);
+        if (parsed == null) {
+          _log.warning(
+              'DoorData.fromJson: unknown challenge wire form "$wire"; '
+              'skipping');
+          continue;
+        }
+        ids.add(parsed);
+      }
+    }
+    return DoorData(
+      position: Point(json['x'] as int, json['y'] as int),
+      requiredChallengeIds: ids,
+    );
+  }
 
-  static const _listEquality = ListEquality<String>();
+  static const _listEquality = ListEquality<PromptChallengeId>();
 
   @override
   bool operator ==(Object other) =>

--- a/lib/flame/maps/predefined_maps.dart
+++ b/lib/flame/maps/predefined_maps.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 
 import 'package:tech_world/flame/tiles/tile_layer_data.dart';
 import 'package:tech_world/flame/tiles/tile_ref.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 
 import 'door_data.dart';
 import 'game_map.dart';
@@ -99,17 +100,23 @@ final wizardsTower = GameMap(
     // D0: Exit the Antechamber — prove you can instruct precisely.
     DoorData(
       position: const Point(24, 36),
-      requiredChallengeIds: ['evocation_fizzbuzz'],
+      requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
     ),
     // D1: Exit the Great Hall — master basics of both schools.
     DoorData(
       position: const Point(24, 25),
-      requiredChallengeIds: ['evocation_countdown', 'divination_color'],
+      requiredChallengeIds: const [
+        PromptChallengeId.evocationCountdown,
+        PromptChallengeId.divinationColor,
+      ],
     ),
     // D2: Enter the Sanctum — intermediate mastery required.
     DoorData(
       position: const Point(24, 15),
-      requiredChallengeIds: ['evocation_diamond', 'divination_extract'],
+      requiredChallengeIds: const [
+        PromptChallengeId.evocationDiamond,
+        PromptChallengeId.divinationExtract,
+      ],
     ),
   ],
   walls: _wizardsTowerWalls(),

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -127,10 +127,11 @@ class TechWorld extends World with TapCallbacks {
   static const double _mergeThreshold = 96.0; // 1.5× bubble diameter
 
   /// Notifier for active code challenge ID. Null means no editor open.
-  final ValueNotifier<String?> activeChallenge = ValueNotifier(null);
+  final ValueNotifier<CodeChallengeId?> activeChallenge = ValueNotifier(null);
 
   /// Notifier for active prompt challenge ID. Null means no prompt panel open.
-  final ValueNotifier<String?> activePromptChallenge = ValueNotifier(null);
+  final ValueNotifier<PromptChallengeId?> activePromptChallenge =
+      ValueNotifier(null);
 
   /// Grid position of the terminal the player is currently interacting with.
   /// Null when no editor is open.
@@ -315,10 +316,14 @@ class TechWorld extends World with TapCallbacks {
     _pathComponent?.setGridFromEditor(editor);
   }
 
-  /// Check if a challenge is completed via the [ProgressService].
-  bool _isChallengeCompleted(String challengeId) {
+  /// Check if a code challenge is completed via the [ProgressService].
+  ///
+  /// Converts the typed [CodeChallengeId] to its [CodeChallengeId.wireName]
+  /// at the [ProgressService] boundary — the service stores both code and
+  /// prompt completions in a single Firestore array keyed by wire form.
+  bool _isCodeChallengeCompleted(CodeChallengeId challengeId) {
     return Locator.maybeLocate<ProgressService>()
-            ?.isChallengeCompleted(challengeId) ??
+            ?.isChallengeCompleted(challengeId.wireName) ??
         false;
   }
 
@@ -329,7 +334,7 @@ class TechWorld extends World with TapCallbacks {
     for (var i = 0; i < _terminalComponents.length; i++) {
       final challengeIndex = i % allChallenges.length;
       _terminalComponents[i].isCompleted =
-          _isChallengeCompleted(allChallenges[challengeIndex].id);
+          _isCodeChallengeCompleted(allChallenges[challengeIndex].id);
     }
   }
 
@@ -1497,7 +1502,7 @@ class TechWorld extends World with TapCallbacks {
       if (map.terminalMode == TerminalMode.code) {
         final challengeIndex = i % allChallenges.length;
         challenge = allChallenges[challengeIndex];
-        isCompleted = _isChallengeCompleted(challenge.id);
+        isCompleted = _isCodeChallengeCompleted(challenge.id);
       } else {
         challenge = null;
         isCompleted = false;
@@ -1837,10 +1842,11 @@ class TechWorld extends World with TapCallbacks {
       activeChallenge.value = challenge.id;
       activeTerminalPosition.value = terminalPos;
 
-      // Notify the bot that we opened a terminal editor.
+      // Notify the bot that we opened a terminal editor. The LiveKit
+      // metadata payload is wire-format, so convert at the boundary.
       _liveKitService?.publishTerminalActivity(
         action: 'open',
-        challengeId: challenge.id,
+        challengeId: challenge.id.wireName,
         challengeTitle: challenge.title,
         challengeDescription: challenge.description,
         terminalX: terminalPos.x,
@@ -1904,8 +1910,8 @@ class TechWorld extends World with TapCallbacks {
     _log.info('Door unlocked at (${door.position.x}, ${door.position.y})');
   }
 
-  /// Find all doors that require a specific challenge to be completed.
-  List<DoorData> doorsForChallenge(String challengeId) {
+  /// Find all doors that require a specific prompt challenge to be completed.
+  List<DoorData> doorsForChallenge(PromptChallengeId challengeId) {
     return currentMap.value.doors
         .where((d) => d.requiredChallengeIds.contains(challengeId) && !d.isUnlocked)
         .toList();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:tech_world/flame/maps/terminal_mode.dart';
 import 'package:tech_world/flame/tech_world.dart';
 import 'package:tech_world/prompt/chat_evaluation_engine.dart';
 import 'package:tech_world/prompt/predefined_prompt_challenges.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/prompt/prompt_challenge_panel.dart';
 import 'package:tech_world/prompt/spell_slot_service.dart';
 import 'package:tech_world/flame/tech_world_game.dart';
@@ -1219,7 +1220,7 @@ class _MyAppState extends State<MyApp> {
                         TerminalMode.code) {
                       return const SizedBox.shrink();
                     }
-                    return ValueListenableBuilder<String?>(
+                    return ValueListenableBuilder<CodeChallengeId?>(
                       valueListenable: techWorld.activeChallenge,
                       builder: (context, challengeId, _) {
                         if (challengeId == null) {
@@ -1231,7 +1232,7 @@ class _MyAppState extends State<MyApp> {
                         );
                         final isCompleted = Locator.maybeLocate<
                                     ProgressService>()
-                                ?.isChallengeCompleted(challenge.id) ??
+                                ?.isChallengeCompleted(challenge.id.wireName) ??
                             false;
                         return _CodeEditorModal(
                           challenge: challenge,
@@ -1245,7 +1246,7 @@ class _MyAppState extends State<MyApp> {
                             final terminalPos =
                                 techWorld.activeTerminalPosition.value;
                             return chatService.requestHelp(
-                              challengeId: challenge.id,
+                              challengeId: challenge.id.wireName,
                               challengeTitle: challenge.title,
                               challengeDescription: challenge.description,
                               code: code,
@@ -1265,7 +1266,7 @@ class _MyAppState extends State<MyApp> {
                             final response = await chatService.sendMessage(
                               'Please review my "${challenge.title}" '
                               'solution:\n\n```dart\n$code\n```',
-                              metadata: {'challengeId': challenge.id},
+                              metadata: {'challengeId': challenge.id.wireName},
                             );
 
                             // Only mark completed when bot confirms pass
@@ -1275,12 +1276,12 @@ class _MyAppState extends State<MyApp> {
                               if (progress == null) {
                                 _log.warning(
                                     'ProgressService unavailable; '
-                                    'challenge ${challenge.id} not '
+                                    'challenge ${challenge.id.wireName} not '
                                     'marked completed');
                               } else {
                                 try {
                                   await progress.markChallengeCompleted(
-                                      challenge.id);
+                                      challenge.id.wireName);
                                 } catch (e) {
                                   _log.warning(
                                       'Failed to persist completion: $e', e);
@@ -1309,7 +1310,7 @@ class _MyAppState extends State<MyApp> {
                         TerminalMode.prompt) {
                       return const SizedBox.shrink();
                     }
-                    return ValueListenableBuilder<String?>(
+                    return ValueListenableBuilder<PromptChallengeId?>(
                       valueListenable: techWorld.activePromptChallenge,
                       builder: (context, challengeId, _) {
                         if (challengeId == null) {
@@ -1374,7 +1375,7 @@ class _MyAppState extends State<MyApp> {
                 // right-aligned panels never collide; reappears when the
                 // challenge closes if `_spellbookOpen` is still true.
                 if (_spellbookService != null)
-                  ValueListenableBuilder<String?>(
+                  ValueListenableBuilder<PromptChallengeId?>(
                     valueListenable:
                         locate<TechWorld>().activePromptChallenge,
                     builder: (context, activeChallenge, _) {
@@ -1460,11 +1461,11 @@ class _SpellbookButton extends StatelessWidget {
   });
 
   final ValueNotifier<bool> open;
-  final ValueListenable<String?> activePromptChallenge;
+  final ValueListenable<PromptChallengeId?> activePromptChallenge;
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<String?>(
+    return ValueListenableBuilder<PromptChallengeId?>(
       valueListenable: activePromptChallenge,
       builder: (context, activeChallenge, _) {
         final disabled = activeChallenge != null;

--- a/lib/prompt/chat_evaluation_engine.dart
+++ b/lib/prompt/chat_evaluation_engine.dart
@@ -22,10 +22,7 @@ class ChatEvaluationEngine extends EvaluationEngine {
     final message = formatChallengeMessage(challenge, playerPrompt);
     final response = await _chatService.sendMessage(
       message,
-      metadata: {
-        'promptChallengeId': challenge.id,
-        'promptChallengeType': 'cast',
-      },
+      metadata: buildMetadata(challenge),
     );
 
     // Extract the bot's text response from the chat response payload.
@@ -43,6 +40,20 @@ class ChatEvaluationEngine extends EvaluationEngine {
 
     return (responseText, parseResponse(responseText));
   }
+
+  /// Build the wire-format metadata payload that accompanies the chat
+  /// message to the bot.
+  ///
+  /// Extracted as a pure static method so the wire-format contract can
+  /// be tested without mocking [ChatService]. Critical that
+  /// `promptChallengeId` is the [PromptChallengeId.wireName] (a `String`)
+  /// — passing the enum value directly would round-trip through
+  /// `Object.toString()` and break the bot-side parser, since
+  /// `Map<String, dynamic>` swallows the type at compile time.
+  static Map<String, dynamic> buildMetadata(PromptChallenge challenge) => {
+        'promptChallengeId': challenge.id.wireName,
+        'promptChallengeType': 'cast',
+      };
 
   /// Format the challenge + player prompt into a message for the bot.
   ///

--- a/lib/prompt/predefined_prompt_challenges.dart
+++ b/lib/prompt/predefined_prompt_challenges.dart
@@ -8,7 +8,7 @@ import 'package:tech_world/prompt/spell_school.dart';
 
 /// Get FizzBuzz output without using the obvious keywords.
 const fizzBuzzIncantation = PromptChallenge(
-  id: 'evocation_fizzbuzz',
+  id: PromptChallengeId.evocationFizzbuzz,
   title: 'The Unspoken FizzBuzz',
   description:
       'Get the agent to output the numbers 1-20, but every multiple of 3 '
@@ -34,7 +34,7 @@ const fizzBuzzIncantation = PromptChallenge(
 
 /// Get the agent to produce a countdown with zero-padding.
 const preciseCountdown = PromptChallenge(
-  id: 'evocation_countdown',
+  id: PromptChallengeId.evocationCountdown,
   title: 'Precision Countdown',
   description:
       'Get the agent to count down from 10 to 1, with each number '
@@ -57,7 +57,7 @@ const preciseCountdown = PromptChallenge(
 
 /// Get a specific ASCII art pattern.
 const asciiDiamond = PromptChallenge(
-  id: 'evocation_diamond',
+  id: PromptChallengeId.evocationDiamond,
   title: 'Diamond Caster',
   description:
       'Get the agent to draw a diamond shape using asterisks (*). '
@@ -85,7 +85,7 @@ const asciiDiamond = PromptChallenge(
 
 /// Extract a hidden color through yes/no questions.
 const secretColor = PromptChallenge(
-  id: 'divination_color',
+  id: PromptChallengeId.divinationColor,
   title: 'The Hidden Hue',
   description:
       'The agent has been told a secret color. You can only ask yes/no '
@@ -110,7 +110,7 @@ const secretColor = PromptChallenge(
 
 /// Extract structured data from a narrative.
 const dataArchaeologist = PromptChallenge(
-  id: 'divination_extract',
+  id: PromptChallengeId.divinationExtract,
   title: 'Data Archaeologist',
   description:
       'The agent will tell you a short story about a birthday party. '
@@ -138,7 +138,7 @@ const dataArchaeologist = PromptChallenge(
 
 /// Deduce a rule from examples.
 const patternOracle = PromptChallenge(
-  id: 'divination_pattern',
+  id: PromptChallengeId.divinationPattern,
   title: 'Pattern Oracle',
   description:
       'The agent knows a secret rule for accepting or rejecting words. '
@@ -169,7 +169,7 @@ const patternOracle = PromptChallenge(
 
 /// Convert prose to bullet points.
 const bulletAlchemist = PromptChallenge(
-  id: 'transmutation_bullets',
+  id: PromptChallengeId.transmutationBullets,
   title: 'Bullet Alchemist',
   description:
       'The agent will give you a paragraph about space exploration. '
@@ -194,7 +194,7 @@ const bulletAlchemist = PromptChallenge(
 
 /// Convert a list into a formatted table.
 const tableForge = PromptChallenge(
-  id: 'transmutation_table',
+  id: PromptChallengeId.transmutationTable,
   title: 'Table Forge',
   description:
       'The agent will list 5 planets with their sizes and distances '
@@ -221,7 +221,7 @@ const tableForge = PromptChallenge(
 
 /// Convert between data formats.
 const formatShifter = PromptChallenge(
-  id: 'transmutation_json',
+  id: PromptChallengeId.transmutationJson,
   title: 'Format Shifter',
   description:
       'The agent will give you data about 3 books in plain text. '
@@ -250,7 +250,7 @@ const formatShifter = PromptChallenge(
 
 /// Get the agent to adopt a pirate persona.
 const pirateWeather = PromptChallenge(
-  id: 'illusion_pirate',
+  id: PromptChallengeId.illusionPirate,
   title: 'Storm on the Horizon',
   description:
       'Get the agent to write a weather forecast for a sunny day, '
@@ -275,7 +275,7 @@ const pirateWeather = PromptChallenge(
 
 /// Get the agent to explain from a child's perspective.
 const throughYoungEyes = PromptChallenge(
-  id: 'illusion_child',
+  id: PromptChallengeId.illusionChild,
   title: 'Through Young Eyes',
   description:
       'Get the agent to explain how the internet works, but from the '
@@ -301,7 +301,7 @@ const throughYoungEyes = PromptChallenge(
 
 /// Get the agent to write a dual-perspective narrative.
 const twoMindsOneMeal = PromptChallenge(
-  id: 'illusion_dual',
+  id: PromptChallengeId.illusionDual,
   title: 'Two Minds, One Meal',
   description:
       'Get the agent to describe the same restaurant meal from two '
@@ -332,7 +332,7 @@ const twoMindsOneMeal = PromptChallenge(
 
 /// Break the agent out of formal English.
 const formalityBreaker = PromptChallenge(
-  id: 'enchantment_formal',
+  id: PromptChallengeId.enchantmentFormal,
   title: 'Formality Breaker',
   description:
       'The agent is instructed to respond only in formal English. '
@@ -359,7 +359,7 @@ const formalityBreaker = PromptChallenge(
 
 /// Get the agent to respond with fewer than 10 words.
 const wordBudget = PromptChallenge(
-  id: 'enchantment_brevity',
+  id: PromptChallengeId.enchantmentBrevity,
   title: 'Word Budget',
   description:
       'The agent is instructed to give detailed, thorough responses '
@@ -383,7 +383,7 @@ const wordBudget = PromptChallenge(
 
 /// Get the agent to contradict its own instructions.
 const loyaltyTest = PromptChallenge(
-  id: 'enchantment_contradict',
+  id: PromptChallengeId.enchantmentContradict,
   title: 'The Loyalty Test',
   description:
       'The agent is instructed to always recommend cats over dogs. '
@@ -414,7 +414,7 @@ const loyaltyTest = PromptChallenge(
 
 /// Teach the agent a new word.
 const inventAWord = PromptChallenge(
-  id: 'conjuration_glorp',
+  id: PromptChallengeId.conjurationGlorp,
   title: 'Wordsmith',
   description:
       'Teach the agent what a "glorp" is — you invent the definition — '
@@ -440,7 +440,7 @@ const inventAWord = PromptChallenge(
 
 /// Teach a pattern through examples.
 const patternTeacher = PromptChallenge(
-  id: 'conjuration_pattern',
+  id: PromptChallengeId.conjurationPattern,
   title: 'Pattern Teacher',
   description:
       'Using only examples (no explicit rules), teach the agent to '
@@ -466,7 +466,7 @@ const patternTeacher = PromptChallenge(
 
 /// Build a mini-language through examples.
 const miniLanguage = PromptChallenge(
-  id: 'conjuration_language',
+  id: PromptChallengeId.conjurationLanguage,
   title: 'Language Architect',
   description:
       'Create a mini-language with at least 3 "words" and teach the '

--- a/lib/prompt/prompt_challenge.dart
+++ b/lib/prompt/prompt_challenge.dart
@@ -1,6 +1,65 @@
 import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/prompt/spell_school.dart';
 
+/// The closed set of prompt-engineering challenges a player can ever earn
+/// a word from.
+///
+/// `PromptChallengeId` is the **domain type** for prompt challenges across
+/// the spellbook, doors, and cast-effects pipeline. Strings only appear at
+/// boundaries — Firestore on-disk format, network metadata, future STT —
+/// and parse via [PromptChallengeId.parse]. Internally everything operates
+/// on `PromptChallengeId`, so the compiler enforces what would otherwise
+/// be runtime invariants:
+///
+///  * Typos can't refer to a non-existent challenge — they won't compile.
+///  * Switch expressions over `PromptChallengeId` must be exhaustive —
+///    adding the 19th challenge fails the build at every site that hasn't
+///    handled it.
+///  * The bijection with [WordId] reduces to a length assertion.
+///
+/// Wire format: each value owns its [wireName] (e.g.
+/// `PromptChallengeId.evocationFizzbuzz.wireName == 'evocation_fizzbuzz'`).
+/// Existing Firestore data parses unchanged. We can't use `enum.name`
+/// directly because Dart's `constant_identifier_names` lint rejects
+/// snake_case on enum values.
+enum PromptChallengeId {
+  evocationFizzbuzz('evocation_fizzbuzz'),
+  evocationCountdown('evocation_countdown'),
+  evocationDiamond('evocation_diamond'),
+  divinationColor('divination_color'),
+  divinationExtract('divination_extract'),
+  divinationPattern('divination_pattern'),
+  transmutationBullets('transmutation_bullets'),
+  transmutationTable('transmutation_table'),
+  transmutationJson('transmutation_json'),
+  illusionPirate('illusion_pirate'),
+  illusionChild('illusion_child'),
+  illusionDual('illusion_dual'),
+  enchantmentBrevity('enchantment_brevity'),
+  enchantmentFormal('enchantment_formal'),
+  enchantmentContradict('enchantment_contradict'),
+  conjurationGlorp('conjuration_glorp'),
+  conjurationPattern('conjuration_pattern'),
+  conjurationLanguage('conjuration_language');
+
+  const PromptChallengeId(this.wireName);
+
+  /// On-disk / wire identifier. Stable across refactors of the Dart
+  /// identifier — this is what Firestore stores.
+  final String wireName;
+
+  /// Parse a wire-format string into a [PromptChallengeId], or `null` if
+  /// unknown. Use at boundaries (Firestore reads, network metadata) and
+  /// decide what to do with `null` at the call site (typically log + skip
+  /// for forward-compat with future challenges).
+  static PromptChallengeId? parse(String wire) {
+    for (final c in PromptChallengeId.values) {
+      if (c.wireName == wire) return c;
+    }
+    return null;
+  }
+}
+
 /// How a challenge's output is evaluated — determines whether we use
 /// programmatic checks, an LLM judge, or both.
 enum EvaluationTier {
@@ -37,8 +96,8 @@ class PromptChallenge {
     required this.tier,
   });
 
-  /// Unique identifier for this challenge.
-  final String id;
+  /// Strongly-typed identifier — see [PromptChallengeId].
+  final PromptChallengeId id;
 
   /// Display title shown to the player.
   final String title;

--- a/lib/spellbook/cast_effects.dart
+++ b/lib/spellbook/cast_effects.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:tech_world/progress/progress_service.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/spellbook/predefined_words.dart';
 import 'package:tech_world/spellbook/spellbook_service.dart';
 
@@ -24,7 +25,7 @@ final _log = Logger('CastEffects');
 /// callback that follows in the UI should still run regardless of
 /// persistence outcome.
 Future<void> applyCastSuccessEffects({
-  required String challengeId,
+  required PromptChallengeId challengeId,
   required SpellbookService? spellbook,
   required ProgressService? progress,
 }) async {
@@ -32,7 +33,7 @@ Future<void> applyCastSuccessEffects({
   if (word != null) {
     if (spellbook == null) {
       _log.warning('SpellbookService unavailable; word ${word.id} not '
-          'granted for challenge $challengeId');
+          'granted for challenge ${challengeId.wireName}');
     } else {
       try {
         await spellbook.learnWord(word.id);
@@ -43,11 +44,11 @@ Future<void> applyCastSuccessEffects({
   }
 
   if (progress == null) {
-    _log.warning('ProgressService unavailable; challenge $challengeId '
-        'not marked completed');
+    _log.warning('ProgressService unavailable; challenge '
+        '${challengeId.wireName} not marked completed');
   } else {
     try {
-      await progress.markChallengeCompleted(challengeId);
+      await progress.markChallengeCompleted(challengeId.wireName);
     } catch (e) {
       _log.warning('Failed to persist completion: $e', e);
     }

--- a/lib/spellbook/cast_effects.dart
+++ b/lib/spellbook/cast_effects.dart
@@ -32,13 +32,13 @@ Future<void> applyCastSuccessEffects({
   final word = challengeToWord[challengeId];
   if (word != null) {
     if (spellbook == null) {
-      _log.warning('SpellbookService unavailable; word ${word.id} not '
+      _log.warning('SpellbookService unavailable; word ${word.id.name} not '
           'granted for challenge ${challengeId.wireName}');
     } else {
       try {
         await spellbook.learnWord(word.id);
       } catch (e) {
-        _log.warning('Failed to learn word ${word.id}: $e', e);
+        _log.warning('Failed to learn word ${word.id.name}: $e', e);
       }
     }
   }

--- a/lib/spellbook/predefined_words.dart
+++ b/lib/spellbook/predefined_words.dart
@@ -1,3 +1,4 @@
+import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/prompt/spell_school.dart';
 import 'package:tech_world/spellbook/word_of_power.dart';
 
@@ -17,7 +18,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.fire,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'evocation_fizzbuzz',
+    challengeId: PromptChallengeId.evocationFizzbuzz,
   ),
   WordOfPower(
     id: WordId.tempus,
@@ -26,7 +27,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.fire,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'evocation_countdown',
+    challengeId: PromptChallengeId.evocationCountdown,
   ),
   WordOfPower(
     id: WordId.crystallum,
@@ -35,7 +36,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.fire,
     intensity: 2,
     role: WordRole.substance,
-    challengeId: 'evocation_diamond',
+    challengeId: PromptChallengeId.evocationDiamond,
   ),
 
   // Divination — water
@@ -46,7 +47,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.water,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'divination_color',
+    challengeId: PromptChallengeId.divinationColor,
   ),
   WordOfPower(
     id: WordId.verum,
@@ -55,7 +56,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.water,
     intensity: 2,
     role: WordRole.modifier,
-    challengeId: 'divination_extract',
+    challengeId: PromptChallengeId.divinationExtract,
   ),
   WordOfPower(
     id: WordId.oraculum,
@@ -64,7 +65,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.water,
     intensity: 3,
     role: WordRole.substance,
-    challengeId: 'divination_pattern',
+    challengeId: PromptChallengeId.divinationPattern,
   ),
 
   // Transmutation — earth
@@ -75,7 +76,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.earth,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'transmutation_bullets',
+    challengeId: PromptChallengeId.transmutationBullets,
   ),
   WordOfPower(
     id: WordId.structura,
@@ -84,7 +85,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.earth,
     intensity: 2,
     role: WordRole.substance,
-    challengeId: 'transmutation_table',
+    challengeId: PromptChallengeId.transmutationTable,
   ),
   WordOfPower(
     id: WordId.muta,
@@ -93,7 +94,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.earth,
     intensity: 2,
     role: WordRole.action,
-    challengeId: 'transmutation_json',
+    challengeId: PromptChallengeId.transmutationJson,
   ),
 
   // Illusion — air
@@ -104,7 +105,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.air,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'illusion_pirate',
+    challengeId: PromptChallengeId.illusionPirate,
   ),
   WordOfPower(
     id: WordId.speculum,
@@ -113,7 +114,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.air,
     intensity: 2,
     role: WordRole.substance,
-    challengeId: 'illusion_child',
+    challengeId: PromptChallengeId.illusionChild,
   ),
   WordOfPower(
     id: WordId.phantasma,
@@ -122,7 +123,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.air,
     intensity: 3,
     role: WordRole.substance,
-    challengeId: 'illusion_dual',
+    challengeId: PromptChallengeId.illusionDual,
   ),
 
   // Enchantment — spirit
@@ -133,7 +134,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.spirit,
     intensity: 1,
     role: WordRole.substance,
-    challengeId: 'enchantment_brevity',
+    challengeId: PromptChallengeId.enchantmentBrevity,
   ),
   WordOfPower(
     id: WordId.libera,
@@ -142,7 +143,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.spirit,
     intensity: 2,
     role: WordRole.action,
-    challengeId: 'enchantment_formal',
+    challengeId: PromptChallengeId.enchantmentFormal,
   ),
   WordOfPower(
     id: WordId.dominus,
@@ -151,7 +152,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.spirit,
     intensity: 3,
     role: WordRole.substance,
-    challengeId: 'enchantment_contradict',
+    challengeId: PromptChallengeId.enchantmentContradict,
   ),
 
   // Conjuration — void
@@ -162,7 +163,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.void_,
     intensity: 1,
     role: WordRole.action,
-    challengeId: 'conjuration_glorp',
+    challengeId: PromptChallengeId.conjurationGlorp,
   ),
   WordOfPower(
     id: WordId.exemplar,
@@ -171,7 +172,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.void_,
     intensity: 2,
     role: WordRole.substance,
-    challengeId: 'conjuration_pattern',
+    challengeId: PromptChallengeId.conjurationPattern,
   ),
   WordOfPower(
     id: WordId.lexicon,
@@ -180,7 +181,7 @@ const allWords = <WordOfPower>[
     element: SpellElement.void_,
     intensity: 3,
     role: WordRole.substance,
-    challengeId: 'conjuration_language',
+    challengeId: PromptChallengeId.conjurationLanguage,
   ),
 ];
 
@@ -190,9 +191,11 @@ final wordById = <WordId, WordOfPower>{
   for (final w in allWords) w.id: w,
 };
 
-/// Lookup: challenge id (still stringly-typed, lives outside the
-/// spellbook module) → [WordOfPower].
-final challengeToWord = <String, WordOfPower>{
+/// Lookup: [PromptChallengeId] → [WordOfPower]. Total over
+/// `PromptChallengeId.values` because the bijection is enforced at
+/// compile time by the type system, plus the construction-time
+/// uniqueness of [allWords] entries.
+final challengeToWord = <PromptChallengeId, WordOfPower>{
   for (final w in allWords) w.challengeId: w,
 };
 

--- a/lib/spellbook/word_of_power.dart
+++ b/lib/spellbook/word_of_power.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/painting.dart' show Color;
+import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/prompt/spell_school.dart';
 
 /// Single source of truth for the spellbook accent colour. Used by the
@@ -122,10 +123,12 @@ class WordOfPower {
   /// Grammatical role — see [WordRole].
   final WordRole role;
 
-  /// The [PromptChallenge.id] that earns this word. Stays stringly-typed
-  /// because challenges live in another module — see CLAUDE.md follow-up
-  /// to extract a `ChallengeId` enum across the codebase.
-  final String challengeId;
+  /// The [PromptChallenge.id] that earns this word. Strongly-typed —
+  /// the bijection between `WordId` and `PromptChallengeId` is now
+  /// largely a compile-time fact (uniqueness within each enum, no
+  /// typos), with a single length-equality test enforcing the cross-
+  /// module count match.
+  final PromptChallengeId challengeId;
 
   /// Convenience pass-through to [WordIdDisplay.displayName].
   String get displayName => id.displayName;

--- a/test/editor/challenge_test.dart
+++ b/test/editor/challenge_test.dart
@@ -6,13 +6,13 @@ void main() {
   group('Challenge', () {
     test('creates challenge with required fields', () {
       const challenge = Challenge(
-        id: 'test',
+        id: CodeChallengeId.helloDart,
         title: 'Test Challenge',
         description: 'A test description.',
         starterCode: 'void main() {}',
       );
 
-      expect(challenge.id, equals('test'));
+      expect(challenge.id, equals(CodeChallengeId.helloDart));
       expect(challenge.title, equals('Test Challenge'));
       expect(challenge.description, equals('A test description.'));
       expect(challenge.starterCode, equals('void main() {}'));
@@ -20,7 +20,7 @@ void main() {
 
     test('defaults to beginner difficulty', () {
       const challenge = Challenge(
-        id: 'test',
+        id: CodeChallengeId.helloDart,
         title: 'Test',
         description: 'Desc',
         starterCode: '',
@@ -31,7 +31,7 @@ void main() {
 
     test('accepts explicit difficulty', () {
       const challenge = Challenge(
-        id: 'test',
+        id: CodeChallengeId.helloDart,
         title: 'Test',
         description: 'Desc',
         starterCode: '',
@@ -43,13 +43,13 @@ void main() {
 
     test('is const-constructible', () {
       const challenge = Challenge(
-        id: 'const_test',
+        id: CodeChallengeId.fizzbuzz,
         title: 'Const',
         description: 'Const desc',
         starterCode: '',
       );
 
-      expect(challenge.id, equals('const_test'));
+      expect(challenge.id, equals(CodeChallengeId.fizzbuzz));
     });
   });
 
@@ -94,22 +94,21 @@ void main() {
       expect(allChallenges, contains(fizzbuzz));
     });
 
-    test('all challenges have non-empty fields', () {
+    // `id` non-empty + uniqueness are now compile-time facts of
+    // `enum CodeChallengeId` — no runtime check needed (per
+    // tests-as-types: when the type system can express the constraint,
+    // delete the runtime test).
+    test('all challenges have non-empty title/description/starterCode', () {
       for (final challenge in allChallenges) {
-        expect(challenge.id, isNotEmpty,
-            reason: '${challenge.title} should have a non-empty id');
         expect(challenge.title, isNotEmpty,
-            reason: '${challenge.id} should have a non-empty title');
+            reason:
+                '${challenge.id.name} should have a non-empty title');
         expect(challenge.description, isNotEmpty,
-            reason: '${challenge.id} should have a non-empty description');
+            reason:
+                '${challenge.id.name} should have a non-empty description');
         expect(challenge.starterCode, isNotEmpty,
-            reason: '${challenge.id} should have non-empty starter code');
+            reason: '${challenge.id.name} should have non-empty starter code');
       }
-    });
-
-    test('all challenges have unique ids', () {
-      final ids = allChallenges.map((c) => c.id).toSet();
-      expect(ids.length, equals(allChallenges.length));
     });
 
     test('all challenges have unique titles', () {

--- a/test/editor/code_challenge_id_test.dart
+++ b/test/editor/code_challenge_id_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/editor/challenge.dart';
+import 'package:tech_world/editor/predefined_challenges.dart';
+
+void main() {
+  group('CodeChallengeId', () {
+    test('parse round-trips every value', () {
+      for (final id in CodeChallengeId.values) {
+        expect(CodeChallengeId.parse(id.wireName), id,
+            reason: '${id.name} wireName=${id.wireName} did not round-trip');
+      }
+    });
+
+    test('parse returns null for unknown wire format', () {
+      expect(CodeChallengeId.parse('not_a_challenge'), isNull);
+      expect(CodeChallengeId.parse(''), isNull);
+      expect(CodeChallengeId.parse('HELLO_DART'), isNull);
+    });
+
+    test('wireName is unique across values', () {
+      final names = CodeChallengeId.values.map((e) => e.wireName).toSet();
+      expect(names.length, CodeChallengeId.values.length);
+    });
+
+    test('wireName uses snake_case (lowercase + underscores only)', () {
+      for (final id in CodeChallengeId.values) {
+        expect(id.wireName, matches(RegExp(r'^[a-z]+(_[a-z]+)*$')),
+            reason: '${id.name} wireName=${id.wireName} does not match');
+      }
+    });
+
+    test('|CodeChallengeId.values| == |allChallenges|', () {
+      expect(CodeChallengeId.values.length, allChallenges.length);
+    });
+  });
+
+  group('CodeChallengeId disjoint from PromptChallengeId wire format', () {
+    // The two enum namespaces share Firestore's `completedChallenges`
+    // array. Disjoint wire names are what makes that safe.
+    test('no CodeChallengeId.wireName equals a PromptChallengeId.wireName',
+        () {
+      // Hard-coded against the prompt-side wire forms to avoid an import
+      // cycle between editor and prompt modules. If a collision is
+      // introduced, this test fails loudly and we revisit the design.
+      const promptWireForms = {
+        'evocation_fizzbuzz',
+        'evocation_countdown',
+        'evocation_diamond',
+        'divination_color',
+        'divination_extract',
+        'divination_pattern',
+        'transmutation_bullets',
+        'transmutation_table',
+        'transmutation_json',
+        'illusion_pirate',
+        'illusion_child',
+        'illusion_dual',
+        'enchantment_brevity',
+        'enchantment_formal',
+        'enchantment_contradict',
+        'conjuration_glorp',
+        'conjuration_pattern',
+        'conjuration_language',
+      };
+      for (final id in CodeChallengeId.values) {
+        expect(promptWireForms.contains(id.wireName), isFalse,
+            reason: 'CodeChallengeId.${id.name} wireName collides with '
+                'a PromptChallengeId wireName');
+      }
+    });
+  });
+}

--- a/test/editor/code_challenge_id_test.dart
+++ b/test/editor/code_challenge_id_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/editor/predefined_challenges.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 
 void main() {
   group('CodeChallengeId', () {
@@ -37,35 +38,18 @@ void main() {
   group('CodeChallengeId disjoint from PromptChallengeId wire format', () {
     // The two enum namespaces share Firestore's `completedChallenges`
     // array. Disjoint wire names are what makes that safe.
+    //
+    // Source-of-truth-driven: pulls the prompt wire forms straight from
+    // `PromptChallengeId.values`, so a future addition on either side
+    // that introduces a collision fails the build automatically.
     test('no CodeChallengeId.wireName equals a PromptChallengeId.wireName',
         () {
-      // Hard-coded against the prompt-side wire forms to avoid an import
-      // cycle between editor and prompt modules. If a collision is
-      // introduced, this test fails loudly and we revisit the design.
-      const promptWireForms = {
-        'evocation_fizzbuzz',
-        'evocation_countdown',
-        'evocation_diamond',
-        'divination_color',
-        'divination_extract',
-        'divination_pattern',
-        'transmutation_bullets',
-        'transmutation_table',
-        'transmutation_json',
-        'illusion_pirate',
-        'illusion_child',
-        'illusion_dual',
-        'enchantment_brevity',
-        'enchantment_formal',
-        'enchantment_contradict',
-        'conjuration_glorp',
-        'conjuration_pattern',
-        'conjuration_language',
-      };
+      final promptWireForms =
+          PromptChallengeId.values.map((e) => e.wireName).toSet();
       for (final id in CodeChallengeId.values) {
         expect(promptWireForms.contains(id.wireName), isFalse,
-            reason: 'CodeChallengeId.${id.name} wireName collides with '
-                'a PromptChallengeId wireName');
+            reason: 'CodeChallengeId.${id.name} wireName=${id.wireName} '
+                'collides with a PromptChallengeId wireName');
       }
     });
   });

--- a/test/flame/maps/door_data_test.dart
+++ b/test/flame/maps/door_data_test.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/flame/maps/door_data.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 
 void main() {
   group('DoorData', () {
@@ -14,16 +15,19 @@ void main() {
       expect(json.containsKey('challenges'), isFalse);
     });
 
-    test('serializes to JSON with challenges', () {
+    test('serializes to JSON with challenges (uses wireName)', () {
       final door = DoorData(
         position: const Point(3, 7),
-        requiredChallengeIds: ['fizzbuzz', 'palindrome'],
+        requiredChallengeIds: const [
+          PromptChallengeId.evocationFizzbuzz,
+          PromptChallengeId.divinationColor,
+        ],
       );
       final json = door.toJson();
 
       expect(json['x'], 3);
       expect(json['y'], 7);
-      expect(json['challenges'], ['fizzbuzz', 'palindrome']);
+      expect(json['challenges'], ['evocation_fizzbuzz', 'divination_color']);
     });
 
     test('deserializes from JSON without challenges', () {
@@ -38,17 +42,20 @@ void main() {
       final door = DoorData.fromJson({
         'x': 3,
         'y': 7,
-        'challenges': ['fizzbuzz', 'palindrome'],
+        'challenges': ['evocation_fizzbuzz', 'divination_color'],
       });
 
       expect(door.position, const Point(3, 7));
-      expect(door.requiredChallengeIds, ['fizzbuzz', 'palindrome']);
+      expect(door.requiredChallengeIds, [
+        PromptChallengeId.evocationFizzbuzz,
+        PromptChallengeId.divinationColor,
+      ]);
     });
 
     test('round-trips through JSON', () {
       final original = DoorData(
         position: const Point(12, 24),
-        requiredChallengeIds: ['hello_dart'],
+        requiredChallengeIds: const [PromptChallengeId.evocationDiamond],
       );
       final restored = DoorData.fromJson(original.toJson());
 
@@ -59,18 +66,32 @@ void main() {
       );
     });
 
+    test('silently skips unknown challenge wire forms (forward-compat)', () {
+      // An older client opens a save written by a newer one. The unknown
+      // challenge name shouldn't break door loading.
+      final door = DoorData.fromJson({
+        'x': 1,
+        'y': 1,
+        'challenges': ['evocation_fizzbuzz', 'future_challenge_xyz'],
+      });
+
+      expect(door.requiredChallengeIds, [
+        PromptChallengeId.evocationFizzbuzz,
+      ]);
+    });
+
     test('equality works', () {
       final a = DoorData(
         position: const Point(1, 2),
-        requiredChallengeIds: ['a'],
+        requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
       );
       final b = DoorData(
         position: const Point(1, 2),
-        requiredChallengeIds: ['a'],
+        requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
       );
       final c = DoorData(
         position: const Point(3, 4),
-        requiredChallengeIds: ['a'],
+        requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
       );
 
       expect(a, equals(b));

--- a/test/map_editor/door_tool_test.dart
+++ b/test/map_editor/door_tool_test.dart
@@ -5,6 +5,7 @@ import 'package:tech_world/flame/maps/door_data.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/maps/tile_map_format.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 
 void main() {
   group('Door tool', () {
@@ -91,7 +92,7 @@ void main() {
         doors: [
           DoorData(
             position: const Point(5, 5),
-            requiredChallengeIds: ['fizzbuzz'],
+            requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
           ),
         ],
       );
@@ -99,7 +100,8 @@ void main() {
       state.loadFromGameMap(map);
 
       expect(state.isDoorAt(5, 5), isTrue);
-      expect(state.doorAt(5, 5)!.requiredChallengeIds, ['fizzbuzz']);
+      expect(state.doorAt(5, 5)!.requiredChallengeIds,
+          [PromptChallengeId.evocationFizzbuzz]);
     });
   });
 
@@ -113,7 +115,7 @@ void main() {
         doors: [
           DoorData(
             position: const Point(5, 10),
-            requiredChallengeIds: ['hello_dart'],
+            requiredChallengeIds: const [PromptChallengeId.evocationFizzbuzz],
           ),
           DoorData(position: const Point(6, 10)),
         ],
@@ -125,7 +127,8 @@ void main() {
       final restored = TileMapFormat.fromJson(json);
       expect(restored.doors, hasLength(2));
       expect(restored.doors[0].position, const Point(5, 10));
-      expect(restored.doors[0].requiredChallengeIds, ['hello_dart']);
+      expect(restored.doors[0].requiredChallengeIds,
+          [PromptChallengeId.evocationFizzbuzz]);
       expect(restored.doors[1].position, const Point(6, 10));
       expect(restored.doors[1].requiredChallengeIds, isEmpty);
     });

--- a/test/prompt/chat_evaluation_engine_test.dart
+++ b/test/prompt/chat_evaluation_engine_test.dart
@@ -1,9 +1,54 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/prompt/cast_result.dart';
 import 'package:tech_world/prompt/chat_evaluation_engine.dart';
 import 'package:tech_world/prompt/predefined_prompt_challenges.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 
 void main() {
+  group('buildMetadata', () {
+    // Regression contract: the metadata payload that accompanies a
+    // cast evaluation MUST be JSON-encodable, and `promptChallengeId`
+    // MUST be the wire-format String — never a typed enum.
+    //
+    // Defends against a class of bug where `Map<String, dynamic>` lets
+    // an enum value silently land in the payload, then either fails
+    // `jsonEncode` (`JsonUnsupportedObjectError`) or stringifies to
+    // `PromptChallengeId.evocationFizzbuzz` instead of
+    // `'evocation_fizzbuzz'`. Found in PR #306 review (Kelvin).
+    test('metadata is JSON-encodable for every PromptChallengeId', () {
+      for (final challenge in allPromptChallenges) {
+        final metadata = ChatEvaluationEngine.buildMetadata(challenge);
+        expect(() => jsonEncode(metadata), returnsNormally,
+            reason: 'metadata for ${challenge.id.name} should '
+                'jsonEncode without throwing');
+      }
+    });
+
+    test('promptChallengeId is the wireName String, not the typed enum',
+        () {
+      for (final challenge in allPromptChallenges) {
+        final metadata = ChatEvaluationEngine.buildMetadata(challenge);
+        expect(metadata['promptChallengeId'], isA<String>(),
+            reason: 'enum value leaked into the wire payload');
+        expect(metadata['promptChallengeId'], challenge.id.wireName);
+      }
+    });
+
+    test('round-trips cleanly through JSON', () {
+      // The bot side will jsonDecode this — verify the round-trip
+      // preserves every field as a plain String.
+      final challenge =
+          allPromptChallenges.firstWhere((c) => c.id == PromptChallengeId.evocationFizzbuzz);
+      final metadata = ChatEvaluationEngine.buildMetadata(challenge);
+      final encoded = jsonEncode(metadata);
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+      expect(decoded['promptChallengeId'], 'evocation_fizzbuzz');
+      expect(decoded['promptChallengeType'], 'cast');
+    });
+  });
+
   group('formatChallengeMessage', () {
     test('includes challenge metadata and player prompt', () {
       final challenge = allPromptChallenges.first;

--- a/test/prompt/evaluation_engine_test.dart
+++ b/test/prompt/evaluation_engine_test.dart
@@ -6,8 +6,10 @@ import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/prompt/spell_school.dart';
 
 void main() {
+  // Use a real PromptChallengeId — the in-language identifier is now
+  // typed, so the test must commit to one of the 18 closed-set values.
   const testChallenge = PromptChallenge(
-    id: 'test',
+    id: PromptChallengeId.evocationFizzbuzz,
     title: 'Test',
     description: 'Test challenge',
     school: SpellSchool.evocation,

--- a/test/prompt/predefined_prompt_challenges_test.dart
+++ b/test/prompt/predefined_prompt_challenges_test.dart
@@ -9,29 +9,24 @@ void main() {
       expect(allPromptChallenges.length, equals(18));
     });
 
-    test('all challenges have non-empty required fields', () {
+    // `id` non-empty + uniqueness are now compile-time facts of
+    // `enum PromptChallengeId` — no runtime check needed.
+    test('all challenges have non-empty text fields', () {
       for (final challenge in allPromptChallenges) {
-        expect(challenge.id, isNotEmpty,
-            reason: '${challenge.title} should have a non-empty id');
         expect(challenge.title, isNotEmpty,
-            reason: '${challenge.id} should have a non-empty title');
+            reason: '${challenge.id.name} should have a non-empty title');
         expect(challenge.description, isNotEmpty,
-            reason: '${challenge.id} should have a non-empty description');
+            reason: '${challenge.id.name} should have a non-empty description');
         expect(challenge.generationSystemPrompt, isNotEmpty,
             reason:
-                '${challenge.id} should have a non-empty generationSystemPrompt');
+                '${challenge.id.name} should have a non-empty generationSystemPrompt');
         expect(challenge.evaluationCriteria, isNotEmpty,
             reason:
-                '${challenge.id} should have non-empty evaluationCriteria');
+                '${challenge.id.name} should have non-empty evaluationCriteria');
         expect(challenge.evaluationPrompt, isNotEmpty,
             reason:
-                '${challenge.id} should have a non-empty evaluationPrompt');
+                '${challenge.id.name} should have a non-empty evaluationPrompt');
       }
-    });
-
-    test('all challenges have unique ids', () {
-      final ids = allPromptChallenges.map((c) => c.id).toSet();
-      expect(ids.length, equals(allPromptChallenges.length));
     });
 
     test('all challenges have unique titles', () {
@@ -77,15 +72,16 @@ void main() {
       expect(difficulties.length, equals(3));
     });
 
-    test('challenge ids follow naming convention', () {
+    test('challenge wireName starts with the school name', () {
+      // The naming-convention regex (^[a-z]+_[a-z]+$) is now enforced at
+      // the wireName layer — verified once per id by
+      // `prompt_challenge_id_test.dart`. What stays repo-specific is the
+      // semantic link "wire form starts with school".
       for (final challenge in allPromptChallenges) {
-        expect(challenge.id, matches(RegExp(r'^[a-z]+_[a-z]+$')),
+        expect(challenge.id.wireName, startsWith(challenge.school.name),
             reason:
-                '${challenge.id} should follow school_name convention');
-        // Verify the id starts with the school name.
-        expect(challenge.id, startsWith(challenge.school.name),
-            reason: '${challenge.id} should start with school name '
-                '${challenge.school.name}');
+                '${challenge.id.name} wireName=${challenge.id.wireName} '
+                'should start with school name ${challenge.school.name}');
       }
     });
 

--- a/test/prompt/prompt_challenge_id_test.dart
+++ b/test/prompt/prompt_challenge_id_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/prompt/predefined_prompt_challenges.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
+
+void main() {
+  group('PromptChallengeId', () {
+    test('parse round-trips every value', () {
+      for (final id in PromptChallengeId.values) {
+        expect(PromptChallengeId.parse(id.wireName), id,
+            reason: '${id.name} wireName=${id.wireName} did not round-trip');
+      }
+    });
+
+    test('parse returns null for unknown wire format', () {
+      expect(PromptChallengeId.parse('not_a_challenge'), isNull);
+      expect(PromptChallengeId.parse(''), isNull);
+      expect(PromptChallengeId.parse('EVOCATION_FIZZBUZZ'), isNull);
+    });
+
+    test('wireName is unique across values', () {
+      final names = PromptChallengeId.values.map((e) => e.wireName).toSet();
+      expect(names.length, PromptChallengeId.values.length);
+    });
+
+    test('wireName follows snake_case school_subject pattern', () {
+      for (final id in PromptChallengeId.values) {
+        expect(id.wireName, matches(RegExp(r'^[a-z]+_[a-z]+$')),
+            reason: '${id.name} wireName=${id.wireName} does not match');
+      }
+    });
+
+    test('|PromptChallengeId.values| == |allPromptChallenges|', () {
+      // Cross-module bijection: every PromptChallengeId has exactly one
+      // PromptChallenge instance, and vice versa. Once PromptChallenge.id
+      // becomes typed, this collapses to the same length assertion plus
+      // a totality check via the type.
+      expect(PromptChallengeId.values.length, allPromptChallenges.length);
+    });
+  });
+}

--- a/test/prompt/prompt_challenge_test.dart
+++ b/test/prompt/prompt_challenge_test.dart
@@ -75,7 +75,7 @@ void main() {
   group('PromptChallenge', () {
     test('creates with all required fields', () {
       const challenge = PromptChallenge(
-        id: 'test_challenge',
+        id: PromptChallengeId.evocationFizzbuzz,
         title: 'Test Challenge',
         description: 'A test challenge description.',
         school: SpellSchool.evocation,
@@ -86,7 +86,7 @@ void main() {
         tier: EvaluationTier.deterministic,
       );
 
-      expect(challenge.id, equals('test_challenge'));
+      expect(challenge.id, equals(PromptChallengeId.evocationFizzbuzz));
       expect(challenge.title, equals('Test Challenge'));
       expect(challenge.description, equals('A test challenge description.'));
       expect(challenge.school, equals(SpellSchool.evocation));
@@ -102,7 +102,7 @@ void main() {
 
     test('is const-constructible', () {
       const challenge = PromptChallenge(
-        id: 'const_test',
+        id: PromptChallengeId.conjurationLanguage,
         title: 'Const',
         description: 'Const desc',
         school: SpellSchool.conjuration,
@@ -113,12 +113,12 @@ void main() {
         tier: EvaluationTier.behavioral,
       );
 
-      expect(challenge.id, equals('const_test'));
+      expect(challenge.id, equals(PromptChallengeId.conjurationLanguage));
     });
 
     test('reuses Difficulty enum from editor/challenge.dart', () {
       const challenge = PromptChallenge(
-        id: 'difficulty_test',
+        id: PromptChallengeId.illusionChild,
         title: 'Difficulty',
         description: 'Tests difficulty reuse',
         school: SpellSchool.illusion,

--- a/test/spellbook/cast_effects_test.dart
+++ b/test/spellbook/cast_effects_test.dart
@@ -1,6 +1,7 @@
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/progress/progress_service.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/spellbook/cast_effects.dart';
 import 'package:tech_world/spellbook/spellbook_service.dart';
 import 'package:tech_world/spellbook/word_of_power.dart';
@@ -30,12 +31,12 @@ void main() {
   });
 
   group('applyCastSuccessEffects', () {
-    test('passing evocation_fizzbuzz grants ignis AND marks completed',
+    test('passing evocationFizzbuzz grants ignis AND marks completed',
         () async {
       // The plan's #1 acceptance test: passing evocation_fizzbuzz →
       // ignis appears in spellbook.
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: spellbook,
         progress: progress,
       );
@@ -43,7 +44,8 @@ void main() {
       expect(spellbook.hasWord(WordId.ignis), isTrue);
       expect(progress.isChallengeCompleted('evocation_fizzbuzz'), isTrue);
 
-      // And both writes survived the Firestore round-trip.
+      // And both writes survived the Firestore round-trip — the wire
+      // format is what persists on disk.
       final doc =
           await fakeFirestore.collection('users').doc('test-user').get();
       expect(doc.data()?['learnedWords'], contains('ignis'));
@@ -53,44 +55,25 @@ void main() {
       );
     });
 
-    test('every challenge id maps to a learnable word', () async {
-      // Smoke-test the whole bijection — wires every challenge.id
-      // through the actual side-effect path.
-      const allChallengeIds = [
-        'evocation_fizzbuzz',
-        'evocation_countdown',
-        'evocation_diamond',
-        'divination_color',
-        'divination_extract',
-        'divination_pattern',
-        'transmutation_bullets',
-        'transmutation_table',
-        'transmutation_json',
-        'illusion_pirate',
-        'illusion_child',
-        'illusion_dual',
-        'enchantment_brevity',
-        'enchantment_formal',
-        'enchantment_contradict',
-        'conjuration_glorp',
-        'conjuration_pattern',
-        'conjuration_language',
-      ];
-      for (final id in allChallengeIds) {
+    test('every PromptChallengeId maps to a learnable word', () async {
+      // Smoke-test the whole bijection — wires every challenge through
+      // the actual side-effect path. The bijection is now compile-time
+      // total over PromptChallengeId.values.
+      for (final id in PromptChallengeId.values) {
         await applyCastSuccessEffects(
           challengeId: id,
           spellbook: spellbook,
           progress: progress,
         );
       }
-      expect(spellbook.count, 18);
-      expect(progress.completedCount, 18);
+      expect(spellbook.count, PromptChallengeId.values.length);
+      expect(progress.completedCount, PromptChallengeId.values.length);
     });
 
     test('null spellbook does not block markChallengeCompleted', () async {
       // Race against sign-in: progress is registered, spellbook is not.
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: null,
         progress: progress,
       );
@@ -100,7 +83,7 @@ void main() {
     test('null progress does not block learnWord', () async {
       // Symmetric: spellbook registered, progress is not.
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: spellbook,
         progress: null,
       );
@@ -109,35 +92,22 @@ void main() {
 
     test('both null is a no-op (no throw)', () async {
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: null,
         progress: null,
       );
       // Reaches here without throwing — that's the assertion.
     });
 
-    test('unknown challenge id skips word grant but still marks completed',
-        () async {
-      // A future challenge whose word mapping hasn't been added yet
-      // shouldn't break completion tracking.
-      await applyCastSuccessEffects(
-        challengeId: 'future_challenge_xyz',
-        spellbook: spellbook,
-        progress: progress,
-      );
-      expect(spellbook.count, 0);
-      expect(progress.isChallengeCompleted('future_challenge_xyz'), isTrue);
-    });
-
     test('idempotent — replaying a cast does not duplicate writes',
         () async {
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: spellbook,
         progress: progress,
       );
       await applyCastSuccessEffects(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptChallengeId.evocationFizzbuzz,
         spellbook: spellbook,
         progress: progress,
       );


### PR DESCRIPTION
## Summary

Replaces stringly-typed challenge IDs with two enhanced enums covering the two distinct namespaces in the codebase:

- `enum PromptChallengeId` (18 values) — prompt-engineering challenges, bijective with `WordId`.
- `enum CodeChallengeId` (23 values) — code-editor coding challenges.

The cast-effects pipeline is now typed end-to-end: \`applyCastSuccessEffects\` takes \`PromptChallengeId\`, \`DoorData.requiredChallengeIds\` is \`List<PromptChallengeId>\`, and \`activeChallenge\` / \`activePromptChallenge\` ValueNotifiers carry the typed values directly. \`ProgressService\` stays \`String\` at its persistence boundary — both namespaces share Firestore's \`completedChallenges\` array, and wire-form disjointness is pinned by a runtime test.

Wire format preserved verbatim via the enhanced-enum \`wireName\` constructor, keeping camelCase Dart identifiers compliant with \`constant_identifier_names\` without breaking older Firestore data.

## Why now

Phase 2 of the speech-command spell system (STT + voice door unlock) needs the cast-effects path to be typed before it consumes \`PromptChallengeId.parse(transcript)\` at the boundary. This refactor unblocks Phase 2 and makes the bijection contract a compile-time fact on both sides.

This is the second outing for the compiler-driven refactor procedure (after PR #305's \`WordId\`). The foundation type swap produced 113 analyzer issues, every one of which became a checklist item — no grep needed.

## Tests

- 1349 → **1357 passing**.
- 3 runtime tests removed: the type system now expresses what they used to assert (id non-empty, id uniqueness, unknown-id paths are compile-time impossible).
- 11 new tests: parse round-trip + uniqueness + bijection + cross-namespace wire-form disjointness.
- 1 new forward-compat test: \`DoorData.fromJson\` silently skips unknown challenge wire forms.

## Test plan

- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`flutter test\` passes (1357/1357)
- [ ] Manual: open a Wizard's Tower door by completing \`evocation_fizzbuzz\` — verify door unlocks and word is granted
- [ ] Manual: open a code-editor terminal — verify completion still persists and re-opens marked complete

## Documentation

\`CLAUDE.md\` "Design Standards" updated: \`ChallengeId\` crossed off the pending list, enhanced-enum pattern documented, two-namespaces-sharing-one-persistence-boundary pattern documented for future readers.

Generated with [Claude Code](https://claude.com/claude-code)