### PR TITLE
Prevent unknown OpLayer from crashing CRDT sync loop

### DIFF
--- a/lib/map_editor/crdt/cell_version_map.dart
+++ b/lib/map_editor/crdt/cell_version_map.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:tech_world/map_editor/crdt/map_edit_op.dart';
 
 /// Last-Writer-Wins conflict resolution for the map editor CRDT.
@@ -68,13 +69,24 @@ class CellVersionMap {
   }
 
   /// Deserialize versions from sync protocol.
+  ///
+  /// Entries whose layer name is unrecognized (e.g. from a newer protocol
+  /// version) are silently skipped with a debug log, so that older clients
+  /// remain functional after a protocol upgrade.
   void loadFromJson(Map<String, dynamic> json) {
     _versions.clear();
     for (final entry in json.entries) {
       final parts = entry.key.split(',');
       final x = int.parse(parts[0]);
       final y = int.parse(parts[1]);
-      final layer = OpLayer.values.byName(parts[2]);
+      final layer = OpLayer.tryParse(parts[2]);
+      if (layer == null) {
+        debugPrint(
+          'CellVersionMap.loadFromJson: skipping entry with unknown '
+          'layer "${parts[2]}"',
+        );
+        continue;
+      }
       final value = entry.value as List<dynamic>;
       _versions[(x, y, layer)] = (value[0] as int, value[1] as String);
     }

--- a/lib/map_editor/crdt/map_edit_op.dart
+++ b/lib/map_editor/crdt/map_edit_op.dart
@@ -1,7 +1,25 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:tech_world/flame/tiles/tile_ref.dart';
 
 /// Which layer a map edit operation targets.
-enum OpLayer { structure, floor, objects, terrain, walls }
+enum OpLayer {
+  structure,
+  floor,
+  objects,
+  terrain,
+  walls;
+
+  /// Returns the matching [OpLayer], or `null` if [name] is unrecognized.
+  ///
+  /// Use this at protocol boundaries instead of [EnumByName.byName] to avoid
+  /// crashing when a future protocol version introduces a new layer value.
+  static OpLayer? tryParse(String name) {
+    for (final layer in values) {
+      if (layer.name == name) return layer;
+    }
+    return null;
+  }
+}
 
 /// A single cell edit in the map editor CRDT.
 ///
@@ -53,16 +71,27 @@ class MapEditOp {
   }
 
   /// Deserialize from JSON (as sent over data channel).
-  factory MapEditOp.fromJson(Map<String, dynamic> json, {
+  ///
+  /// Returns `null` if the `layer` field names an unrecognized layer (e.g. one
+  /// introduced by a newer protocol version). Callers should skip null results
+  /// rather than crashing, so that old clients remain functional after a
+  /// protocol upgrade.
+  static MapEditOp? fromJson(Map<String, dynamic> json, {
     required String playerId,
     required int counter,
   }) {
+    final layerName = json['layer'] as String;
+    final layer = OpLayer.tryParse(layerName);
+    if (layer == null) {
+      debugPrint('MapEditOp.fromJson: skipping op with unknown layer "$layerName"');
+      return null;
+    }
     return MapEditOp(
       playerId: playerId,
       counter: counter,
       x: json['x'] as int,
       y: json['y'] as int,
-      layer: OpLayer.values.byName(json['layer'] as String),
+      layer: layer,
       oldValue: json['old'],
       newValue: json['new'],
     );
@@ -129,6 +158,10 @@ class MapEditBatch {
   }
 
   /// Deserialize from a JSON map (data channel format).
+  ///
+  /// Ops with unrecognized layer names are silently skipped (see
+  /// [MapEditOp.fromJson]), so a batch from a newer client may produce fewer
+  /// ops than it contained on the wire.
   factory MapEditBatch.fromJson(Map<String, dynamic> json) {
     final playerId = json['playerId'] as String;
     final counter = json['counter'] as int;
@@ -142,6 +175,7 @@ class MapEditBatch {
                 playerId: playerId,
                 counter: counter,
               ))
+          .whereType<MapEditOp>()
           .toList(),
     );
   }

--- a/lib/map_editor/map_sync_service.dart
+++ b/lib/map_editor/map_sync_service.dart
@@ -575,6 +575,7 @@ class MapSyncService {
 
     if (msg.topic == _editTopic) {
       final batch = MapEditBatch.fromJson(json);
+      if (batch.ops.isEmpty) return;
       if (_isSyncing) {
         _syncBuffer.add(batch);
       } else {
@@ -917,7 +918,11 @@ class MapSyncService {
   }
 
   TileType _tileTypeFromName(String name) {
-    return TileType.values.byName(name);
+    for (final type in TileType.values) {
+      if (type.name == name) return type;
+    }
+    debugPrint('_tileTypeFromName: unknown TileType "$name", defaulting to open');
+    return TileType.open;
   }
 
   /// Dispose subscriptions and resources.

--- a/test/map_editor/crdt/cell_version_map_test.dart
+++ b/test/map_editor/crdt/cell_version_map_test.dart
@@ -123,6 +123,20 @@ void main() {
   });
 
   group('serialization', () {
+    test('loadFromJson skips entries with unknown layer', () {
+      final json = <String, dynamic>{
+        '1,2,structure': [3, 'alice'],
+        '3,4,lighting': [5, 'bob'], // unknown future layer
+        '5,6,floor': [7, 'charlie'],
+      };
+      vmap.loadFromJson(json);
+
+      // Known layers are loaded; unknown 'lighting' is silently skipped.
+      expect(vmap.versionAt(1, 2, OpLayer.structure), (3, 'alice'));
+      expect(vmap.versionAt(5, 6, OpLayer.floor), (7, 'charlie'));
+      expect(vmap.length, 2);
+    });
+
     test('toJson/loadFromJson round-trip', () {
       const op1 = MapEditOp(
         playerId: 'alice',

--- a/test/map_editor/crdt/map_edit_op_test.dart
+++ b/test/map_editor/crdt/map_edit_op_test.dart
@@ -15,7 +15,7 @@ void main() {
       );
 
       final json = op.toJson();
-      final decoded = MapEditOp.fromJson(json, playerId: 'alice', counter: 5);
+      final decoded = MapEditOp.fromJson(json, playerId: 'alice', counter: 5)!;
 
       expect(decoded.x, 10);
       expect(decoded.y, 20);
@@ -36,7 +36,7 @@ void main() {
       );
 
       final json = op.toJson();
-      final decoded = MapEditOp.fromJson(json, playerId: 'bob', counter: 3);
+      final decoded = MapEditOp.fromJson(json, playerId: 'bob', counter: 3)!;
 
       expect(decoded.layer, OpLayer.floor);
       expect(decoded.oldValue, isNull);
@@ -79,6 +79,22 @@ void main() {
       expect(inv.y, 2);
       expect(inv.oldValue, 'barrier');
       expect(inv.newValue, isNull);
+    });
+
+    test('fromJson returns null for unrecognized layer', () {
+      final json = <String, dynamic>{
+        'x': 3,
+        'y': 4,
+        'layer': 'lighting', // hypothetical future layer
+        'new': 'dim',
+      };
+      final result = MapEditOp.fromJson(json, playerId: 'alice', counter: 1);
+      expect(result, isNull);
+    });
+
+    test('OpLayer.tryParse returns null for unknown name', () {
+      expect(OpLayer.tryParse('unknown'), isNull);
+      expect(OpLayer.tryParse('floor'), OpLayer.floor);
     });
 
     test('equality considers all fields', () {
@@ -153,6 +169,24 @@ void main() {
       expect(decoded.ops.length, 2);
       expect(decoded.ops[0].layer, OpLayer.structure);
       expect(decoded.ops[1].layer, OpLayer.floor);
+    });
+
+    test('fromJson skips ops with unrecognized layer', () {
+      final json = <String, dynamic>{
+        'type': 'edit',
+        'playerId': 'alice',
+        'counter': 7,
+        'ops': [
+          {'x': 0, 'y': 0, 'layer': 'structure', 'new': 'barrier'},
+          {'x': 1, 'y': 0, 'layer': 'lighting', 'new': 'dim'}, // unknown
+          {'x': 2, 'y': 0, 'layer': 'floor'},
+        ],
+      };
+      final batch = MapEditBatch.fromJson(json);
+      // The unknown 'lighting' op is dropped; the other two are kept.
+      expect(batch.ops.length, 2);
+      expect(batch.ops[0].layer, OpLayer.structure);
+      expect(batch.ops[1].layer, OpLayer.floor);
     });
 
     test('inverse reverses ops order and swaps values', () {


### PR DESCRIPTION
## Summary
- `OpLayer.values.byName()` throws `ArgumentError` on unrecognized layer names, which propagates uncaught through the map-edit stream listener and silently kills the CRDT sync loop
- Added `OpLayer.tryParse()` that returns null on unknown values
- Changed `MapEditOp.fromJson` to return `MapEditOp?` — unknown layers are logged and skipped
- `MapEditBatch.fromJson` filters out null ops via `.whereType<MapEditOp>()`

## Context
Found during Phase 1 protocol audit — see `robin-docs/phase1-protocol-audit.md` finding C2/backward compatibility section. If a future protocol version adds a new layer, all existing clients currently crash.

## Test plan
- [ ] Existing tests pass (`flutter test`)
- [ ] New test: `fromJson returns null for unrecognized layer`
- [ ] New test: `OpLayer.tryParse returns null for unknown name`
- [ ] New test: `MapEditBatch.fromJson skips ops with unrecognized layer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)