### PR TITLE
Gate code submission button on bot availability

### DIFF
--- a/lib/editor/code_editor_panel.dart
+++ b/lib/editor/code_editor_panel.dart
@@ -362,21 +362,38 @@ class _CodeEditorPanelState extends State<CodeEditorPanel> {
                   ),
                 ),
                 const SizedBox(width: 12),
-                ElevatedButton.icon(
-                  onPressed: _handleSubmit,
-                  icon: const Icon(Icons.send, size: 16),
-                  label: const Text('Submit to Clawd'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: _clawdOrange,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                  ),
+                ValueListenableBuilder<BotStatus>(
+                  valueListenable: botStatusNotifier,
+                  builder: (context, botStatus, _) {
+                    final enabled = botStatus != BotStatus.absent;
+                    final button = ElevatedButton.icon(
+                      onPressed: enabled ? _handleSubmit : null,
+                      icon: const Icon(Icons.send, size: 16),
+                      label: const Text('Submit to Clawd'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: _clawdOrange,
+                        foregroundColor: Colors.white,
+                        disabledBackgroundColor:
+                            _clawdOrange.withValues(alpha: 0.3),
+                        disabledForegroundColor:
+                            Colors.white.withValues(alpha: 0.5),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 20,
+                          vertical: 12,
+                        ),
+                      ),
+                    );
+                    if (!enabled) {
+                      return Tooltip(
+                        message: 'Clawd is offline',
+                        child: button,
+                      );
+                    }
+                    return button;
+                  },
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- Wrap the "Submit to Clawd" button in a `ValueListenableBuilder<BotStatus>`, matching the existing help button pattern
- Disable the button when `BotStatus.absent` (bot-claude offline)
- Show "Clawd is offline" tooltip on the disabled button
- Add `disabledBackgroundColor`/`disabledForegroundColor` for visual feedback

## Context
Phase 2 audit finding P2-F3 (Medium). The submit button was always enabled regardless of bot status, causing submissions to silently fail when bot-claude was offline. The help button already correctly gates on `BotStatus.absent` — this PR applies the same pattern to the submit button.

## Test plan
- [ ] Verify submit button is enabled when bot is connected (BotStatus.idle or .thinking)
- [ ] Verify submit button is disabled and dimmed when bot is absent
- [ ] Verify "Clawd is offline" tooltip appears on hover when disabled
- [ ] Verify help button behavior is unchanged
- [ ] CI passes (`flutter analyze --fatal-infos` + `flutter test`)

Generated with Claude Code