### PR TITLE
ci: enable test workflow for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ permissions:
   pull-requests: write
 jobs:
   changes:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
@@ -69,4 +68,3 @@ jobs:
           minimum-coverage: 50
           github-token: ${{ secrets.GITHUB_TOKEN }}
           update-comment: true
-


### PR DESCRIPTION
## Summary

- Remove the same-repo restriction from `test.yml` so CI runs on PRs from the fork
- The upstream workflow has `if: github.event.pull_request.head.repo.full_name == github.repository` which skips all fork PRs
- This is a 2-line deletion — no logic changes to the workflow itself

## Why

Without this, none of Robin's audit PRs get CI feedback. The `REVIEW_REQUIRED` branch protection on upstream means PRs sit blocked with no automated verification.

## Test plan

- [x] Workflow syntax valid (identical to upstream minus the restriction)
- [ ] Verify CI triggers on a subsequent PR to this fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)