### PR TITLE
Add 30-second timeout to prompt challenge evaluation

### DIFF
--- a/lib/prompt/chat_evaluation_engine.dart
+++ b/lib/prompt/chat_evaluation_engine.dart
@@ -14,8 +14,29 @@ class ChatEvaluationEngine extends EvaluationEngine {
 
   final ChatService _chatService;
 
+  /// Match the chat service's own 30-second response timeout so a hung bot
+  /// cannot block the UI indefinitely.
+  static const _evaluationTimeout = Duration(seconds: 30);
+
   @override
   Future<(String, CastResult)> evaluate(
+    PromptChallenge challenge,
+    String playerPrompt,
+  ) async {
+    return _evaluate(challenge, playerPrompt).timeout(
+      _evaluationTimeout,
+      onTimeout: () => (
+        '',
+        const CastResult(
+          passed: false,
+          feedback: CastFeedback.unclear,
+          judgeReasoning: 'Evaluation timed out.',
+        ),
+      ),
+    );
+  }
+
+  Future<(String, CastResult)> _evaluate(
     PromptChallenge challenge,
     String playerPrompt,
   ) async {


### PR DESCRIPTION
## Summary
- Wrap `ChatEvaluationEngine.evaluate` in `Future.timeout(30s)`
- Returns `CastFeedback.unclear` on timeout instead of blocking indefinitely
- Matches the existing 30s timeout in `ChatService`

Phase 2 audit finding P2-F5 (Low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)