### PR TITLE
Fix thundering herd in CRDT sync-response handling

### DIFF
--- a/lib/map_editor/map_sync_service.dart
+++ b/lib/map_editor/map_sync_service.dart
@@ -55,6 +55,7 @@ class MapSyncService {
   // -------------------------------------------------------------------------
 
   bool _isSyncing = false;
+  bool _syncResponseReceived = false;
   Completer<void>? _syncCompleter;
   final List<MapEditBatch> _syncBuffer = [];
 
@@ -549,6 +550,7 @@ class MapSyncService {
   /// editors are present).
   Future<void> requestSync() async {
     _isSyncing = true;
+    _syncResponseReceived = false;
     _syncBuffer.clear();
     _syncCompleter = Completer<void>();
 
@@ -670,6 +672,8 @@ class MapSyncService {
 
   void _handleSyncResponse(Map<String, dynamic> json) {
     if (!_isSyncing) return;
+    if (_syncResponseReceived) return;
+    _syncResponseReceived = true;
 
     // Apply structure tiles.
     final structure = json['structure'] as List<dynamic>? ?? [];


### PR DESCRIPTION
## Summary
- Added a `_syncResponseReceived` guard flag to `MapSyncService` so only the first sync-response is applied during late-join sync
- All editors previously responded to every sync-request with a full snapshot; multiple responses clobbered the version map via `loadFromJson` (clear-and-load)
- Now subsequent sync-responses after the first are silently dropped

## Changes
- `lib/map_editor/map_sync_service.dart`: 4 lines added
  - `bool _syncResponseReceived = false` field declaration
  - Reset to `false` at the start of `requestSync()`
  - Early return in `_handleSyncResponse()` if already received, then set `true`

## Test plan
- [ ] Verify late-join sync still works with a single other editor present
- [ ] With 3+ editors, confirm only one sync-response is applied (add a `debugPrint` to the early-return path to verify drops)
- [ ] Confirm version map is not clobbered after sync completes

Phase 2 audit findings S1+S2+S4 (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)