### PR TITLE
Log LSP configuration errors instead of silently swallowing

### DIFF
--- a/lib/editor/code_editor_panel.dart
+++ b/lib/editor/code_editor_panel.dart
@@ -84,7 +84,8 @@ class _CodeEditorPanelState extends State<CodeEditorPanel> {
           rename: false,
         ),
       );
-    } catch (_) {
+    } catch (e) {
+      debugPrint('LSP config error: $e');
       // Catches synchronous constructor errors (e.g. malformed URL).
       // Async WebSocket failures (e.g. DNS) are handled internally by
       // CodeForgeWebController — the editor falls back to plain text.


### PR DESCRIPTION
## Summary
- Replace bare `catch (_)` with `catch (e)` + `debugPrint` in LSP config setup
- Makes LSP connection failures diagnosable instead of invisible

Phase 2 audit finding P2-F7 (Low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)