### PR TITLE
refactor(flame): extract BubbleManager from TechWorld

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ Services registered with `Locator`, accessed via `locate<T>()`. Static: `AuthSer
 ### Key Classes
 
 - **`TechWorldGame`** — extends `FlameGame`, wraps `TechWorld` world component
-- **`TechWorld`** — extends `World`, manages all game components, subscribes to LiveKit events
+- **`TechWorld`** — extends `World`, manages game components, subscribes to LiveKit events, delegates bubble lifecycle to `BubbleManager`
+- **`BubbleManager`** — plain Dart class (not a Component) owning all proximity bubble state: creation/removal, physics repulsion, metaball field, merged video, audio enable/disable, shader loading, Dreamfinder avatar bridge. Receives `addComponent` callback to add to the World.
 
 ### Communication (All via LiveKit)
 

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -82,7 +82,7 @@ class BubbleManager {
   // ── Constants ─────────────────────────────────────────────────────────────
 
   static const _localPlayerBubbleKey = '_local_player_';
-  static const int visualThreshold = 5; // grid squares — bubbles visible
+  static const int _visualThreshold = 5; // grid squares — bubbles visible
   static const int _audioThreshold = 2; // grid squares — audio enabled
   static final _bubbleOffset =
       Vector2(16, -20); // center horizontally, above sprite
@@ -124,7 +124,7 @@ class BubbleManager {
 
     // Check each other player for proximity.
     final nearbyPlayerIds = <String>{};
-    int closestDistance = visualThreshold + 1;
+    int closestDistance = _visualThreshold + 1;
 
     for (final entry in _remotePlayers.entries) {
       final playerId = entry.key;
@@ -132,7 +132,7 @@ class BubbleManager {
 
       final distance =
           chebyshevDistance(playerGrid, playerComponent.miniGridPosition);
-      final isVisible = distance <= visualThreshold;
+      final isVisible = distance <= _visualThreshold;
 
       if (isVisible) {
         nearbyPlayerIds.add(playerId);
@@ -158,7 +158,7 @@ class BubbleManager {
       final dfGrid = dreamfinderComponent!.miniGridPosition;
       final dfDistance = chebyshevDistance(playerGrid, dfGrid);
 
-      if (dfDistance <= visualThreshold) {
+      if (dfDistance <= _visualThreshold) {
         nearbyPlayerIds.add(dreamfinderIdentity);
         if (dfDistance < closestDistance) closestDistance = dfDistance;
 
@@ -186,7 +186,7 @@ class BubbleManager {
       final botDistance =
           chebyshevDistance(playerGrid, botComp.miniGridPosition);
 
-      if (botDistance <= visualThreshold) {
+      if (botDistance <= _visualThreshold) {
         nearbyPlayerIds.add(botId);
         if (botDistance < closestDistance) closestDistance = botDistance;
 
@@ -400,7 +400,7 @@ class BubbleManager {
       _shaderProgram =
           await ui.FragmentProgram.fromAsset('shaders/video_bubble.frag');
     } catch (e) {
-      // Shader loading failed — video bubbles will render without effects.
+      _log.warning('Video bubble shader failed to load', e);
     }
   }
 

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -1,0 +1,731 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart' show Color, Colors;
+import 'package:livekit_client/livekit_client.dart';
+import 'package:logging/logging.dart';
+
+import 'package:tech_world/bots/bot_config.dart';
+import 'package:tech_world/flame/components/bot_bubble_component.dart';
+import 'package:tech_world/flame/components/bot_character_component.dart';
+import 'package:tech_world/flame/components/bubble_field_component.dart';
+import 'package:tech_world/flame/components/dreamfinder_component.dart';
+import 'package:tech_world/flame/components/merged_video_bubble_component.dart';
+import 'package:tech_world/flame/components/player_bubble_component.dart';
+import 'package:tech_world/flame/components/player_component.dart';
+import 'package:tech_world/flame/components/video_bubble_component.dart';
+import 'package:tech_world/livekit/dreamfinder_avatar_bridge.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+import 'package:tech_world/proximity/proximity_service.dart';
+
+final _log = Logger('BubbleManager');
+
+/// Manages the lifecycle of all player proximity bubbles in the game world.
+///
+/// Plain Dart class (not a Flame Component). Receives a callback to add
+/// components to the World, keeping component tree ownership in TechWorld.
+///
+/// Responsibilities:
+///  - Proximity detection and bubble creation/removal
+///  - Physics repulsion between overlapping bubbles
+///  - Metaball field and merged video rendering
+///  - Audio enable/disable based on distance
+///  - Shader loading and assignment
+///  - Dreamfinder avatar bridge lifecycle
+class BubbleManager {
+  BubbleManager({
+    required PlayerComponent localPlayer,
+    required void Function(Component) addComponent,
+    required Map<String, PlayerComponent> remotePlayers,
+    required Map<String, BotCharacterComponent> bots,
+  })  : _localPlayer = localPlayer,
+        _addComponent = addComponent,
+        _remotePlayers = remotePlayers,
+        _bots = bots;
+
+  // ── Construction-time stable references ──────────────────────────────────
+
+  final PlayerComponent _localPlayer;
+  final void Function(Component) _addComponent;
+  final Map<String, PlayerComponent> _remotePlayers;
+  final Map<String, BotCharacterComponent> _bots;
+
+  // ── LiveKit (arrives after construction) ─────────────────────────────────
+
+  LiveKitService? _liveKitService;
+  DreamfinderAvatarBridge? _dreamfinderAvatarBridge;
+
+  // ── Mutable references set by TechWorld ──────────────────────────────────
+
+  DreamfinderComponent? dreamfinderComponent;
+  String dreamfinderIdentity = dreamfinderBot.identity;
+
+  // ── Bubble state ─────────────────────────────────────────────────────────
+
+  final Map<String, PositionComponent> _playerBubbles = {};
+  final Map<String, Vector2> _bubbleDisplacements = {};
+  final Set<String> _audioEnabledParticipants = {};
+  Point<int>? _lastPlayerGridPosition;
+
+  // ── Rendering components ─────────────────────────────────────────────────
+
+  BubbleFieldComponent? _bubbleField;
+  MergedVideoBubbleComponent? _mergedBubble;
+
+  // ── Shader programs ───────────────────────────────────────────────────────
+
+  ui.FragmentProgram? _shaderProgram;
+  ui.FragmentProgram? _metaballShaderProgram;
+  ui.FragmentProgram? _mergedVideoShaderProgram;
+
+  // ── Constants ─────────────────────────────────────────────────────────────
+
+  static const _localPlayerBubbleKey = '_local_player_';
+  static const int visualThreshold = 5; // grid squares — bubbles visible
+  static const int _audioThreshold = 2; // grid squares — audio enabled
+  static final _bubbleOffset =
+      Vector2(16, -20); // center horizontally, above sprite
+  static const double _mergeThreshold = 96.0; // 1.5× bubble diameter
+  static const double _bubbleDiameter = 64.0;
+  static const double _maxTetherDistance = 24.0;
+  static const double _repulsionDamping = 0.85;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Public API
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /// Chebyshev distance (max of x/y difference) — the metric for proximity.
+  static int chebyshevDistance(Point<int> a, Point<int> b) =>
+      max((a.x - b.x).abs(), (a.y - b.y).abs());
+
+  /// Load all three shader programs in parallel.
+  Future<void> loadShaders() => Future.wait([
+        _loadVideoBubbleShader(),
+        _loadMetaballShader(),
+        _loadMergedVideoShader(),
+      ]);
+
+  /// Called when LiveKitService becomes available (after connectToLiveKit).
+  void setLiveKitService(LiveKitService service) {
+    _liveKitService = service;
+  }
+
+  /// Main per-frame entry point. Called from TechWorld.update().
+  void update(double dt) {
+    final playerGrid = _localPlayer.miniGridPosition;
+
+    // Skip proximity re-evaluation if player hasn't moved to a new grid cell.
+    if (_lastPlayerGridPosition == playerGrid) {
+      _updateBubblePositions(dt);
+      return;
+    }
+    _lastPlayerGridPosition = playerGrid;
+
+    // Check each other player for proximity.
+    final nearbyPlayerIds = <String>{};
+    int closestDistance = visualThreshold + 1;
+
+    for (final entry in _remotePlayers.entries) {
+      final playerId = entry.key;
+      final playerComponent = entry.value;
+
+      final distance =
+          chebyshevDistance(playerGrid, playerComponent.miniGridPosition);
+      final isVisible = distance <= visualThreshold;
+
+      if (isVisible) {
+        nearbyPlayerIds.add(playerId);
+        if (distance < closestDistance) closestDistance = distance;
+
+        if (!_playerBubbles.containsKey(playerId)) {
+          final bubble = _createBubbleForPlayer(playerId, playerComponent);
+          bubble.position = playerComponent.position + _bubbleOffset;
+          _playerBubbles[playerId] = bubble;
+          _addComponent(bubble);
+        }
+
+        _setBubbleOpacity(_playerBubbles[playerId]!, distance);
+        _updateParticipantAudio(playerId, distance);
+      } else {
+        // Beyond visual range — ensure audio is disabled.
+        _updateParticipantAudio(playerId, distance);
+      }
+    }
+
+    // Check proximity to Dreamfinder.
+    if (dreamfinderComponent != null) {
+      final dfGrid = dreamfinderComponent!.miniGridPosition;
+      final dfDistance = chebyshevDistance(playerGrid, dfGrid);
+
+      if (dfDistance <= visualThreshold) {
+        nearbyPlayerIds.add(dreamfinderIdentity);
+        if (dfDistance < closestDistance) closestDistance = dfDistance;
+
+        if (!_playerBubbles.containsKey(dreamfinderIdentity)) {
+          final dfParticipant =
+              _liveKitService?.getParticipant(dreamfinderIdentity);
+          PositionComponent bubble;
+          if (dfParticipant != null) {
+            bubble = _createDreamfinderVideoBubble(dfParticipant);
+          } else {
+            bubble = BotBubbleComponent();
+          }
+          bubble.position =
+              dreamfinderComponent!.position + _bubbleOffset;
+          _playerBubbles[dreamfinderIdentity] = bubble;
+          _addComponent(bubble);
+        }
+      }
+    }
+
+    // Check proximity to all bot characters.
+    for (final entry in _bots.entries) {
+      final botId = entry.key;
+      final botComp = entry.value;
+      final botDistance =
+          chebyshevDistance(playerGrid, botComp.miniGridPosition);
+
+      if (botDistance <= visualThreshold) {
+        nearbyPlayerIds.add(botId);
+        if (botDistance < closestDistance) closestDistance = botDistance;
+
+        if (!_playerBubbles.containsKey(botId)) {
+          final bubble = BotBubbleComponent();
+          bubble.position = botComp.position + _bubbleOffset;
+          _playerBubbles[botId] = bubble;
+          _addComponent(bubble);
+        }
+      }
+    }
+
+    // Show local player's bubble if near anyone.
+    if (nearbyPlayerIds.isNotEmpty) {
+      if (!_playerBubbles.containsKey(_localPlayerBubbleKey)) {
+        final localBubble = _createLocalPlayerBubble();
+        localBubble.position = _localPlayer.position + _bubbleOffset;
+        _playerBubbles[_localPlayerBubbleKey] = localBubble;
+        _addComponent(localBubble);
+      }
+      _setBubbleOpacity(
+          _playerBubbles[_localPlayerBubbleKey]!, closestDistance);
+      nearbyPlayerIds.add(_localPlayerBubbleKey);
+    }
+
+    // Remove bubbles for players no longer nearby.
+    final toRemove = <String>[];
+    for (final playerId in _playerBubbles.keys) {
+      if (!nearbyPlayerIds.contains(playerId)) {
+        _playerBubbles[playerId]?.removeFromParent();
+        toRemove.add(playerId);
+      }
+    }
+    for (final playerId in toRemove) {
+      _playerBubbles.remove(playerId);
+    }
+
+    _updateBubblePositions(dt);
+  }
+
+  /// Refresh (upgrade to video or re-create) the bubble for a remote player.
+  void refreshBubbleForPlayer(String playerId) {
+    // Handle Dreamfinder separately.
+    if (isDreamfinderIdentity(playerId) && dreamfinderComponent != null) {
+      final existingBubble = _playerBubbles[playerId];
+      final dfParticipant =
+          _liveKitService?.getParticipant(dreamfinderIdentity);
+      if (dfParticipant == null) return;
+
+      final hasCanvasCapture = existingBubble is VideoBubbleComponent &&
+          existingBubble.externalVideoCapture != null;
+      final needsUpgrade = existingBubble is! VideoBubbleComponent ||
+          (!hasCanvasCapture && _dreamfinderAvatarBridge?.isReady == true);
+
+      if (needsUpgrade) {
+        existingBubble?.removeFromParent();
+        final videoBubble = _createDreamfinderVideoBubble(dfParticipant);
+        videoBubble.position =
+            dreamfinderComponent!.position + _bubbleOffset;
+        _playerBubbles[playerId] = videoBubble;
+        _addComponent(videoBubble);
+      }
+      return;
+    }
+
+    final existingBubble = _playerBubbles[playerId];
+    if (existingBubble == null) return;
+
+    if (existingBubble is VideoBubbleComponent) return;
+
+    final playerComponent = _remotePlayers[playerId];
+    if (playerComponent == null) return;
+
+    existingBubble.removeFromParent();
+
+    final newBubble = _createBubbleForPlayer(playerId, playerComponent);
+    newBubble.position = playerComponent.position + _bubbleOffset;
+    _playerBubbles[playerId] = newBubble;
+    _addComponent(newBubble);
+  }
+
+  /// Refresh the local player's bubble (e.g. after camera comes online).
+  void refreshLocalPlayerBubble() {
+    final existingBubble = _playerBubbles[_localPlayerBubbleKey];
+    if (existingBubble == null) return;
+
+    if (existingBubble is VideoBubbleComponent) return;
+
+    _log.fine('Refreshing local player bubble after camera enabled');
+
+    existingBubble.removeFromParent();
+
+    final newBubble = _createLocalPlayerBubble();
+    newBubble.position = _localPlayer.position + _bubbleOffset;
+    _playerBubbles[_localPlayerBubbleKey] = newBubble;
+    _addComponent(newBubble);
+  }
+
+  /// Downgrade a video bubble to a static placeholder.
+  void downgradeVideoBubble(String playerId) {
+    final existingBubble = _playerBubbles[playerId];
+    if (existingBubble == null) return;
+
+    if (existingBubble is! VideoBubbleComponent) return;
+
+    final position = existingBubble.position.clone();
+    existingBubble.removeFromParent();
+
+    if (isDreamfinderIdentity(playerId)) {
+      final botBubble = BotBubbleComponent(bubbleSize: 64);
+      botBubble.position = position;
+      _playerBubbles[playerId] = botBubble;
+      _addComponent(botBubble);
+    } else {
+      final playerComponent = _remotePlayers[playerId];
+      if (playerComponent != null) {
+        final newBubble = PlayerBubbleComponent(
+          displayName: playerComponent.displayName,
+          playerId: playerId,
+        );
+        newBubble.position = position;
+        _playerBubbles[playerId] = newBubble;
+        _addComponent(newBubble);
+      } else {
+        _playerBubbles.remove(playerId);
+      }
+    }
+  }
+
+  /// Update the speaking indicator on a video bubble.
+  void updateSpeakingState(String participantId, bool isSpeaking) {
+    final bubble = _playerBubbles[participantId];
+    if (bubble is VideoBubbleComponent) {
+      bubble.speakingLevel = isSpeaking ? 1.0 : 0.0;
+    }
+  }
+
+  /// Signal that a video track is ready for frame capture.
+  void notifyTrackReady(String participantId) {
+    final bubble = _playerBubbles[participantId];
+    if (bubble is VideoBubbleComponent) {
+      _log.fine('Notifying bubble track ready for $participantId');
+      bubble.notifyTrackReady();
+    }
+  }
+
+  /// Initialize the Dreamfinder 3D avatar bridge (web only).
+  void initDreamfinderBridge() {
+    if (_dreamfinderAvatarBridge != null) return;
+    final liveKit = _liveKitService;
+    if (liveKit == null) return;
+
+    _dreamfinderAvatarBridge =
+        DreamfinderAvatarBridge(liveKitService: liveKit);
+    _dreamfinderAvatarBridge!.initialize().then((_) {
+      if (_dreamfinderAvatarBridge?.isReady == true) {
+        _log.info('Dreamfinder avatar bridge ready — refreshing bubble');
+        refreshBubbleForPlayer(dreamfinderIdentity);
+      }
+    }).catchError((Object e) {
+      _log.warning('Dreamfinder avatar bridge failed to initialize: $e');
+    });
+  }
+
+  /// Clean up Dreamfinder-specific state when the participant leaves.
+  void handleDreamfinderLeft() {
+    dreamfinderIdentity = dreamfinderBot.identity;
+    _dreamfinderAvatarBridge?.dispose();
+    _dreamfinderAvatarBridge = null;
+  }
+
+  /// Remove a single bubble by player ID.
+  void removeBubble(String playerId) {
+    final bubble = _playerBubbles.remove(playerId);
+    bubble?.removeFromParent();
+  }
+
+  /// Remove all bubbles and reset state. Safe to call multiple times.
+  void clear() {
+    for (final bubble in _playerBubbles.values) {
+      bubble.removeFromParent();
+    }
+    _playerBubbles.clear();
+    _bubbleDisplacements.clear();
+    _bubbleField?.removeFromParent();
+    _bubbleField = null;
+    _mergedBubble?.removeFromParent();
+    _mergedBubble = null;
+    _audioEnabledParticipants.clear();
+    _lastPlayerGridPosition = null;
+    _liveKitService = null;
+    _dreamfinderAvatarBridge?.dispose();
+    _dreamfinderAvatarBridge = null;
+    dreamfinderIdentity = dreamfinderBot.identity;
+  }
+
+  /// Final teardown. Call from TechWorld.dispose().
+  void dispose() {
+    clear();
+    _shaderProgram = null;
+    _metaballShaderProgram = null;
+    _mergedVideoShaderProgram = null;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Private — shader loading
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  Future<void> _loadVideoBubbleShader() async {
+    try {
+      _shaderProgram =
+          await ui.FragmentProgram.fromAsset('shaders/video_bubble.frag');
+    } catch (e) {
+      // Shader loading failed — video bubbles will render without effects.
+    }
+  }
+
+  Future<void> _loadMetaballShader() async {
+    try {
+      _metaballShaderProgram =
+          await ui.FragmentProgram.fromAsset('shaders/metaball_field.frag');
+    } catch (e) {
+      _log.warning('Metaball shader failed to load', e);
+    }
+  }
+
+  Future<void> _loadMergedVideoShader() async {
+    try {
+      _mergedVideoShaderProgram = await ui.FragmentProgram.fromAsset(
+          'shaders/merged_video_bubble.frag');
+    } catch (e) {
+      _log.warning('Merged video shader failed to load', e);
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Private — bubble creation
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  bool _hasVideoTrack(Participant participant) {
+    for (final publication in participant.videoTrackPublications) {
+      if (publication.track != null) {
+        if (participant is LocalParticipant) {
+          return true;
+        } else {
+          if (publication.subscribed) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  PositionComponent _createBubbleForPlayer(
+      String playerId, PlayerComponent playerComponent) {
+    final participant = _liveKitService?.getParticipant(playerId);
+    if (participant != null && _hasVideoTrack(participant)) {
+      final videoBubble = VideoBubbleComponent(
+        participant: participant,
+        displayName: playerComponent.displayName,
+        bubbleSize: 64,
+        targetFps: 15,
+      );
+
+      if (_shaderProgram != null) {
+        videoBubble.setShader(_shaderProgram!.fragmentShader());
+      }
+
+      return videoBubble;
+    }
+
+    return PlayerBubbleComponent(
+      displayName: playerComponent.displayName,
+      playerId: playerId,
+    );
+  }
+
+  PositionComponent _createLocalPlayerBubble() {
+    final localParticipant = _liveKitService?.localParticipant;
+
+    if (localParticipant != null && _hasVideoTrack(localParticipant)) {
+      _log.fine('Creating local VideoBubbleComponent');
+      final videoBubble = VideoBubbleComponent(
+        participant: localParticipant,
+        displayName: _localPlayer.displayName,
+        bubbleSize: 64,
+        targetFps: 15,
+      );
+
+      if (_shaderProgram != null) {
+        videoBubble.setShader(_shaderProgram!.fragmentShader());
+      }
+
+      videoBubble.glowColor = Colors.cyan;
+
+      return videoBubble;
+    }
+
+    return PlayerBubbleComponent(
+      displayName: _localPlayer.displayName,
+      playerId: _localPlayer.id,
+    );
+  }
+
+  VideoBubbleComponent _createDreamfinderVideoBubble(
+      Participant participant) {
+    final videoBubble = VideoBubbleComponent(
+      participant: participant,
+      displayName: dreamfinderBot.displayName,
+      bubbleSize: 64,
+      targetFps: 10,
+      externalVideoCapture: _dreamfinderAvatarBridge?.canvasCapture,
+    );
+    videoBubble.glowColor = const Color(0xFFDAA520); // gold
+    videoBubble.glowIntensity = 0.7;
+    return videoBubble;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Private — proximity and audio
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  void _setBubbleOpacity(PositionComponent bubble, int distance) {
+    final opacity = ProximityService.calculateOpacity(distance);
+    if (bubble is VideoBubbleComponent) {
+      bubble.opacity = opacity;
+    } else if (bubble is PlayerBubbleComponent) {
+      bubble.opacity = opacity;
+    }
+  }
+
+  void _updateParticipantAudio(String playerId, int distance) {
+    final shouldHaveAudio = distance <= _audioThreshold;
+    final hasAudio = _audioEnabledParticipants.contains(playerId);
+
+    if (shouldHaveAudio && !hasAudio) {
+      _audioEnabledParticipants.add(playerId);
+      _liveKitService?.setParticipantAudioEnabled(playerId, true);
+    } else if (!shouldHaveAudio && hasAudio) {
+      _audioEnabledParticipants.remove(playerId);
+      _liveKitService?.setParticipantAudioEnabled(playerId, false);
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Private — physics and rendering
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  void _updateBubblePositions(double dt) {
+    // 1. Set base positions from owning characters.
+    for (final entry in _playerBubbles.entries) {
+      if (entry.key == _localPlayerBubbleKey) {
+        entry.value.position = _localPlayer.position + _bubbleOffset;
+        entry.value.priority = _localPlayer.priority + 1;
+      } else if (entry.key == dreamfinderIdentity &&
+          dreamfinderComponent != null) {
+        entry.value.position =
+            dreamfinderComponent!.position + _bubbleOffset;
+        entry.value.priority = dreamfinderComponent!.priority + 1;
+        if (entry.value is VideoBubbleComponent) {
+          (entry.value as VideoBubbleComponent).loadingProgress =
+              _dreamfinderAvatarBridge?.avatarLoadProgress;
+        }
+      } else if (_bots.containsKey(entry.key)) {
+        final botComp = _bots[entry.key]!;
+        entry.value.position = botComp.position + _bubbleOffset;
+        entry.value.priority = botComp.priority + 1;
+      } else {
+        final playerComponent = _remotePlayers[entry.key];
+        if (playerComponent != null) {
+          entry.value.position = playerComponent.position + _bubbleOffset;
+          entry.value.priority = playerComponent.priority + 1;
+        }
+      }
+    }
+
+    // 2. Apply physics repulsion so bubbles don't overlap.
+    _applyBubbleRepulsion(dt);
+
+    // 3. Collect centres for the metaball field.
+    final centres = <Vector2>[];
+    int lowestPriority = 999;
+    for (final entry in _playerBubbles.entries) {
+      centres.add(entry.value.center);
+      if (entry.value.priority < lowestPriority) {
+        lowestPriority = entry.value.priority;
+      }
+    }
+
+    _updateBubbleField(centres, lowestPriority);
+    _updateMergedVideo(lowestPriority);
+  }
+
+  void _applyBubbleRepulsion(double dt) {
+    final entries = _playerBubbles.entries.toList();
+    if (entries.length < 2) return;
+
+    _bubbleDisplacements
+        .removeWhere((k, _) => !_playerBubbles.containsKey(k));
+
+    final forces = <String, Vector2>{};
+    for (var i = 0; i < entries.length; i++) {
+      for (var j = i + 1; j < entries.length; j++) {
+        final ci = entries[i].value.center;
+        final cj = entries[j].value.center;
+        final delta = ci - cj;
+        final dist = delta.length;
+        if (dist < _bubbleDiameter && dist > 0.01) {
+          final overlap = _bubbleDiameter - dist;
+          final direction = delta.normalized();
+          final clampedDt = min(dt, 0.05);
+          final push = direction * (overlap * 0.5 * clampedDt / 0.016);
+          forces[entries[i].key] =
+              (forces[entries[i].key] ?? Vector2.zero()) + push;
+          forces[entries[j].key] =
+              (forces[entries[j].key] ?? Vector2.zero()) - push;
+        }
+      }
+    }
+
+    for (final entry in entries) {
+      final key = entry.key;
+      var disp = _bubbleDisplacements[key] ?? Vector2.zero();
+      disp = disp * _repulsionDamping + (forces[key] ?? Vector2.zero());
+      if (disp.length > _maxTetherDistance) {
+        disp = disp.normalized() * _maxTetherDistance;
+      }
+      _bubbleDisplacements[key] = disp;
+      entry.value.position += disp;
+    }
+  }
+
+  void _updateBubbleField(List<Vector2> centres, int lowestPriority) {
+    if (centres.length < 2 || _metaballShaderProgram == null) {
+      _bubbleField?.removeFromParent();
+      _bubbleField = null;
+      return;
+    }
+
+    if (_bubbleField == null) {
+      _bubbleField = BubbleFieldComponent(
+        shaderProgram: _metaballShaderProgram!,
+        glowColor: const Color(0xFF00FF88),
+        bubbleRadius: 32,
+      );
+      _addComponent(_bubbleField!);
+    }
+
+    _bubbleField!.priority = lowestPriority - 1;
+    _bubbleField!.updateBubblePositions(centres);
+  }
+
+  void _updateMergedVideo(int lowestPriority) {
+    if (_mergedVideoShaderProgram == null) return;
+
+    final videoBubbles = <String, VideoBubbleComponent>{};
+    for (final entry in _playerBubbles.entries) {
+      if (entry.value is VideoBubbleComponent) {
+        videoBubbles[entry.key] = entry.value as VideoBubbleComponent;
+      }
+    }
+
+    final mergeGroup = _findMergeGroup(videoBubbles);
+
+    if (mergeGroup.length >= 2) {
+      if (_mergedBubble == null) {
+        _mergedBubble = MergedVideoBubbleComponent(
+          shaderProgram: _mergedVideoShaderProgram!,
+          glowColor: const Color(0xFF00FF88),
+          bubbleRadius: 32,
+        );
+        _addComponent(_mergedBubble!);
+      }
+
+      final sources = <VideoBubbleComponent>[];
+      final positions = <Vector2>[];
+      for (final key in mergeGroup) {
+        final bubble = videoBubbles[key]!;
+        bubble.hiddenForMerge = true;
+        sources.add(bubble);
+        positions.add(bubble.center);
+      }
+
+      _mergedBubble!.priority = lowestPriority;
+      _mergedBubble!.updateSources(sources);
+      _mergedBubble!.updatePositions(positions);
+
+      for (final entry in videoBubbles.entries) {
+        if (!mergeGroup.contains(entry.key)) {
+          entry.value.hiddenForMerge = false;
+        }
+      }
+    } else {
+      for (final bubble in videoBubbles.values) {
+        bubble.hiddenForMerge = false;
+      }
+      _mergedBubble?.removeFromParent();
+      _mergedBubble = null;
+    }
+  }
+
+  List<String> _findMergeGroup(Map<String, VideoBubbleComponent> bubbles) {
+    if (bubbles.length < 2) return [];
+
+    final keys = bubbles.keys.toList();
+    final visited = <String>{};
+    List<String> largestGroup = [];
+
+    for (final startKey in keys) {
+      if (visited.contains(startKey)) continue;
+
+      final group = <String>[startKey];
+      final queue = <String>[startKey];
+      visited.add(startKey);
+
+      while (queue.isNotEmpty) {
+        final current = queue.removeAt(0);
+        final currentCenter = bubbles[current]!.center;
+
+        for (final candidateKey in keys) {
+          if (visited.contains(candidateKey)) continue;
+          final candidateCenter = bubbles[candidateKey]!.center;
+          final dist = currentCenter.distanceTo(candidateCenter);
+          if (dist < _mergeThreshold) {
+            visited.add(candidateKey);
+            group.add(candidateKey);
+            queue.add(candidateKey);
+          }
+        }
+      }
+
+      if (group.length > largestGroup.length) {
+        largestGroup = group;
+      }
+    }
+
+    return largestGroup.length >= 2
+        ? largestGroup.take(maxMergedBubbles).toList()
+        : [];
+  }
+}

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -13,16 +13,13 @@ import 'package:tech_world/auth/auth_user.dart';
 import 'package:tech_world/bots/bot_config.dart';
 import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/editor/predefined_challenges.dart';
+import 'package:tech_world/flame/bubble_manager.dart';
 import 'package:tech_world/flame/components/barriers_component.dart';
 import 'package:tech_world/flame/components/door_component.dart';
 import 'package:tech_world/flame/maps/barrier_occlusion.dart';
-import 'package:tech_world/flame/components/bubble_field_component.dart';
-import 'package:tech_world/flame/components/merged_video_bubble_component.dart';
-import 'package:tech_world/flame/components/bot_bubble_component.dart';
 import 'package:tech_world/flame/components/bot_character_component.dart';
 import 'package:tech_world/flame/components/dreamfinder_component.dart';
 import 'package:tech_world/flame/components/map_preview_component.dart';
-import 'package:tech_world/flame/components/player_bubble_component.dart';
 import 'package:tech_world/flame/components/speech_bubble_component.dart';
 import 'package:tech_world/flame/components/tile_floor_component.dart';
 import 'package:tech_world/flame/components/tile_object_layer_component.dart';
@@ -31,7 +28,6 @@ import 'package:tech_world/flame/components/tile_object_layer_component.dart';
 import 'package:tech_world/flame/components/path_component.dart';
 import 'package:tech_world/flame/components/player_component.dart';
 import 'package:tech_world/flame/components/terminal_component.dart';
-import 'package:tech_world/flame/components/video_bubble_component.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/maps/predefined_maps.dart';
 import 'package:tech_world/flame/maps/door_data.dart';
@@ -51,9 +47,7 @@ import 'package:tech_world/flame/tech_world_game.dart';
 import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/infra/infra_health_service.dart';
 import 'package:tech_world/avatar/predefined_avatars.dart';
-import 'package:tech_world/livekit/dreamfinder_avatar_bridge.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
-import 'package:tech_world/proximity/proximity_service.dart';
 import 'package:tech_world/progress/progress_service.dart';
 import 'package:tech_world/utils/locator.dart';
 
@@ -69,7 +63,14 @@ final _log = Logger('TechWorld');
 /// are used to create a set of [MoveEffect]s and set the appropriate animation.
 class TechWorld extends World with TapCallbacks {
   TechWorld({required Stream<AuthUser> authStateChanges})
-      : _authStateChanges = authStateChanges;
+      : _authStateChanges = authStateChanges {
+    _bubbleManager = BubbleManager(
+      localPlayer: _userPlayerComponent,
+      addComponent: add,
+      remotePlayers: _otherPlayerComponentsMap,
+      bots: _botCharacterComponents,
+    );
+  }
 
   final PlayerComponent _userPlayerComponent = PlayerComponent(
     position: Vector2(0, 0),
@@ -80,11 +81,7 @@ class TechWorld extends World with TapCallbacks {
   final Map<String, PlayerComponent> _otherPlayerComponentsMap = {};
   final Map<String, BotCharacterComponent> _botCharacterComponents = {};
   DreamfinderComponent? _dreamfinderComponent;
-  /// The LiveKit identity of the active Dreamfinder participant.
-  /// Defaults to [dreamfinderBot.identity] (`bot-dreamfinder`) but updated
-  /// at runtime when the embodied agent joins with an `agent-{jobId}` identity.
-  String _dreamfinderIdentity = dreamfinderBot.identity;
-  DreamfinderAvatarBridge? _dreamfinderAvatarBridge;
+  late final BubbleManager _bubbleManager;
   // Participant saved when DF joins before onLoad completes (pathComponent
   // not yet available). Processed in onLoad once the world is ready.
   RemoteParticipant? _pendingDreamfinderParticipant;
@@ -99,16 +96,7 @@ class TechWorld extends World with TapCallbacks {
   final List<TerminalComponent> _terminalComponents = [];
   final List<DoorComponent> _doorComponents = [];
 
-  // Bubble components - shown when player is near other players
-  static const _localPlayerBubbleKey = '_local_player_';
-  static const _visualThreshold = 5; // grid squares — bubbles visible
-  static const _audioThreshold = 2; // grid squares — audio enabled
-  static final _bubbleOffset =
-      Vector2(16, -20); // center horizontally, above sprite
-  final Map<String, PositionComponent> _playerBubbles = {};
-  final Map<String, Vector2> _bubbleDisplacements = {}; // physics repulsion
-  final Set<String> _audioEnabledParticipants = {}; // track audio state
-  Point<int>? _lastPlayerGridPosition; // track to skip unnecessary updates
+  Point<int>? _lastKnownPlayerGrid;
 
   /// Current player grid position, updated each frame for UI consumers
   /// (e.g. the map editor mini-grid).
@@ -120,7 +108,7 @@ class TechWorld extends World with TapCallbacks {
   /// voice-cast mic FAB — the UI shows the cast affordance only when
   /// the player is near a door they could plausibly try to open.
   ///
-  /// Updated when the player moves (in [_updatePlayerBubbles]) and
+  /// Updated when the player moves (in [update]) and
   /// when a door unlocks (in [unlockDoor]) so the FAB hides
   /// immediately the door swings.
   final ValueNotifier<DoorData?> nearbyLockedDoor = ValueNotifier(null);
@@ -130,16 +118,7 @@ class TechWorld extends World with TapCallbacks {
   /// not after they've stopped.
   static const int _doorProximityThreshold = 2;
 
-  // LiveKit integration for video bubbles
   LiveKitService? _liveKitService;
-  ui.FragmentProgram? _shaderProgram; // Keep reference for creating new shaders
-  ui.FragmentProgram? _metaballShaderProgram;
-  ui.FragmentProgram? _mergedVideoShaderProgram;
-  BubbleFieldComponent? _bubbleField;
-  MergedVideoBubbleComponent? _mergedBubble;
-
-  /// Distance below which video bubbles merge into a single blob.
-  static const double _mergeThreshold = 96.0; // 1.5× bubble diameter
 
   /// Notifier for active code challenge ID. Null means no editor open.
   final ValueNotifier<CodeChallengeId?> activeChallenge = ValueNotifier(null);
@@ -396,7 +375,7 @@ class TechWorld extends World with TapCallbacks {
       positions[entry.key] = entry.value.miniGridPosition;
     }
     if (_dreamfinderComponent != null) {
-      positions[_dreamfinderIdentity] =
+      positions[_bubbleManager.dreamfinderIdentity] =
           _dreamfinderComponent!.miniGridPosition;
     }
     return positions;
@@ -405,507 +384,13 @@ class TechWorld extends World with TapCallbacks {
   @override
   void update(double dt) {
     super.update(dt);
-    _updatePlayerBubbles(dt);
-  }
-
-  void _updatePlayerBubbles(double dt) {
     final playerGrid = _userPlayerComponent.miniGridPosition;
-
-    // Skip update if player hasn't moved to a new grid position
-    if (_lastPlayerGridPosition == playerGrid) {
-      // Still update positions of existing bubbles
-      _updateBubblePositions(dt);
-      return;
+    if (_lastKnownPlayerGrid != playerGrid) {
+      _lastKnownPlayerGrid = playerGrid;
+      playerGridPosition.value = playerGrid;
+      _recomputeNearbyLockedDoor();
     }
-    _lastPlayerGridPosition = playerGrid;
-    playerGridPosition.value = playerGrid;
-    _recomputeNearbyLockedDoor();
-
-    // Check each other player for proximity
-    final nearbyPlayerIds = <String>{};
-    int closestDistance = _visualThreshold + 1;
-
-    for (final entry in _otherPlayerComponentsMap.entries) {
-      final playerId = entry.key;
-      final playerComponent = entry.value;
-
-      // Calculate Chebyshev distance (max of x/y difference)
-      final otherGrid = playerComponent.miniGridPosition;
-      final distance = max(
-        (otherGrid.x - playerGrid.x).abs(),
-        (otherGrid.y - playerGrid.y).abs(),
-      );
-
-      final isVisible = distance <= _visualThreshold;
-
-      if (isVisible) {
-        nearbyPlayerIds.add(playerId);
-        if (distance < closestDistance) closestDistance = distance;
-
-        if (!_playerBubbles.containsKey(playerId)) {
-          // Create bubble for this player
-          final bubble = _createBubbleForPlayer(playerId, playerComponent);
-          bubble.position = playerComponent.position + _bubbleOffset;
-          _playerBubbles[playerId] = bubble;
-          add(bubble);
-        }
-
-        // Set opacity based on distance
-        _setBubbleOpacity(_playerBubbles[playerId]!, distance);
-
-        // Manage audio: enable within audio threshold, disable outside
-        _updateParticipantAudio(playerId, distance);
-      } else {
-        // Beyond visual range — ensure audio is disabled
-        _updateParticipantAudio(playerId, distance);
-      }
-    }
-
-    // Check proximity to Dreamfinder (separate from other bots — has its
-    // own component type and can publish a video track for the holographic
-    // wizard projection).
-    if (_dreamfinderComponent != null) {
-      final dfGrid = _dreamfinderComponent!.miniGridPosition;
-      final dfDistance = max(
-        (dfGrid.x - playerGrid.x).abs(),
-        (dfGrid.y - playerGrid.y).abs(),
-      );
-
-      if (dfDistance <= _visualThreshold) {
-        nearbyPlayerIds.add(_dreamfinderIdentity);
-        if (dfDistance < closestDistance) closestDistance = dfDistance;
-
-        if (!_playerBubbles.containsKey(_dreamfinderIdentity)) {
-          // Create Dreamfinder's video bubble eagerly once the participant
-          // exists. The video track may subscribe slightly later than the
-          // participant join event, so gating bubble creation on _hasVideoTrack
-          // can leave the hologram stuck on a static placeholder forever.
-          final dfParticipant =
-              _liveKitService?.getParticipant(_dreamfinderIdentity);
-          PositionComponent bubble;
-          if (dfParticipant != null) {
-            bubble = _createDreamfinderVideoBubble(dfParticipant);
-          } else {
-            bubble = BotBubbleComponent();
-          }
-          bubble.position =
-              _dreamfinderComponent!.position + _bubbleOffset;
-          _playerBubbles[_dreamfinderIdentity] = bubble;
-          add(bubble);
-        }
-      }
-    }
-
-    // Check proximity to all bot characters
-    for (final entry in _botCharacterComponents.entries) {
-      final botId = entry.key;
-      final botComp = entry.value;
-      final botGrid = botComp.miniGridPosition;
-      final botDistance = max(
-        (botGrid.x - playerGrid.x).abs(),
-        (botGrid.y - playerGrid.y).abs(),
-      );
-
-      if (botDistance <= _visualThreshold) {
-        nearbyPlayerIds.add(botId);
-        if (botDistance < closestDistance) closestDistance = botDistance;
-
-        if (!_playerBubbles.containsKey(botId)) {
-          final bubble = BotBubbleComponent();
-          bubble.position = botComp.position + _bubbleOffset;
-          _playerBubbles[botId] = bubble;
-          add(bubble);
-        }
-      }
-    }
-
-    // Show local player's bubble if near anyone
-    if (nearbyPlayerIds.isNotEmpty) {
-      if (!_playerBubbles.containsKey(_localPlayerBubbleKey)) {
-        final localBubble = _createLocalPlayerBubble();
-        localBubble.position = _userPlayerComponent.position + _bubbleOffset;
-        _playerBubbles[_localPlayerBubbleKey] = localBubble;
-        add(localBubble);
-      }
-      // Local bubble opacity matches the closest other player
-      _setBubbleOpacity(_playerBubbles[_localPlayerBubbleKey]!, closestDistance);
-      nearbyPlayerIds.add(_localPlayerBubbleKey);
-    }
-
-    // Remove bubbles for players no longer nearby
-    final toRemove = <String>[];
-    for (final playerId in _playerBubbles.keys) {
-      if (!nearbyPlayerIds.contains(playerId)) {
-        _playerBubbles[playerId]?.removeFromParent();
-        toRemove.add(playerId);
-      }
-    }
-    for (final playerId in toRemove) {
-      _playerBubbles.remove(playerId);
-    }
-
-    _updateBubblePositions(dt);
-  }
-
-  /// Apply opacity to a bubble component (works for both Video and Player types).
-  void _setBubbleOpacity(PositionComponent bubble, int distance) {
-    final opacity = ProximityService.calculateOpacity(distance);
-    if (bubble is VideoBubbleComponent) {
-      bubble.opacity = opacity;
-    } else if (bubble is PlayerBubbleComponent) {
-      bubble.opacity = opacity;
-    }
-    // BotBubbleComponent doesn't fade — it stays fully visible when in range
-  }
-
-  /// Enable or disable audio for a participant based on distance.
-  void _updateParticipantAudio(String playerId, int distance) {
-    final shouldHaveAudio = distance <= _audioThreshold;
-    final hasAudio = _audioEnabledParticipants.contains(playerId);
-
-    if (shouldHaveAudio && !hasAudio) {
-      _audioEnabledParticipants.add(playerId);
-      _liveKitService?.setParticipantAudioEnabled(playerId, true);
-    } else if (!shouldHaveAudio && hasAudio) {
-      _audioEnabledParticipants.remove(playerId);
-      _liveKitService?.setParticipantAudioEnabled(playerId, false);
-    }
-  }
-
-  // Physics repulsion constants
-  static const double _bubbleDiameter = 64.0;
-  static const double _maxTetherDistance = 24.0;
-  static const double _repulsionDamping = 0.85;
-
-  void _updateBubblePositions(double dt) {
-    // 1. Set base positions from owning characters.
-    for (final entry in _playerBubbles.entries) {
-      if (entry.key == _localPlayerBubbleKey) {
-        entry.value.position = _userPlayerComponent.position + _bubbleOffset;
-        entry.value.priority = _userPlayerComponent.priority + 1;
-      } else if (entry.key == _dreamfinderIdentity &&
-          _dreamfinderComponent != null) {
-        entry.value.position =
-            _dreamfinderComponent!.position + _bubbleOffset;
-        entry.value.priority = _dreamfinderComponent!.priority + 1;
-        // Pass avatar download progress to the bubble's loading spinner.
-        if (entry.value is VideoBubbleComponent) {
-          (entry.value as VideoBubbleComponent).loadingProgress =
-              _dreamfinderAvatarBridge?.avatarLoadProgress;
-        }
-      } else if (_botCharacterComponents.containsKey(entry.key)) {
-        final botComp = _botCharacterComponents[entry.key]!;
-        entry.value.position = botComp.position + _bubbleOffset;
-        entry.value.priority = botComp.priority + 1;
-      } else {
-        final playerComponent = _otherPlayerComponentsMap[entry.key];
-        if (playerComponent != null) {
-          entry.value.position = playerComponent.position + _bubbleOffset;
-          entry.value.priority = playerComponent.priority + 1;
-        }
-      }
-    }
-
-    // 2. Apply physics repulsion so bubbles don't overlap.
-    _applyBubbleRepulsion(dt);
-
-    // 3. Collect centres for the metaball field.
-    final centres = <Vector2>[];
-    int lowestPriority = 999;
-    for (final entry in _playerBubbles.entries) {
-      centres.add(entry.value.center);
-      if (entry.value.priority < lowestPriority) {
-        lowestPriority = entry.value.priority;
-      }
-    }
-
-    _updateBubbleField(centres, lowestPriority);
-    _updateMergedVideo(lowestPriority);
-  }
-
-  /// Detect merge groups and manage the merged video renderer.
-  void _updateMergedVideo(int lowestPriority) {
-    if (_mergedVideoShaderProgram == null) return;
-
-    // Find VideoBubbleComponents close enough to merge.
-    final videoBubbles = <String, VideoBubbleComponent>{};
-    for (final entry in _playerBubbles.entries) {
-      if (entry.value is VideoBubbleComponent) {
-        videoBubbles[entry.key] = entry.value as VideoBubbleComponent;
-      }
-    }
-
-    // Find the largest connected group within merge threshold.
-    final mergeGroup = _findMergeGroup(videoBubbles);
-
-    if (mergeGroup.length >= 2) {
-      // Lazily create the merged renderer.
-      if (_mergedBubble == null) {
-        _mergedBubble = MergedVideoBubbleComponent(
-          shaderProgram: _mergedVideoShaderProgram!,
-          glowColor: const Color(0xFF00FF88),
-          bubbleRadius: 32,
-        );
-        add(_mergedBubble!);
-      }
-
-      // Hide individual bubbles and feed their frames to the merged renderer.
-      final sources = <VideoBubbleComponent>[];
-      final positions = <Vector2>[];
-      for (final key in mergeGroup) {
-        final bubble = videoBubbles[key]!;
-        bubble.hiddenForMerge = true;
-        sources.add(bubble);
-        positions.add(bubble.center);
-      }
-
-      _mergedBubble!.priority = lowestPriority;
-      _mergedBubble!.updateSources(sources);
-      _mergedBubble!.updatePositions(positions);
-
-      // Un-hide any video bubbles NOT in the merge group.
-      for (final entry in videoBubbles.entries) {
-        if (!mergeGroup.contains(entry.key)) {
-          entry.value.hiddenForMerge = false;
-        }
-      }
-    } else {
-      // No merge — un-hide all and remove the merged renderer.
-      for (final bubble in videoBubbles.values) {
-        bubble.hiddenForMerge = false;
-      }
-      _mergedBubble?.removeFromParent();
-      _mergedBubble = null;
-    }
-  }
-
-  /// Find the largest connected group of video bubbles within merge distance.
-  List<String> _findMergeGroup(Map<String, VideoBubbleComponent> bubbles) {
-    if (bubbles.length < 2) return [];
-
-    final keys = bubbles.keys.toList();
-    final visited = <String>{};
-    List<String> largestGroup = [];
-
-    for (final startKey in keys) {
-      if (visited.contains(startKey)) continue;
-
-      // BFS from startKey.
-      final group = <String>[startKey];
-      final queue = <String>[startKey];
-      visited.add(startKey);
-
-      while (queue.isNotEmpty) {
-        final current = queue.removeAt(0);
-        final currentCenter = bubbles[current]!.center;
-
-        for (final candidateKey in keys) {
-          if (visited.contains(candidateKey)) continue;
-          final candidateCenter = bubbles[candidateKey]!.center;
-          final dist = currentCenter.distanceTo(candidateCenter);
-          if (dist < _mergeThreshold) {
-            visited.add(candidateKey);
-            group.add(candidateKey);
-            queue.add(candidateKey);
-          }
-        }
-      }
-
-      if (group.length > largestGroup.length) {
-        largestGroup = group;
-      }
-    }
-
-    return largestGroup.length >= 2
-        ? largestGroup.take(maxMergedBubbles).toList()
-        : [];
-  }
-
-  /// Pairwise spring repulsion — prevents bubble overlap.
-  ///
-  /// Each bubble accumulates a displacement that persists across frames
-  /// (damped). When two bubbles are closer than [_bubbleDiameter], they
-  /// push each other apart along the connecting line.
-  void _applyBubbleRepulsion(double dt) {
-    final entries = _playerBubbles.entries.toList();
-    if (entries.length < 2) return;
-
-    // Clean up stale displacements.
-    _bubbleDisplacements.removeWhere((k, _) => !_playerBubbles.containsKey(k));
-
-    // Accumulate repulsion forces.
-    final forces = <String, Vector2>{};
-    for (var i = 0; i < entries.length; i++) {
-      for (var j = i + 1; j < entries.length; j++) {
-        final ci = entries[i].value.center;
-        final cj = entries[j].value.center;
-        final delta = ci - cj;
-        final dist = delta.length;
-        if (dist < _bubbleDiameter && dist > 0.01) {
-          final overlap = _bubbleDiameter - dist;
-          final direction = delta.normalized();
-          // Force proportional to overlap, scaled by dt for frame-independence.
-          final clampedDt = min(dt, 0.05);
-          final push = direction * (overlap * 0.5 * clampedDt / 0.016);
-          forces[entries[i].key] =
-              (forces[entries[i].key] ?? Vector2.zero()) + push;
-          forces[entries[j].key] =
-              (forces[entries[j].key] ?? Vector2.zero()) - push;
-        }
-      }
-    }
-
-    // Apply forces + damping, then update positions.
-    for (final entry in entries) {
-      final key = entry.key;
-      var disp = _bubbleDisplacements[key] ?? Vector2.zero();
-      disp = disp * _repulsionDamping + (forces[key] ?? Vector2.zero());
-      if (disp.length > _maxTetherDistance) {
-        disp = disp.normalized() * _maxTetherDistance;
-      }
-      _bubbleDisplacements[key] = disp;
-      entry.value.position += disp;
-    }
-  }
-
-  /// Create, update, or remove the metaball field based on active bubbles.
-  void _updateBubbleField(List<Vector2> centres, int lowestPriority) {
-    if (centres.length < 2 || _metaballShaderProgram == null) {
-      // Not enough bubbles to merge — remove the field if it exists.
-      _bubbleField?.removeFromParent();
-      _bubbleField = null;
-      return;
-    }
-
-    // Lazily create the field component.
-    if (_bubbleField == null) {
-      _bubbleField = BubbleFieldComponent(
-        shaderProgram: _metaballShaderProgram!,
-        glowColor: const Color(0xFF00FF88),
-        bubbleRadius: 32,
-      );
-      add(_bubbleField!);
-    }
-
-    // Render just below the lowest bubble so glow appears behind video.
-    _bubbleField!.priority = lowestPriority - 1;
-    _bubbleField!.updateBubblePositions(centres);
-  }
-
-  PositionComponent _createBubbleForPlayer(
-      String playerId, PlayerComponent playerComponent) {
-    // Check if this player has a LiveKit participant with video
-    final participant = _liveKitService?.getParticipant(playerId);
-    if (participant != null && _hasVideoTrack(participant)) {
-      final videoBubble = VideoBubbleComponent(
-        participant: participant,
-        displayName: playerComponent.displayName,
-        bubbleSize: 64,
-        targetFps: 15,
-      );
-
-      // Apply shader if loaded
-      if (_shaderProgram != null) {
-        videoBubble.setShader(_shaderProgram!.fragmentShader());
-      }
-
-      return videoBubble;
-    }
-
-    // Fallback to static bubble
-    return PlayerBubbleComponent(
-      displayName: playerComponent.displayName,
-      playerId: playerId,
-    );
-  }
-
-  /// Initialize the Dreamfinder 3D avatar bridge (web only).
-  ///
-  /// Creates a hidden iframe that renders the Three.js avatar, then captures
-  /// frames from its canvas for display as a [VideoBubbleComponent] in the
-  /// Flame world. Also forwards audio and mood data channels to the iframe
-  /// for lip-sync and expression changes.
-  void _initDreamfinderAvatarBridge() {
-    if (_dreamfinderAvatarBridge != null) return;
-    final liveKit = _liveKitService;
-    if (liveKit == null) return;
-
-    _dreamfinderAvatarBridge =
-        DreamfinderAvatarBridge(liveKitService: liveKit);
-    _dreamfinderAvatarBridge!.initialize().then((_) {
-      if (_dreamfinderAvatarBridge?.isReady == true) {
-        _log.info('Dreamfinder avatar bridge ready — refreshing bubble');
-        _refreshBubbleForPlayer(_dreamfinderIdentity);
-      }
-    }).catchError((Object e) {
-      _log.warning('Dreamfinder avatar bridge failed to initialize: $e');
-    });
-  }
-
-  /// Create a [VideoBubbleComponent] configured for Dreamfinder's holographic
-  /// wizard projection (gold glow, 10fps for ethereal quality).
-  ///
-  /// If the 3D avatar bridge is active, uses its [CanvasCapture] as the frame
-  /// source instead of a LiveKit video track (which DF does not publish).
-  VideoBubbleComponent _createDreamfinderVideoBubble(
-      Participant participant) {
-    final videoBubble = VideoBubbleComponent(
-      participant: participant,
-      displayName: dreamfinderBot.displayName,
-      bubbleSize: 64,
-      targetFps: 10,
-      externalVideoCapture: _dreamfinderAvatarBridge?.canvasCapture,
-    );
-    videoBubble.glowColor = const Color(0xFFDAA520); // gold
-    videoBubble.glowIntensity = 0.7;
-    return videoBubble;
-  }
-
-  bool _hasVideoTrack(Participant participant) {
-    for (final publication in participant.videoTrackPublications) {
-      if (publication.track != null) {
-        // For local participant, check if track is published
-        // For remote participant, check if track is subscribed
-        if (participant is LocalParticipant) {
-          return true; // Local tracks are always "active" when present
-        } else {
-          if (publication.subscribed) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
-
-  /// Load the video bubble shader program
-  Future<void> _loadVideoBubbleShader() async {
-    try {
-      _shaderProgram =
-          await ui.FragmentProgram.fromAsset('shaders/video_bubble.frag');
-    } catch (e) {
-      // Shader loading failed - video bubbles will render without effects
-    }
-  }
-
-  /// Load the metaball field shader program.
-  Future<void> _loadMetaballShader() async {
-    try {
-      _metaballShaderProgram =
-          await ui.FragmentProgram.fromAsset('shaders/metaball_field.frag');
-    } catch (e) {
-      _log.warning('Metaball shader failed to load', e);
-    }
-  }
-
-  /// Load the merged video bubble shader program.
-  Future<void> _loadMergedVideoShader() async {
-    try {
-      _mergedVideoShaderProgram = await ui.FragmentProgram.fromAsset(
-          'shaders/merged_video_bubble.frag');
-    } catch (e) {
-      _log.warning('Merged video shader failed to load', e);
-    }
+    _bubbleManager.update(dt);
   }
 
   /// Listen for gameReady and process pending Dreamfinder participant.
@@ -933,7 +418,7 @@ class TechWorld extends World with TapCallbacks {
   /// Handle a participant joining the room
   void _handleParticipantJoined(RemoteParticipant participant) {
     _log.info('LiveKit participant joined: ${participant.identity}');
-    _refreshBubbleForPlayer(participant.identity);
+    _bubbleManager.refreshBubbleForPlayer(participant.identity);
 
     // Create component based on participant type
     if (isBotIdentity(participant.identity)) {
@@ -949,7 +434,7 @@ class TechWorld extends World with TapCallbacks {
         // PathComponent not ready yet (onLoad hasn't finished).
         // Defer until gameReady fires.
         _pendingDreamfinderParticipant = participant;
-        _dreamfinderIdentity = participant.identity;
+        _bubbleManager.dreamfinderIdentity = participant.identity;
         _waitForGameReady();
         return;
       }
@@ -959,7 +444,7 @@ class TechWorld extends World with TapCallbacks {
         // Dreamfinder — use DreamfinderComponent with idle behavior.
         // Update identity to match whatever the agent SDK assigned
         // (e.g. `agent-{jobId}` instead of `bot-dreamfinder`).
-        _dreamfinderIdentity = participant.identity;
+        _bubbleManager.dreamfinderIdentity = participant.identity;
         if (_dreamfinderComponent == null) {
           final dfComp = DreamfinderComponent(
             position: Vector2(
@@ -971,6 +456,7 @@ class TechWorld extends World with TapCallbacks {
             pathComponent: _pathComponent!,
           );
           _dreamfinderComponent = dfComp;
+          _bubbleManager.dreamfinderComponent = dfComp;
           add(dfComp);
 
           // If the local user is already connected, notice them.
@@ -979,7 +465,7 @@ class TechWorld extends World with TapCallbacks {
           }
 
           // Initialize the 3D avatar bridge (web only — loads iframe renderer).
-          _initDreamfinderAvatarBridge();
+          _bubbleManager.initDreamfinderBridge();
         }
       } else if (botConfig.spriteSheetAsset != null) {
         // Other animated bot — use PlayerComponent with sprite sheet.
@@ -1116,6 +602,7 @@ class TechWorld extends World with TapCallbacks {
     }
 
     _log.info('Using LiveKitService from Locator');
+    _bubbleManager.setLiveKitService(_liveKitService!);
 
     // Respond to bot map-info requests by sending the current map.
     _mapInfoRequestedSubscription =
@@ -1131,7 +618,7 @@ class TechWorld extends World with TapCallbacks {
       // Don't process our own position
       if (path.playerId == userId) return;
 
-      if (path.playerId == _dreamfinderIdentity &&
+      if (path.playerId == _bubbleManager.dreamfinderIdentity &&
           _dreamfinderComponent != null) {
         // Route Dreamfinder movement through its dedicated component.
         _dreamfinderComponent!
@@ -1184,9 +671,8 @@ class TechWorld extends World with TapCallbacks {
           _dreamfinderComponent != null) {
         remove(_dreamfinderComponent!);
         _dreamfinderComponent = null;
-        _dreamfinderIdentity = dreamfinderBot.identity; // reset to default
-        _dreamfinderAvatarBridge?.dispose();
-        _dreamfinderAvatarBridge = null;
+        _bubbleManager.dreamfinderComponent = null;
+        _bubbleManager.handleDreamfinderLeft();
       } else if (_botCharacterComponents.containsKey(participant.identity)) {
         final botComp = _botCharacterComponents.remove(participant.identity);
         if (botComp != null) remove(botComp);
@@ -1198,14 +684,13 @@ class TechWorld extends World with TapCallbacks {
         }
       }
 
-      final bubble = _playerBubbles.remove(participant.identity);
-      bubble?.removeFromParent();
+      _bubbleManager.removeBubble(participant.identity);
     });
 
     _speakingSubscription =
         _liveKitService!.speakingChanged.listen((event) {
       final (participant, isSpeaking) = event;
-      _updateBubbleSpeakingState(participant.identity, isSpeaking);
+      _bubbleManager.updateSpeakingState(participant.identity, isSpeaking);
     });
 
     // Listen for track subscription events to upgrade placeholder bubbles to video
@@ -1215,9 +700,9 @@ class TechWorld extends World with TapCallbacks {
       if (track.kind == TrackType.VIDEO) {
         _log.fine('Video track subscribed for ${participant.identity}, refreshing bubble');
         // This will upgrade PlayerBubbleComponent to VideoBubbleComponent
-        _refreshBubbleForPlayer(participant.identity);
+        _bubbleManager.refreshBubbleForPlayer(participant.identity);
       }
-      _notifyBubbleTrackReady(participant.identity);
+      _bubbleManager.notifyTrackReady(participant.identity);
     });
 
     // Listen for track unsubscription to downgrade video bubbles back to static
@@ -1228,7 +713,7 @@ class TechWorld extends World with TapCallbacks {
         _log.info(
             'Video track unsubscribed for ${participant.identity}, '
             'downgrading bubble');
-        _downgradeVideoBubble(participant.identity);
+        _bubbleManager.downgradeVideoBubble(participant.identity);
       }
     });
 
@@ -1263,7 +748,7 @@ class TechWorld extends World with TapCallbacks {
         _liveKitService!.localTrackPublished.listen((publication) {
       if (publication.kind == TrackType.VIDEO) {
         _log.fine('Local video track published, refreshing bubble');
-        _refreshLocalPlayerBubble();
+        _bubbleManager.refreshLocalPlayerBubble();
       }
     });
 
@@ -1272,7 +757,7 @@ class TechWorld extends World with TapCallbacks {
     // to keep media device management out of the game world layer.
     if (_liveKitService!.isConnected) {
       _log.fine('LiveKit already connected');
-      _refreshLocalPlayerBubble();
+      _bubbleManager.refreshLocalPlayerBubble();
 
       // Re-publish avatar so late joiners see our character
       if (_localAvatar != null) {
@@ -1281,162 +766,6 @@ class TechWorld extends World with TapCallbacks {
     } else {
       _log.fine('Waiting for LiveKit connection...');
     }
-  }
-
-  /// Refresh a player's bubble (recreate if video is now available)
-  void _refreshBubbleForPlayer(String playerId) {
-    // Handle Dreamfinder separately — it uses DreamfinderComponent, not
-    // PlayerComponent. When a video track arrives, upgrade its static
-    // BotBubbleComponent to a VideoBubbleComponent (holographic wizard).
-    if (isDreamfinderIdentity(playerId) &&
-        _dreamfinderComponent != null) {
-      final existingBubble = _playerBubbles[playerId];
-      final dfParticipant =
-          _liveKitService?.getParticipant(_dreamfinderIdentity);
-      if (dfParticipant == null) return;
-
-      // Recreate the bubble if:
-      // - It's not a VideoBubbleComponent yet (initial placeholder), OR
-      // - It's a VideoBubbleComponent without canvas capture but the bridge
-      //   is now ready (bridge initialized after the bubble was created).
-      final hasCanvasCapture = existingBubble is VideoBubbleComponent &&
-          existingBubble.externalVideoCapture != null;
-      final needsUpgrade = existingBubble is! VideoBubbleComponent ||
-          (!hasCanvasCapture && _dreamfinderAvatarBridge?.isReady == true);
-
-      if (needsUpgrade) {
-        existingBubble?.removeFromParent();
-        final videoBubble = _createDreamfinderVideoBubble(dfParticipant);
-        videoBubble.position =
-            _dreamfinderComponent!.position + _bubbleOffset;
-        _playerBubbles[playerId] = videoBubble;
-        add(videoBubble);
-      }
-      return;
-    }
-
-    final existingBubble = _playerBubbles[playerId];
-    if (existingBubble == null) return; // No bubble to refresh
-
-    // If it's already a video bubble, no need to refresh
-    if (existingBubble is VideoBubbleComponent) return;
-
-    // Get player component
-    final playerComponent = _otherPlayerComponentsMap[playerId];
-    if (playerComponent == null) return;
-
-    // Remove old bubble
-    existingBubble.removeFromParent();
-
-    // Create new bubble (might be video bubble now)
-    final newBubble = _createBubbleForPlayer(playerId, playerComponent);
-    newBubble.position = playerComponent.position + _bubbleOffset;
-    _playerBubbles[playerId] = newBubble;
-    add(newBubble);
-  }
-
-  /// Downgrade a video bubble back to a static placeholder when the video
-  /// track is unsubscribed. Without this, dead [VideoBubbleComponent]s
-  /// accumulate and continue attempting frame capture on stale tracks.
-  void _downgradeVideoBubble(String playerId) {
-    final existingBubble = _playerBubbles[playerId];
-    if (existingBubble == null) return;
-
-    // Only downgrade if it's currently a video bubble
-    if (existingBubble is! VideoBubbleComponent) return;
-
-    final position = existingBubble.position.clone();
-    existingBubble.removeFromParent();
-
-    // Dreamfinder gets a BotBubbleComponent, others get PlayerBubbleComponent
-    if (isDreamfinderIdentity(playerId)) {
-      final botBubble = BotBubbleComponent(bubbleSize: 64);
-      botBubble.position = position;
-      _playerBubbles[playerId] = botBubble;
-      add(botBubble);
-    } else {
-      final playerComponent = _otherPlayerComponentsMap[playerId];
-      if (playerComponent != null) {
-        final newBubble = PlayerBubbleComponent(
-          displayName: playerComponent.displayName,
-          playerId: playerId,
-        );
-        newBubble.position = position;
-        _playerBubbles[playerId] = newBubble;
-        add(newBubble);
-      } else {
-        // Player component already removed — just clean up the bubble entry
-        _playerBubbles.remove(playerId);
-      }
-    }
-  }
-
-  /// Refresh local player bubble (recreate if video is now available)
-  void _refreshLocalPlayerBubble() {
-    final existingBubble = _playerBubbles[_localPlayerBubbleKey];
-    if (existingBubble == null) return; // No bubble to refresh
-
-    // If it's already a video bubble, no need to refresh
-    if (existingBubble is VideoBubbleComponent) return;
-
-    _log.fine('Refreshing local player bubble after camera enabled');
-
-    // Remove old bubble
-    existingBubble.removeFromParent();
-
-    // Create new bubble (should be video bubble now)
-    final newBubble = _createLocalPlayerBubble();
-    newBubble.position = _userPlayerComponent.position + _bubbleOffset;
-    _playerBubbles[_localPlayerBubbleKey] = newBubble;
-    add(newBubble);
-  }
-
-  /// Update speaking state on video bubbles
-  void _updateBubbleSpeakingState(String participantId, bool isSpeaking) {
-    final bubble = _playerBubbles[participantId];
-    if (bubble is VideoBubbleComponent) {
-      bubble.speakingLevel = isSpeaking ? 1.0 : 0.0;
-    }
-  }
-
-  /// Notify a video bubble that its track is ready for capture
-  void _notifyBubbleTrackReady(String participantId) {
-    final bubble = _playerBubbles[participantId];
-    if (bubble is VideoBubbleComponent) {
-      _log.fine('Notifying bubble track ready for $participantId');
-      bubble.notifyTrackReady();
-    }
-  }
-
-  /// Create bubble for local player (video if available, otherwise static)
-  PositionComponent _createLocalPlayerBubble() {
-    final localParticipant = _liveKitService?.localParticipant;
-
-    if (localParticipant != null && _hasVideoTrack(localParticipant)) {
-      _log.fine('Creating local VideoBubbleComponent');
-      final videoBubble = VideoBubbleComponent(
-        participant: localParticipant,
-        displayName: _userPlayerComponent.displayName,
-        bubbleSize: 64,
-        targetFps: 15,
-      );
-
-      // Apply shader if loaded
-      if (_shaderProgram != null) {
-        videoBubble.setShader(_shaderProgram!.fragmentShader());
-      }
-
-      // Local player gets a cyan glow
-      videoBubble.glowColor = Colors.cyan;
-
-      return videoBubble;
-    }
-
-    // Fallback to static bubble
-    return PlayerBubbleComponent(
-      displayName: _userPlayerComponent.displayName,
-      playerId: _userPlayerComponent.id,
-    );
   }
 
   @override
@@ -1464,12 +793,8 @@ class TechWorld extends World with TapCallbacks {
     final game = findGame() as TechWorldGame?;
     game?.camera.follow(_userPlayerComponent);
 
-    // Load shaders
-    await Future.wait([
-      _loadVideoBubbleShader(),
-      _loadMetaballShader(),
-      _loadMergedVideoShader(),
-    ]);
+    // Load bubble shaders (BubbleManager created in constructor).
+    await _bubbleManager.loadShaders();
 
     gameReady.value = true;
 
@@ -2071,24 +1396,11 @@ class TechWorld extends World with TapCallbacks {
     // Clear pending avatar data
     _pendingAvatars.clear();
 
-    // Clear the service reference so _connectToLiveKit can reconnect
+    // Clear the service reference so connectToLiveKit can reconnect.
     _liveKitService = null;
 
-    // Clean up avatar bridge
-    _dreamfinderAvatarBridge?.dispose();
-    _dreamfinderAvatarBridge = null;
-
-    // Remove all player bubbles
-    for (final bubble in _playerBubbles.values) {
-      bubble.removeFromParent();
-    }
-    _playerBubbles.clear();
-    _bubbleDisplacements.clear();
-    _bubbleField?.removeFromParent();
-    _bubbleField = null;
-    _mergedBubble?.removeFromParent();
-    _mergedBubble = null;
-    _audioEnabledParticipants.clear();
+    // Clear all bubble state (bridge, shaders survive in BubbleManager).
+    _bubbleManager.clear();
 
     // Remove other player components
     for (final component in _otherPlayerComponentsMap.values) {
@@ -2102,9 +1414,8 @@ class TechWorld extends World with TapCallbacks {
     }
     _botCharacterComponents.clear();
 
-    // Reset position tracking
-    _lastPlayerGridPosition = null;
-    _dreamfinderIdentity = dreamfinderBot.identity;
+    // Reset position tracking.
+    _lastKnownPlayerGrid = null;
   }
 
   void dispose() {
@@ -2115,5 +1426,6 @@ class TechWorld extends World with TapCallbacks {
     currentMap.dispose();
     nearbyLockedDoor.dispose();
     disconnectFromLiveKit();
+    _bubbleManager.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -398,15 +398,7 @@ class _MyAppState extends State<MyApp> {
             wires.complete(Wire.camera);
             wires.complete(Wire.chat);
             _liveKitConnectionFailed = true;
-            _connectionFailureMessage = switch (result) {
-              ConnectionResult.tokenAuthError =>
-                'Session expired — please sign in again',
-              ConnectionResult.tokenNetworkError =>
-                'Could not reach server — check your connection',
-              ConnectionResult.roomFailed =>
-                'Room connection failed — try again later',
-              _ => 'Video & chat unavailable — connection failed',
-            };
+            _connectionFailureMessage = _failureMessageFor(result);
           } else {
             wires.complete(Wire.server);
             wires.complete(Wire.camera);
@@ -503,15 +495,7 @@ class _MyAppState extends State<MyApp> {
       await _chatService!.loadHistory(roomId);
     } else if (result != ConnectionResult.alreadyConnected) {
       _liveKitConnectionFailed = true;
-      _connectionFailureMessage = switch (result) {
-        ConnectionResult.tokenAuthError =>
-          'Session expired — please sign in again',
-        ConnectionResult.tokenNetworkError =>
-          'Could not reach server — check your connection',
-        ConnectionResult.roomFailed =>
-          'Room connection failed — try again later',
-        _ => 'Video & chat unavailable — connection failed',
-      };
+      _connectionFailureMessage = _failureMessageFor(result);
     }
 
     // Apply saved avatar to game world.
@@ -519,6 +503,20 @@ class _MyAppState extends State<MyApp> {
       locate<TechWorld>().setLocalAvatar(_selectedAvatar!);
     }
   }
+
+  /// Map a [ConnectionResult] failure code to a user-visible error message.
+  ///
+  /// Does not handle [ConnectionResult.connected] or
+  /// [ConnectionResult.alreadyConnected] — callers must guard against those
+  /// before invoking this helper.
+  String _failureMessageFor(ConnectionResult result) => switch (result) {
+    ConnectionResult.tokenAuthError =>
+      'Session expired — please sign in again',
+    ConnectionResult.tokenNetworkError =>
+      'Could not reach server — check your connection',
+    ConnectionResult.roomFailed => 'Room connection failed — try again later',
+    _ => 'Video & chat unavailable — connection failed',
+  };
 
   /// Leave the current room — disconnect LiveKit and return to lobby.
   ///

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -23,6 +23,8 @@ import 'package:tech_world/flame/shared/direction.dart';
 import 'package:tech_world/flame/shared/player_path.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
+
+Future<void> pumpEventQueue() => Future<void>.delayed(Duration.zero);
 void main() {
   group('ChatService', () {
     late FakeLiveKitService fakeLiveKit;
@@ -56,7 +58,7 @@ void main() {
       unawaited(chatService.sendMessage('Hello bot'));
 
       // Give it time to process
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(chatService.currentMessages.length, equals(1));
       expect(chatService.currentMessages.first.text, equals('Hello bot'));
@@ -67,7 +69,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Test message'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(fakeLiveKit.publishedMessages.length, equals(1));
 
@@ -88,7 +90,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(botStatusNotifier.value, equals(BotStatus.thinking));
     });
@@ -97,7 +99,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Simulate bot response
       final messageId = fakeLiveKit.publishedMessages.first['payload']['id'];
@@ -106,7 +108,7 @@ void main() {
         'messageId': messageId,
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(chatService.currentMessages.length, equals(2));
       expect(chatService.currentMessages.last.text, equals('Hello human!'));
@@ -117,7 +119,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       final messageId = fakeLiveKit.publishedMessages.first['payload']['id'];
       fakeLiveKit.simulateResponse({
@@ -125,7 +127,7 @@ void main() {
         'messageId': messageId,
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(botStatusNotifier.value, equals(BotStatus.idle));
     });
@@ -150,7 +152,7 @@ void main() {
       chatService.messages.listen(messages.add);
 
       unawaited(chatService.sendMessage('Test'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(messages.length, greaterThan(0));
       expect(messages.last.first.text, equals('Test'));
@@ -160,12 +162,12 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Send invalid response (not JSON)
       fakeLiveKit.simulateInvalidResponse('not json at all');
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should only have user message, no bot response
       expect(chatService.currentMessages.length, equals(1));
@@ -176,7 +178,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       final messageId = fakeLiveKit.publishedMessages.first['payload']['id'];
       // Response missing 'text' field
@@ -185,7 +187,7 @@ void main() {
         'notText': 'wrong field',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should only have user message
       expect(chatService.currentMessages.length, equals(1));
@@ -195,14 +197,14 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Response without messageId - should still add message
       fakeLiveKit.simulateResponse({
         'text': 'Response without ID',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(chatService.currentMessages.length, equals(2));
       expect(chatService.currentMessages.last.text, equals('Response without ID'));
@@ -212,14 +214,14 @@ void main() {
       fakeLiveKit.connected = true;
 
       unawaited(chatService.sendMessage('Hello'));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Send message with wrong topic
       fakeLiveKit.simulateMessageWithTopic('other-topic', {
         'text': 'Should be ignored',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should only have user message
       expect(chatService.currentMessages.length, equals(1));
@@ -230,7 +232,7 @@ void main() {
 
       // Should not throw after dispose
       fakeLiveKit.simulateResponse({'text': 'After dispose'});
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
     });
 
     test('deduplicates messages with same id', () async {
@@ -242,7 +244,7 @@ void main() {
         'id': 'msg-123',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // First message should be added
       expect(chatService.currentMessages.length, equals(1));
@@ -253,7 +255,7 @@ void main() {
         'id': 'msg-123',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should still be only 1 message (duplicate filtered)
       expect(chatService.currentMessages.length, equals(1));
@@ -269,7 +271,7 @@ void main() {
         'senderName': 'Other User',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(chatService.currentMessages.length, equals(1));
       expect(chatService.currentMessages.first.text, equals('Hello from another user'));
@@ -288,7 +290,7 @@ void main() {
         'senderName': 'Test User',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should be ignored (we add our own messages locally)
       expect(chatService.currentMessages, isEmpty);
@@ -304,7 +306,7 @@ void main() {
         // No senderName field
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       expect(chatService.currentMessages.length, equals(1));
       // Should use senderId as fallback
@@ -318,7 +320,7 @@ void main() {
       final sendFuture = chatService.sendMessage('Hello');
 
       // Give it time to publish the message
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Get the message ID that was published
       final messageId = fakeLiveKit.publishedMessages.first['payload']['id'];
@@ -346,7 +348,7 @@ void main() {
         'messageId': 'non-existent-id',
       });
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Should still add the message (it's a valid response)
       expect(chatService.currentMessages.length, equals(1));
@@ -356,7 +358,7 @@ void main() {
       fakeLiveKit.connected = true;
 
       final sendFuture = chatService.sendMessage('Check my code');
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       final messageId = fakeLiveKit.publishedMessages.first['payload']['id'];
       fakeLiveKit.simulateResponse({
@@ -381,7 +383,7 @@ void main() {
         'My solution',
         metadata: {'challengeId': 'hello_dart'},
       ));
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       final payload =
           fakeLiveKit.publishedMessages.first['payload'] as Map<String, dynamic>;
@@ -402,7 +404,7 @@ void main() {
       // when no response arrives but we manually trigger timeout
       // behavior, the method returns null.
 
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Simulate a timeout by completing the message without a response
       // (we can't easily test 30s timeout, but we can verify null on disconnect)
@@ -431,7 +433,7 @@ void main() {
         fakeLiveKit.connected = true;
 
         await chatService.sendDm('peer-uid', 'Hey there!', peerDisplayName: 'Peer');
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         expect(fakeLiveKit.publishedMessages.length, equals(1));
 
@@ -451,7 +453,7 @@ void main() {
         fakeLiveKit.connected = true;
 
         await chatService.sendDm('peer-uid', 'Hello', peerDisplayName: 'Peer');
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -475,7 +477,7 @@ void main() {
           'senderId': 'alice-uid',
         });
 
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -495,7 +497,7 @@ void main() {
           'senderId': 'alice-uid',
         });
 
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -517,7 +519,7 @@ void main() {
           'senderId': 'alice-uid',
         });
 
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -542,7 +544,7 @@ void main() {
           'senderName': 'Alice',
           'senderId': 'alice-uid',
         });
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         // DM from Bob
         fakeLiveKit.simulateDm('bob-uid', {
@@ -551,7 +553,7 @@ void main() {
           'senderName': 'Bob',
           'senderId': 'bob-uid',
         });
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         expect(chatService.totalUnreadNotifier.value, equals(2));
       });
@@ -561,7 +563,7 @@ void main() {
 
         await chatService.sendDm('peer-uid', 'First', peerDisplayName: 'Peer');
         await chatService.sendDm('peer-uid', 'Second', peerDisplayName: 'Peer');
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -614,7 +616,7 @@ void main() {
           'senderId': 'alice-uid',
         });
 
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         expect(dmMsgs.length, greaterThan(0));
         expect(dmMsgs.last.first.text, equals('Hello via DM'));
@@ -634,7 +636,7 @@ void main() {
           'senderId': 'alice-uid',
         });
 
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         expect(convSnapshots.length, greaterThan(0));
         expect(convSnapshots.last.length, greaterThanOrEqualTo(2)); // group + DM
@@ -645,7 +647,7 @@ void main() {
 
         // First send a DM to the bot to create the conversation
         await chatService.sendDm('bot-claude', 'Help me', peerDisplayName: 'Clawd');
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         // Simulate bot DM response
         fakeLiveKit.simulateDmResponse('bot-claude', {
@@ -654,7 +656,7 @@ void main() {
           'senderName': 'Clawd',
           'senderId': 'bot-claude',
         });
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         final expectedConvId = Conversation.conversationIdFor(
           'test-user-id',
@@ -740,7 +742,7 @@ void main() {
         fakeLiveKit.connected = true;
         botStatusNotifier.value = BotStatus.idle;
         unawaited(service.sendMessage('Hello after failed history'));
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         expect(service.currentMessages.length, equals(1));
         expect(service.currentMessages.first.text,

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -1,0 +1,395 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tech_world/flame/bubble_manager.dart';
+import 'package:tech_world/flame/components/bot_bubble_component.dart';
+import 'package:tech_world/flame/components/bot_character_component.dart';
+import 'package:tech_world/flame/components/player_bubble_component.dart';
+import 'package:tech_world/flame/components/player_component.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+
+class MockLiveKitService extends Mock implements LiveKitService {}
+
+void main() {
+  group('BubbleManager', () {
+    group('chebyshevDistance', () {
+      test('returns max of x and y difference', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(0, 0), const Point(3, 4)),
+          equals(4),
+        );
+      });
+
+      test('returns 0 for identical points', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(5, 5), const Point(5, 5)),
+          equals(0),
+        );
+      });
+
+      test('handles negative coordinates', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(-2, 3), const Point(1, 0)),
+          equals(3),
+        );
+      });
+
+      test('is symmetric', () {
+        const a = Point(1, 7);
+        const b = Point(4, 2);
+        expect(
+          BubbleManager.chebyshevDistance(a, b),
+          equals(BubbleManager.chebyshevDistance(b, a)),
+        );
+      });
+
+      test('returns x distance when y is 0', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(0, 0), const Point(7, 0)),
+          equals(7),
+        );
+      });
+
+      test('returns y distance when x is 0', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(0, 0), const Point(0, 3)),
+          equals(3),
+        );
+      });
+
+      test('adjacent diagonal is distance 1', () {
+        expect(
+          BubbleManager.chebyshevDistance(
+              const Point(0, 0), const Point(1, 1)),
+          equals(1),
+        );
+      });
+    });
+
+    group('update — bubble lifecycle', () {
+      late BubbleManager manager;
+      late PlayerComponent localPlayer;
+      late Map<String, PlayerComponent> remotePlayers;
+      late Map<String, BotCharacterComponent> bots;
+      late List<Component> addedComponents;
+
+      setUp(() {
+        addedComponents = [];
+        localPlayer = PlayerComponent(
+          position: Vector2(160, 160), // grid (5, 5) assuming 32px squares
+          id: 'local-user',
+          displayName: 'Local',
+        );
+        remotePlayers = {};
+        bots = {};
+
+        manager = BubbleManager(
+          localPlayer: localPlayer,
+          addComponent: addedComponents.add,
+          remotePlayers: remotePlayers,
+          bots: bots,
+        );
+      });
+
+      test('creates bubble for nearby remote player', () {
+        // Place remote player 3 grid squares away (within visual threshold)
+        final remote = PlayerComponent(
+          position: Vector2(256, 160), // grid (8, 5) — 3 away on x
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+
+        manager.update(0.016);
+
+        // Should create 2 bubbles: one for remote, one for local
+        expect(addedComponents.length, equals(2));
+        expect(
+          addedComponents.whereType<PlayerBubbleComponent>().length,
+          equals(2),
+        );
+      });
+
+      test('does not create bubble for distant remote player', () {
+        // Place remote player 10 grid squares away (beyond threshold)
+        final remote = PlayerComponent(
+          position: Vector2(480, 160), // grid (15, 5) — 10 away
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+
+        manager.update(0.016);
+
+        expect(addedComponents, isEmpty);
+      });
+
+      test('creates bot bubble for nearby bot', () {
+        final bot = BotCharacterComponent(
+          position: Vector2(192, 160), // grid (6, 5) — 1 away
+          id: 'bot-claude',
+          displayName: 'Clawd',
+        );
+        bots['bot-claude'] = bot;
+
+        manager.update(0.016);
+
+        // Bot bubble + local player bubble
+        expect(addedComponents.length, equals(2));
+        expect(
+          addedComponents.whereType<BotBubbleComponent>().length,
+          equals(1),
+        );
+      });
+
+      test('skips proximity re-evaluation on same grid position', () {
+        final remote = PlayerComponent(
+          position: Vector2(256, 160),
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+
+        // First update creates bubbles
+        manager.update(0.016);
+        final initialCount = addedComponents.length;
+
+        // Second update at same position — no new bubbles
+        manager.update(0.016);
+        expect(addedComponents.length, equals(initialCount));
+      });
+    });
+
+    group('audio threshold', () {
+      late BubbleManager manager;
+      late MockLiveKitService mockLiveKit;
+      late PlayerComponent localPlayer;
+      late Map<String, PlayerComponent> remotePlayers;
+
+      setUp(() {
+        mockLiveKit = MockLiveKitService();
+        localPlayer = PlayerComponent(
+          position: Vector2(160, 160),
+          id: 'local-user',
+          displayName: 'Local',
+        );
+        remotePlayers = {};
+
+        manager = BubbleManager(
+          localPlayer: localPlayer,
+          addComponent: (_) {},
+          remotePlayers: remotePlayers,
+          bots: {},
+        );
+        manager.setLiveKitService(mockLiveKit);
+      });
+
+      test('enables audio within threshold', () {
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+
+        // Place player 2 squares away (at audio threshold)
+        remotePlayers['remote-1'] = PlayerComponent(
+          position: Vector2(224, 160), // 2 away
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+
+        manager.update(0.016);
+
+        verify(() =>
+                mockLiveKit.setParticipantAudioEnabled('remote-1', true))
+            .called(1);
+      });
+
+      test('disables audio beyond threshold', () {
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+
+        // Place player 4 squares away (beyond audio threshold)
+        remotePlayers['remote-1'] = PlayerComponent(
+          position: Vector2(288, 160), // 4 away
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+
+        manager.update(0.016);
+
+        verifyNever(() =>
+            mockLiveKit.setParticipantAudioEnabled('remote-1', true));
+      });
+    });
+
+    group('clear', () {
+      late BubbleManager manager;
+      late List<Component> addedComponents;
+      late Map<String, PlayerComponent> remotePlayers;
+
+      setUp(() {
+        addedComponents = [];
+        remotePlayers = {};
+        manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2(160, 160),
+            id: 'local-user',
+            displayName: 'Local',
+          ),
+          addComponent: addedComponents.add,
+          remotePlayers: remotePlayers,
+          bots: {},
+        );
+      });
+
+      test('removes all bubbles and resets state', () {
+        // Create some bubbles
+        remotePlayers['remote-1'] = PlayerComponent(
+          position: Vector2(192, 160),
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        manager.update(0.016);
+        expect(addedComponents, isNotEmpty);
+
+        // Clear everything
+        manager.clear();
+
+        // After clear, a new update with a different position should
+        // not carry over stale state.
+        addedComponents.clear();
+        remotePlayers.remove('remote-1');
+        manager.update(0.016);
+        expect(addedComponents, isEmpty);
+      });
+
+      test('is idempotent', () {
+        manager.clear();
+        manager.clear(); // Should not throw
+      });
+    });
+
+    group('removeBubble', () {
+      late BubbleManager manager;
+      late List<Component> addedComponents;
+      late Map<String, PlayerComponent> remotePlayers;
+
+      setUp(() {
+        addedComponents = [];
+        remotePlayers = {};
+        manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2(160, 160),
+            id: 'local-user',
+            displayName: 'Local',
+          ),
+          addComponent: addedComponents.add,
+          remotePlayers: remotePlayers,
+          bots: {},
+        );
+      });
+
+      test('no-op for non-existent player', () {
+        manager.removeBubble('nonexistent');
+        // Should not throw
+      });
+    });
+
+    group('updateSpeakingState', () {
+      test('no-op when no bubble exists', () {
+        final manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2.zero(),
+            id: 'local',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+
+        // Should not throw
+        manager.updateSpeakingState('nonexistent', true);
+      });
+    });
+
+    group('notifyTrackReady', () {
+      test('no-op when no bubble exists', () {
+        final manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2.zero(),
+            id: 'local',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+
+        // Should not throw
+        manager.notifyTrackReady('nonexistent');
+      });
+    });
+
+    group('refreshBubbleForPlayer', () {
+      test('no-op when no bubble exists for player', () {
+        final manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2.zero(),
+            id: 'local',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+
+        // Should not throw
+        manager.refreshBubbleForPlayer('nonexistent');
+      });
+    });
+
+    group('refreshLocalPlayerBubble', () {
+      test('no-op when no local bubble exists', () {
+        final manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2.zero(),
+            id: 'local',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+
+        // Should not throw
+        manager.refreshLocalPlayerBubble();
+      });
+    });
+
+    group('downgradeVideoBubble', () {
+      test('no-op when no bubble exists', () {
+        final manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2.zero(),
+            id: 'local',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+
+        // Should not throw
+        manager.downgradeVideoBubble('nonexistent');
+      });
+    });
+  });
+}

--- a/test/flame/tech_world_auth_test.dart
+++ b/test/flame/tech_world_auth_test.dart
@@ -6,6 +6,8 @@ import 'package:tech_world/flame/tech_world.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/utils/locator.dart';
 
+
+Future<void> pumpEventQueue() => Future<void>.delayed(Duration.zero);
 void main() {
   group('TechWorld auth state handling', () {
     late StreamController<AuthUser> authController;
@@ -26,12 +28,12 @@ void main() {
       // First sign in
       final user1 = AuthUser(id: 'user1', displayName: 'User 1');
       authController.add(user1);
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // Sign out
       final signedOut = SignedOutUser(id: 'user1', displayName: 'User 1');
       authController.add(signedOut);
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // The internal _liveKitService should be null now
       // We can't access it directly, but we can verify by signing in again
@@ -47,7 +49,7 @@ void main() {
 
       final user2 = AuthUser(id: 'user2', displayName: 'User 2');
       authController.add(user2);
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // If the bug exists, TechWorld would still hold the old service reference
       // and _connectToLiveKit would return early without setting up subscriptions.
@@ -68,13 +70,13 @@ void main() {
       // Sign in
       final user1 = AuthUser(id: 'user1', displayName: 'User 1');
       authController.add(user1);
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // Sign out
       Locator.remove<LiveKitService>();
       service1.dispose();
       authController.add(SignedOutUser(id: 'user1', displayName: 'User 1'));
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // Create second service (simulates what main.dart does on re-sign-in)
       final service2 = LiveKitService(
@@ -87,7 +89,7 @@ void main() {
       // Sign in again
       final user2 = AuthUser(id: 'user2', displayName: 'User 2');
       authController.add(user2);
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // Verify we can interact with the new service
       // (this would fail if TechWorld held onto the old disposed service)
@@ -108,13 +110,13 @@ void main() {
 
         // Sign in
         authController.add(AuthUser(id: 'user$i', displayName: 'User $i'));
-        await Future.delayed(const Duration(milliseconds: 30));
+        await pumpEventQueue();
 
         // Sign out
         Locator.remove<LiveKitService>();
         service.dispose();
         authController.add(SignedOutUser(id: 'user$i', displayName: 'User $i'));
-        await Future.delayed(const Duration(milliseconds: 30));
+        await pumpEventQueue();
       }
 
       // Final sign in should work
@@ -126,7 +128,7 @@ void main() {
       Locator.add<LiveKitService>(finalService);
 
       authController.add(AuthUser(id: 'final', displayName: 'Final User'));
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       expect(finalService.userId, equals('final'));
       finalService.dispose();
@@ -135,7 +137,7 @@ void main() {
     test('PlaceholderUser does not trigger connection', () async {
       // Send placeholder (initial state)
       authController.add(PlaceholderUser());
-      await Future.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
 
       // No service should be accessed because PlaceholderUser is ignored
       // This should not throw even without a service registered

--- a/test/flame/tech_world_integration_test.dart
+++ b/test/flame/tech_world_integration_test.dart
@@ -36,6 +36,8 @@ class TestGameWithMockImages extends TechWorldGame {
   }
 }
 
+
+Future<void> pumpEventQueue() => Future<void>.delayed(Duration.zero);
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -184,7 +186,7 @@ void main() {
         ));
 
         // Allow async processing
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Player ID should be updated
         expect(world.localPlayerId, equals('test-user-123'));
@@ -225,11 +227,11 @@ void main() {
           id: 'user-1',
           displayName: 'User One',
         ));
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Then sign out
         authController.add(SignedOutUser(id: 'user-1', displayName: 'User One'));
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Should handle gracefully
         expect(world.isMounted, isTrue);

--- a/test/integration/service_lifecycle_test.dart
+++ b/test/integration/service_lifecycle_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
 
+
+Future<void> pumpEventQueue() => Future<void>.delayed(Duration.zero);
 void main() {
   group('Service lifecycle', () {
     group('LiveKitService connect/disconnect/reconnect', () {
@@ -61,7 +63,7 @@ void main() {
 
         // Start first connection (will hang on token retrieval).
         unawaited(hangingService.connect());
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         // Second call should return immediately.
         final result = await hangingService.connect();


### PR DESCRIPTION
## Summary

- Extract ~730 lines of bubble lifecycle management from TechWorld (2081→1392 lines, -33%) into a dedicated `BubbleManager` class
- BubbleManager is a plain Dart class (not a Flame Component) that owns proximity detection, physics repulsion, metaball/merged video rendering, audio threshold management, shader loading, and Dreamfinder avatar bridge lifecycle
- Adds `static chebyshevDistance()` replacing 3 inline computations
- Adds 21 unit tests for the new class

## Design decisions

- **Shared map references** — `remotePlayers` and `bots` are the same Map objects TechWorld mutates; BubbleManager reads them without per-frame parameter passing
- **Callback injection** — `addComponent: add` keeps Flame component tree ownership in TechWorld
- **Constructor init** — BubbleManager created in TechWorld constructor (not `onLoad`) so `dispose()` is safe without mounting
- **`dreamfinderIdentity`** — public mutable field on BubbleManager; TechWorld sets it on join/leave, reads it for position routing

## Test plan

- [x] `flutter analyze --fatal-infos` — zero issues
- [x] `flutter test` — 1441 tests pass (21 new)
- [x] No behavior change — pure extract-class refactor
- [ ] Manual test: run on macOS, verify bubbles appear/disappear/merge with 2+ participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)