### PR TITLE
Log malformed data channel messages instead of swallowing silently

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -705,7 +705,13 @@ class DataChannelMessage {
   Map<String, dynamic>? get json {
     try {
       return jsonDecode(utf8.decode(data)) as Map<String, dynamic>;
-    } catch (_) {
+    } catch (e) {
+      final preview = utf8.decode(data, allowMalformed: true);
+      debugPrint(
+        'DataChannelMessage: JSON parse failed '
+        '(topic: $topic, error: $e, '
+        'data: ${preview.length > 200 ? preview.substring(0, 200) : preview})',
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- `DataChannelMessage.json` getter used `catch (_)` to swallow all JSON parse errors, returning null with zero diagnostic output
- Added `debugPrint` in the catch block logging: topic, error, and truncated raw data preview (200 chars)
- Makes wire format debugging possible without attaching a debugger

## Context
Found during Phase 1 protocol audit — see `robin-docs/phase1-protocol-audit.md` finding L1.

## Test plan
- [ ] Existing tests pass (`flutter test`)
- [ ] No behaviour change — malformed messages are still dropped, just now with a log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)