### PR TITLE
Reset Dreamfinder server-controlled flag after movement completes

### DIFF
--- a/lib/flame/components/dreamfinder_component.dart
+++ b/lib/flame/components/dreamfinder_component.dart
@@ -309,6 +309,11 @@ class DreamfinderComponent
         current = DreamfinderState.idle;
         playing = false;
         _wanderCooldown = _postGreetingDelay;
+      } else if (_serverControlled) {
+        _serverControlled = false;
+        current = DreamfinderState.working;
+        playing = true;
+        _resetWanderCooldown();
       } else {
         current = DreamfinderState.idle;
         playing = false;


### PR DESCRIPTION
## Summary
- `_serverControlled` was set to `true` by `moveFromServer()` but never reset to `false`
- Once the server sent a position update, autonomous behavior (wandering, noticing players) permanently stopped because the `update()` loop checks `!_serverControlled` before ticking the wander cooldown
- Added a branch in `_addNextMoveEffect()` to reset `_serverControlled = false` when the server-directed movement path is exhausted, transitioning back to `working` state with a fresh wander cooldown

## Test plan
- [ ] Verify Dreamfinder resumes wandering after a server-directed movement completes
- [ ] Verify Dreamfinder still responds to `moveFromServer()` calls during autonomous wandering
- [ ] Verify `noticePlayer()` still works after server-controlled movement

Phase 2 audit finding P2-D1 (Low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)