### PR TITLE
Require all challenges completed before unlocking multi-req doors

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -1903,11 +1903,31 @@ class TechWorld extends World with TapCallbacks {
     }
   }
 
-  /// Unlock a door and update its visual state.
+  /// Try to unlock a door and update its visual state.
   ///
-  /// Called when a prompt challenge is passed and the door's required
-  /// challenges are all completed. Broadcasts the unlock to other players.
-  void unlockDoor(DoorData door) {
+  /// Returns `true` if the door actually unlocked, `false` if some required
+  /// challenges are still incomplete. Callers should show partial-progress
+  /// feedback when `false` is returned.
+  ///
+  /// Checks [ProgressService] for ALL of the door's [DoorData.requiredChallengeIds]
+  /// before unlocking. A door with multiple requirements (e.g. D1 needs both
+  /// evocationCountdown AND divinationColor) stays locked until every seal is
+  /// broken.
+  bool unlockDoor(DoorData door) {
+    // Guard: all required challenges must be completed before the door opens.
+    if (door.requiredChallengeIds.isNotEmpty) {
+      final progress = Locator.maybeLocate<ProgressService>();
+      for (final challengeId in door.requiredChallengeIds) {
+        if (!(progress?.isChallengeCompleted(challengeId.wireName) ?? false)) {
+          _log.info(
+            'Door at (${door.position.x}, ${door.position.y}) not unlocked: '
+            'challenge ${challengeId.wireName} still incomplete',
+          );
+          return false;
+        }
+      }
+    }
+
     door.isUnlocked = true;
 
     // Remove the barrier at the door position so the player can walk through.
@@ -1928,6 +1948,7 @@ class TechWorld extends World with TapCallbacks {
     );
 
     _log.info('Door unlocked at (${door.position.x}, ${door.position.y})');
+    return true;
   }
 
   /// Recompute [nearbyLockedDoor] given the current player position and

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart' show useResult;
 import 'package:flutter/material.dart' show Color, Colors, FontWeight, TextStyle;
 import 'package:logging/logging.dart';
 
@@ -1913,12 +1914,17 @@ class TechWorld extends World with TapCallbacks {
   /// before unlocking. A door with multiple requirements (e.g. D1 needs both
   /// evocationCountdown AND divinationColor) stays locked until every seal is
   /// broken.
+  @useResult
   bool unlockDoor(DoorData door) {
     // Guard: all required challenges must be completed before the door opens.
     if (door.requiredChallengeIds.isNotEmpty) {
       final progress = Locator.maybeLocate<ProgressService>();
+      if (progress == null) {
+        _log.warning('ProgressService not available — door check skipped');
+        return false;
+      }
       for (final challengeId in door.requiredChallengeIds) {
-        if (!(progress?.isChallengeCompleted(challengeId.wireName) ?? false)) {
+        if (!progress.isChallengeCompleted(challengeId.wireName)) {
           _log.info(
             'Door at (${door.position.x}, ${door.position.y}) not unlocked: '
             'challenge ${challengeId.wireName} still incomplete',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1385,7 +1385,7 @@ class _MyAppState extends State<MyApp> {
                                 final doors = techWorld
                                     .doorsForChallenge(challenge.id);
                                 for (final door in doors) {
-                                  techWorld.unlockDoor(door);
+                                  final _ = techWorld.unlockDoor(door);
                                 }
                               }
 

--- a/lib/spellbook/speech_cast_overlay.dart
+++ b/lib/spellbook/speech_cast_overlay.dart
@@ -44,9 +44,13 @@ class SpeechCastOverlay extends StatefulWidget {
   /// Bot-mediated flavor channel. Asked for a fresh line on [DoorCastNoMatch].
   final OracleService oracle;
 
-  /// Called with the door that was opened on a successful cast — the
-  /// world uses this to flip the door's visual state and broadcast.
-  final void Function(DoorData door) onCastSuccess;
+  /// Called with the door on a successful cast — the world checks
+  /// whether ALL required challenges are complete and, if so, flips
+  /// the door's visual state and broadcasts the unlock.
+  ///
+  /// Returns `true` if the door actually opened, `false` if some
+  /// required challenges remain incomplete (partial progress).
+  final bool Function(DoorData door) onCastSuccess;
 
   @override
   State<SpeechCastOverlay> createState() => _SpeechCastOverlayState();
@@ -114,14 +118,19 @@ class _SpeechCastOverlayState extends State<SpeechCastOverlay> {
     switch (result) {
       case CastPass(:final challengeId):
         // Persistence (spellbook + progress) already ran inside
-        // performCast; this just flips the world's door visual + broadcast.
-        widget.onCastSuccess(door);
-        // challengeToWord is total over PromptChallengeId.values, so the
-        // lookup never fails for a CastPass (which carries a real
-        // challenge id from a learned word).
+        // performCast; this asks the world to unlock the door.
+        // unlockDoor returns false when the door has multiple required
+        // challenges and some are still incomplete.
+        final opened = widget.onCastSuccess(door);
         final word = challengeToWord[challengeId]!;
-        text = '${word.id.displayName} — the door yields.';
-        color = arcaneColor;
+        if (opened) {
+          text = '${word.id.displayName} — the door yields.';
+          color = arcaneColor;
+        } else {
+          text = '${word.id.displayName} — one seal broken, '
+              'but the door still holds.';
+          color = Colors.amber.shade800;
+        }
       case DoorCastNotLearned(:final wordId):
         text = 'You have not learned ${wordId.displayName} yet.';
         color = Colors.orange.shade700;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,7 +873,7 @@ packages:
     source: hosted
     version: "0.13.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   tiled: ^0.11.1 # TMX/TSX parser only — no rendering
   xml: ^6.6.1
   logging: ^1.3.0
+  meta: ^1.16.0
   path_provider: ^2.1.5
 
 

--- a/test/spellbook/voice_cast_acceptance_test.dart
+++ b/test/spellbook/voice_cast_acceptance_test.dart
@@ -237,7 +237,7 @@ void main() {
       expect(progress.isChallengeCompleted('evocation_fizzbuzz'), isFalse);
     });
 
-    test('multi-challenge door: speaking any one required word unlocks',
+    test('multi-challenge door: speaking a matching word passes the cast',
         () async {
       // A door listing two required challenges is satisfied per-cast —
       // the door tracks completion server-side via progress, not in


### PR DESCRIPTION
## Summary
- `unlockDoor()` now checks `ProgressService` for ALL `requiredChallengeIds` before opening
- Returns `bool` so callers can show partial-progress feedback ("One seal broken, but the door still holds")
- `SpeechCastOverlay.onCastSuccess` signature updated to `bool Function(DoorData)`
- Fixes bypass where casting any single required word unlocked multi-requirement doors

Phase 2 audit finding P2-F1 (Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)