### PR TITLE
Reset BotStatus to absent when leaving a room

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -528,6 +528,9 @@ class _MyAppState extends State<MyApp> {
   Future<void> _leaveRoom() async {
     if (_currentRoom == null) return;
 
+    // Reset bot status so stale state (e.g. thinking) doesn't carry over.
+    botStatusNotifier.value = BotStatus.absent;
+
     // Exit editor mode if active (before tearing down services).
     final techWorld = locate<TechWorld>();
     if (techWorld.mapEditorActive.value) {


### PR DESCRIPTION
## Summary
- `_leaveRoom()` never reset `botStatusNotifier`, so stale bot status (e.g. `thinking`) carried across room transitions
- Added `botStatusNotifier.value = BotStatus.absent;` at the start of `_leaveRoom()`, after the null check but before service teardown
- Follows the same pattern already used in `_handleConnectionLost()` (line 589)

Phase 2 audit finding P2-B1 (Medium).

## Test plan
- [ ] Join a room, trigger bot interaction (status goes to `thinking`), leave the room, join another room -- verify bot status shows `absent` rather than stale `thinking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)