### PR TITLE
refactor: extract RoomSession from _MyAppState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Services registered with `Locator`, accessed via `locate<T>()`. Static: `AuthSer
 
 - **`TechWorldGame`** — extends `FlameGame`, wraps `TechWorld` world component
 - **`TechWorld`** — extends `World`, manages all game components, subscribes to LiveKit events
+- **`RoomSession`** — `lib/rooms/room_session.dart`, encapsulates room-scoped service lifecycle (LiveKit, Chat, Proximity, Oracle). Static `create()` factory, `connect()`, `enableMedia()`, `leave()`. Owned by `_MyAppState` as `_session: RoomSession?`
 
 ### Communication (All via LiveKit)
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1262,44 +1262,50 @@ class _MyAppState extends State<MyApp> {
                 if (_session != null)
                   ScreenShareOverlay(
                       liveKitService: _session!.liveKitService),
-                // Connection failure banner
+                // Connection failure banner — listens to both the failed
+                // flag and the message so reconnection text updates reactively.
                 if (_session != null)
                   ValueListenableBuilder<bool>(
                     valueListenable: _session!.connectionFailed,
                     builder: (context, failed, _) {
                       if (!failed) return const SizedBox.shrink();
-                      return Positioned(
-                        bottom: 16,
-                        left: 16,
-                        child: Material(
-                          color: Colors.transparent,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 16,
-                              vertical: 10,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.orange.shade800,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(Icons.wifi_off,
-                                    color: Colors.white, size: 18),
-                                const SizedBox(width: 8),
-                                Text(
-                                  _session!.connectionMessage.value ??
-                                      'Video & chat unavailable — connection failed',
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 13,
-                                  ),
+                      return ValueListenableBuilder<String?>(
+                        valueListenable: _session!.connectionMessage,
+                        builder: (context, message, _) {
+                          return Positioned(
+                            bottom: 16,
+                            left: 16,
+                            child: Material(
+                              color: Colors.transparent,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 10,
                                 ),
-                              ],
+                                decoration: BoxDecoration(
+                                  color: Colors.orange.shade800,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(Icons.wifi_off,
+                                        color: Colors.white, size: 18),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      message ??
+                                          'Video & chat unavailable — connection failed',
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 13,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
                             ),
-                          ),
-                        ),
+                          );
+                        },
                       );
                     },
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,11 +17,8 @@ import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/avatar/avatar_selection_screen.dart';
 import 'package:tech_world/avatar/predefined_avatars.dart';
 import 'package:tech_world/auth/user_profile_service.dart';
-import 'package:tech_world/flame/components/bot_status.dart';
-import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/chat_panel.dart';
 import 'package:tech_world/chat/chat_service.dart';
-import 'package:tech_world/services/dreamfinder_client.dart';
 import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/editor/code_editor_panel.dart';
 import 'package:tech_world/editor/predefined_challenges.dart';
@@ -38,7 +35,6 @@ import 'package:tech_world/livekit/widgets/screen_share_overlay.dart';
 import 'package:tech_world/progress/progress_service.dart';
 import 'package:tech_world/services/stt_service.dart';
 import 'package:tech_world/spellbook/cast_effects.dart';
-import 'package:tech_world/spellbook/oracle_service.dart';
 import 'package:tech_world/spellbook/speech_cast_overlay.dart';
 import 'package:tech_world/spellbook/speech_cast_service.dart';
 import 'package:tech_world/spellbook/spellbook_panel.dart';
@@ -46,12 +42,12 @@ import 'package:tech_world/spellbook/spellbook_service.dart';
 import 'package:tech_world/spellbook/word_of_power.dart' show arcaneColor;
 import 'package:tech_world/map_editor/map_editor_panel.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
-import 'package:tech_world/proximity/proximity_service.dart';
 import 'package:tech_world/rooms/room_browser.dart';
 import 'package:tech_world/flame/maps/tmx_importer.dart';
 import 'package:tech_world/flame/tiles/tileset_storage_service.dart';
 import 'package:tech_world/rooms/room_data.dart';
 import 'package:tech_world/rooms/room_service.dart';
+import 'package:tech_world/rooms/room_session.dart';
 import 'package:tech_world/widgets/auth_menu.dart';
 import 'package:tech_world/widgets/join_overlay.dart';
 import 'package:tech_world/widgets/map_selector.dart';
@@ -102,30 +98,20 @@ class _MyAppState extends State<MyApp> {
   bool _initialized = false;
   String _loadingMessage = 'Initializing...';
   double? _progress;
-  LiveKitService? _liveKitService;
-  ChatService? _chatService;
-  ProximityService? _proximityService;
   ProgressService? _progressService;
   SpellbookService? _spellbookService;
   SttService? _sttService;
   SpeechCastService? _speechCastService;
-  /// Cached per-room: lazily created on first build that has both
-  /// LiveKit and the speech-cast service available, cleared in
-  /// [_leaveRoom] alongside [_liveKitService]. Caching lets the
-  /// service's `_seq` request counter actually disambiguate microsecond
-  /// collisions instead of starting at 0 on every Stack rebuild.
-  OracleService? _oracleService;
   final ValueNotifier<bool> _spellbookOpen = ValueNotifier<bool>(false);
   final MapEditorState _mapEditorState = MapEditorState();
   final ValueNotifier<bool> _chatCollapsed = ValueNotifier<bool>(false);
   final ValueNotifier<String?> _activeDmPeer = ValueNotifier<String?>(null);
-  ChatMessageRepository? _chatMessageRepository;
   final SpellSlotService _spellSlotService = SpellSlotService();
-  bool _liveKitConnectionFailed = false;
-  String? _connectionFailureMessage;
   StreamSubscription<AuthUser>? _authSubscription;
-  StreamSubscription<String?>? _connectionLostSubscription;
-  bool _isReconnecting = false;
+
+  /// The current room session, or null when in the lobby / signed out.
+  /// Encapsulates LiveKit, Chat, Proximity, and Oracle service lifecycles.
+  RoomSession? _session;
 
   /// Wire-state tracker for the current join operation's circuit-board overlay.
   WireStates? _wireStates;
@@ -236,8 +222,6 @@ class _MyAppState extends State<MyApp> {
       _roomService = null;
       _myRooms = null;
       Locator.remove<RoomService>();
-      _liveKitConnectionFailed = false;
-      _connectionFailureMessage = null;
       _selectedAvatar = null;
       _avatarLoaded = false;
       _currentUserId = null;
@@ -356,22 +340,27 @@ class _MyAppState extends State<MyApp> {
       wires.start(Wire.server);
       final wireB = () async {
         try {
-          _createServices(room.id, userId, _currentDisplayName);
-          final result = await _liveKitService!.connect();
-          _log.info('LiveKit connection result for room ${room.id}: $result');
+          _session = RoomSession.create(
+            room: room,
+            userId: userId,
+            displayName: _currentDisplayName,
+            onStateChanged: () => setState(() {}),
+            onReconnectWorld: () =>
+                locate<TechWorld>().connectToLiveKit(
+                  userId,
+                  _currentDisplayName,
+                ),
+          );
+          final result = await _session!.connect();
           if (result == ConnectionResult.connected) {
             wires.complete(Wire.server);
             await techWorld.connectToLiveKit(userId, _currentDisplayName);
-            _listenForConnectionLoss();
 
             // Wire C: camera + mic (depends on server connection).
             wires.start(Wire.camera);
             final wireC = () async {
               try {
-                await Future.wait([
-                  _liveKitService!.setCameraEnabled(true),
-                  _liveKitService!.setMicrophoneEnabled(true),
-                ]);
+                await _session!.enableMedia();
                 wires.complete(Wire.camera);
               } catch (e) {
                 _log.warning('Camera/mic setup failed', e);
@@ -383,7 +372,7 @@ class _MyAppState extends State<MyApp> {
             wires.start(Wire.chat);
             final wireD = () async {
               try {
-                await _chatService!.loadHistory(room.id);
+                await _session!.chatService.loadHistory(room.id);
                 wires.complete(Wire.chat);
               } catch (e) {
                 _log.warning('Chat history load failed', e);
@@ -397,16 +386,7 @@ class _MyAppState extends State<MyApp> {
             // Mark dependent wires as complete (skipped) so overlay dismisses.
             wires.complete(Wire.camera);
             wires.complete(Wire.chat);
-            _liveKitConnectionFailed = true;
-            _connectionFailureMessage = switch (result) {
-              ConnectionResult.tokenAuthError =>
-                'Session expired — please sign in again',
-              ConnectionResult.tokenNetworkError =>
-                'Could not reach server — check your connection',
-              ConnectionResult.roomFailed =>
-                'Room connection failed — try again later',
-              _ => 'Video & chat unavailable — connection failed',
-            };
+            // Session already set connectionFailed/connectionMessage.
           } else {
             wires.complete(Wire.server);
             wires.complete(Wire.camera);
@@ -452,79 +432,12 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  /// Create and register LiveKit, Chat, and Proximity services.
-  void _createServices(String roomId, String userId, String displayName) {
-    _liveKitService = LiveKitService(
-      userId: userId,
-      displayName: displayName,
-      roomName: roomId,
-    );
-    _chatMessageRepository = ChatMessageRepository();
-    _chatService = ChatService(
-      liveKitService: _liveKitService!,
-      repository: _chatMessageRepository,
-      dreamfinderClient: DreamfinderClient(
-        baseUrl: 'https://dreamfinder.imagineering.cc',
-        apiKey: const String.fromEnvironment(
-          'DREAMFINDER_API_KEY',
-          defaultValue: '2aa0e9ab3207b197dc0d392fe6e35e8cbe8bfa78f72ce7f9',
-        ),
-      ),
-    );
-    _proximityService = ProximityService();
-
-    Locator.add<LiveKitService>(_liveKitService!);
-    Locator.add<ChatService>(_chatService!);
-    Locator.add<ProximityService>(_proximityService!);
-  }
-
-  /// Create LiveKit, Chat, and Proximity services, connect, and enable media.
-  ///
-  /// Sets [_liveKitConnectionFailed] on failure so the UI can show a banner.
-  /// Applies the saved avatar if one is selected.
-  ///
-  /// Used by the [_onCreateRoom] / save-room flow which doesn't use the
-  /// circuit-board overlay.
-  Future<void> _setupLiveKit(
-    String roomId,
-    String userId,
-    String displayName,
-  ) async {
-    _createServices(roomId, userId, displayName);
-
-    final result = await _liveKitService!.connect();
-    _log.info('LiveKit connection result for room $roomId: $result');
-
-    if (result == ConnectionResult.connected) {
-      await locate<TechWorld>().connectToLiveKit(userId, displayName);
-      _listenForConnectionLoss();
-      await _liveKitService!.setCameraEnabled(true);
-      await _liveKitService!.setMicrophoneEnabled(true);
-      await _chatService!.loadHistory(roomId);
-    } else if (result != ConnectionResult.alreadyConnected) {
-      _liveKitConnectionFailed = true;
-      _connectionFailureMessage = switch (result) {
-        ConnectionResult.tokenAuthError =>
-          'Session expired — please sign in again',
-        ConnectionResult.tokenNetworkError =>
-          'Could not reach server — check your connection',
-        ConnectionResult.roomFailed =>
-          'Room connection failed — try again later',
-        _ => 'Video & chat unavailable — connection failed',
-      };
-    }
-
-    // Apply saved avatar to game world.
-    if (_selectedAvatar != null) {
-      locate<TechWorld>().setLocalAvatar(_selectedAvatar!);
-    }
-  }
-
   /// Leave the current room — disconnect LiveKit and return to lobby.
   ///
   /// Disposal order: TechWorld subscriptions first (cancels stream listeners
-  /// while the underlying services are still alive), then consumers before
-  /// producers (ChatService → ProximityService → LiveKitService).
+  /// while the underlying services are still alive), then RoomSession handles
+  /// consumer-before-producer disposal (ChatService → ProximityService →
+  /// LiveKitService).
   Future<void> _leaveRoom() async {
     if (_currentRoom == null) return;
 
@@ -534,29 +447,14 @@ class _MyAppState extends State<MyApp> {
       await techWorld.exitEditorMode();
     }
 
-    // Cancel connection-loss subscription before tearing down services.
-    _connectionLostSubscription?.cancel();
-    _connectionLostSubscription = null;
-    _isReconnecting = false;
-
     // Cancel TechWorld's LiveKit subscriptions before disposing services.
     techWorld.disconnectFromLiveKit();
 
-    // Dispose consumers before producers.
-    _chatService?.dispose();
-    _proximityService?.dispose();
-    await _liveKitService?.dispose();
-    _chatService = null;
-    _chatMessageRepository = null;
-    _proximityService = null;
-    _liveKitService = null;
-    _oracleService = null;
+    // RoomSession handles service disposal in dependency order.
+    await _session?.leave();
+    _session = null;
+
     _activeDmPeer.value = null;
-    _liveKitConnectionFailed = false;
-    _connectionFailureMessage = null;
-    Locator.remove<LiveKitService>();
-    Locator.remove<ChatService>();
-    Locator.remove<ProximityService>();
     _currentRoom = null;
     _mapEditorState.setRoomId(null);
     _wireStates?.dispose();
@@ -564,68 +462,6 @@ class _MyAppState extends State<MyApp> {
     _showJoinOverlay = false;
 
     setState(() {});
-  }
-
-  /// Subscribe to [LiveKitService.connectionLost] for auto-reconnection.
-  ///
-  /// Called after a successful LiveKit connection from both [_joinRoom]
-  /// and [_setupLiveKit]. On unexpected disconnect: shows a banner, resets
-  /// bot presence, and attempts to reconnect automatically.
-  void _listenForConnectionLoss() {
-    _connectionLostSubscription?.cancel();
-    _connectionLostSubscription =
-        _liveKitService?.connectionLost.listen(_handleConnectionLost);
-  }
-
-  Future<void> _handleConnectionLost(String? reason) async {
-    _log.warning('LiveKit connection lost: $reason');
-    if (_isReconnecting) return; // Already handling a reconnection attempt.
-    _isReconnecting = true;
-
-    // Show failure banner immediately.
-    _liveKitConnectionFailed = true;
-    _connectionFailureMessage = 'Connection lost — reconnecting…';
-    // Reset bot presence so the chat panel shows "offline".
-    botStatusNotifier.value = BotStatus.absent;
-    setState(() {});
-
-    // TechWorld's own connectionLost listener calls disconnectFromLiveKit(),
-    // which clears its subscriptions and nulls its service reference. That
-    // enables re-initialization when connectToLiveKit() is called again.
-
-    try {
-      // Wait briefly then attempt reconnection.
-      await Future.delayed(const Duration(seconds: 2));
-      if (_liveKitService == null || _currentRoom == null) return;
-
-      final result = await _liveKitService!.connect();
-      _log.info('Reconnection attempt result: $result');
-
-      if (result == ConnectionResult.connected) {
-        // Re-initialize TechWorld's LiveKit subscriptions.
-        final userId = _currentUserId;
-        if (userId != null) {
-          await locate<TechWorld>()
-              .connectToLiveKit(userId, _currentDisplayName);
-          _listenForConnectionLoss();
-          // Re-enable camera/mic.
-          await _liveKitService!.setCameraEnabled(true);
-          await _liveKitService!.setMicrophoneEnabled(true);
-        }
-
-        _liveKitConnectionFailed = false;
-        _connectionFailureMessage = null;
-        _log.info('Reconnected successfully');
-        setState(() {});
-      } else {
-        // Reconnection failed — update banner.
-        _connectionFailureMessage =
-            'Video & chat unavailable — connection lost';
-        setState(() {});
-      }
-    } finally {
-      _isReconnecting = false;
-    }
   }
 
   /// Create a new room — enter editor with empty map, then save.
@@ -709,8 +545,30 @@ class _MyAppState extends State<MyApp> {
       _currentRoom = room;
 
       // Now connect LiveKit for the new room.
-      if (_liveKitService == null) {
-        await _setupLiveKit(room.id, userId, _currentDisplayName);
+      if (_session == null) {
+        _session = RoomSession.create(
+          room: room,
+          userId: userId,
+          displayName: _currentDisplayName,
+          onStateChanged: () => setState(() {}),
+          onReconnectWorld: () =>
+              locate<TechWorld>().connectToLiveKit(
+                userId,
+                _currentDisplayName,
+              ),
+        );
+        final result = await _session!.connect();
+        if (result == ConnectionResult.connected) {
+          await locate<TechWorld>()
+              .connectToLiveKit(userId, _currentDisplayName);
+          await _session!.enableMedia();
+          await _session!.chatService.loadHistory(room.id);
+        }
+
+        // Apply saved avatar to game world.
+        if (_selectedAvatar != null) {
+          locate<TechWorld>().setLocalAvatar(_selectedAvatar!);
+        }
       }
     }
 
@@ -968,19 +826,11 @@ class _MyAppState extends State<MyApp> {
                     ),
                     // Side panel - map editor or chat (hidden in lobby and
                     // during avatar selection)
-                    StreamBuilder<AuthUser>(
-                      stream: locate<AuthService>().authStateChanges,
-                      builder: (context, snapshot) {
-                        if (!snapshot.hasData ||
-                            snapshot.data is SignedOutUser ||
-                            _currentRoom == null ||
-                            _selectedAvatar == null) {
-                          return const SizedBox.shrink();
-                        }
-                        final techWorld = locate<TechWorld>();
-                        return ValueListenableBuilder<bool>(
-                          valueListenable: techWorld.mapEditorActive,
+                    if (_currentRoom != null && _selectedAvatar != null)
+                      ValueListenableBuilder<bool>(
+                          valueListenable: locate<TechWorld>().mapEditorActive,
                           builder: (context, editorActive, _) {
+                            final techWorld = locate<TechWorld>();
                             if (editorActive) {
                               final canEdit = _currentRoom != null &&
                                   _currentUserId != null &&
@@ -1110,7 +960,7 @@ class _MyAppState extends State<MyApp> {
                                     builder: (context, dmPeer, _) {
                                       return ChatPanel(
                                         chatService: chatService,
-                                        liveKitService: _liveKitService!,
+                                        liveKitService: _session!.liveKitService,
                                         onCollapse: () =>
                                             _chatCollapsed.value = true,
                                         initialDmPeerId: dmPeer,
@@ -1123,136 +973,113 @@ class _MyAppState extends State<MyApp> {
                               },
                             );
                           },
-                        );
-                      },
-                    ),
+                        ),
                   ],
                 ),
                 // Toolbar — top right when in a room (hidden during avatar
-                // selection)
-                StreamBuilder<AuthUser>(
-                  stream: locate<AuthService>().authStateChanges,
-                  builder: (context, snapshot) {
-                    if (!snapshot.hasData ||
-                        snapshot.data is SignedOutUser ||
-                        _currentRoom == null ||
-                        _selectedAvatar == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return ValueListenableBuilder<bool>(
-                      valueListenable: _chatCollapsed,
-                      builder: (context, chatCollapsed, child) {
-                    return ValueListenableBuilder<bool>(
-                      valueListenable: _spellbookOpen,
-                      builder: (context, spellbookOpen, _) {
-                    final techWorld = locate<TechWorld>();
-                    // The spellbook panel only renders when no challenge is
-                    // active — see the overlay's gating below — so the
-                    // toolbar should only shift for the spellbook in that
-                    // same window.
-                    final spellbookVisible = spellbookOpen &&
-                        techWorld.activePromptChallenge.value == null;
-                    // Toolbar offset depends on what's showing in the side panel
-                    final double toolbarRight;
-                    if (techWorld.mapEditorActive.value) {
-                      toolbarRight = (constraints.maxWidth >= 800 ? 480 : 360) + 16;
-                    } else if (spellbookVisible) {
-                      toolbarRight = constraints.maxWidth >= 800 ? 400 : 320;
-                    } else if (chatCollapsed) {
-                      toolbarRight = 64;
-                    } else {
-                      toolbarRight = constraints.maxWidth >= 800 ? 336 : 296;
-                    }
-                    return Positioned(
-                      top: 16,
-                      right: toolbarRight,
-                      child: SafeArea(
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            // Leave room button
-                            IconButton(
-                              onPressed: _leaveRoom,
-                              icon: const Icon(Icons.arrow_back,
-                                  color: Colors.white70, size: 20),
-                              tooltip: 'Leave room',
-                              style: IconButton.styleFrom(
-                                backgroundColor: Colors.black54,
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(8),
-                                ),
+                // selection and in the lobby)
+                if (_currentRoom != null && _selectedAvatar != null)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _chatCollapsed,
+                    builder: (context, chatCollapsed, child) {
+                  return ValueListenableBuilder<bool>(
+                    valueListenable: _spellbookOpen,
+                    builder: (context, spellbookOpen, _) {
+                  final techWorld = locate<TechWorld>();
+                  // The spellbook panel only renders when no challenge is
+                  // active — see the overlay's gating below — so the
+                  // toolbar should only shift for the spellbook in that
+                  // same window.
+                  final spellbookVisible = spellbookOpen &&
+                      techWorld.activePromptChallenge.value == null;
+                  // Toolbar offset depends on what's showing in the side panel
+                  final double toolbarRight;
+                  if (techWorld.mapEditorActive.value) {
+                    toolbarRight = (constraints.maxWidth >= 800 ? 480 : 360) + 16;
+                  } else if (spellbookVisible) {
+                    toolbarRight = constraints.maxWidth >= 800 ? 400 : 320;
+                  } else if (chatCollapsed) {
+                    toolbarRight = 64;
+                  } else {
+                    toolbarRight = constraints.maxWidth >= 800 ? 336 : 296;
+                  }
+                  return Positioned(
+                    top: 16,
+                    right: toolbarRight,
+                    child: SafeArea(
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // Leave room button
+                          IconButton(
+                            onPressed: _leaveRoom,
+                            icon: const Icon(Icons.arrow_back,
+                                color: Colors.white70, size: 20),
+                            tooltip: 'Leave room',
+                            style: IconButton.styleFrom(
+                              backgroundColor: Colors.black54,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
                               ),
                             ),
+                          ),
+                          const SizedBox(width: 8),
+                          // Map selector with saved rooms
+                          MapSelector(
+                            techWorld: techWorld,
+                            roomService: _roomService,
+                            userId: _currentUserId,
+                            savedRooms: _myRooms,
+                            onPopupOpened: _refreshMyRooms,
+                            onLoadRoom: _loadSavedRoom,
+                            onDeleteRoom: _deleteSavedRoom,
+                          ),
+                          if (_currentRoom!.canEdit(_currentUserId!)) ...[
                             const SizedBox(width: 8),
-                            // Map selector with saved rooms
-                            MapSelector(
-                              techWorld: techWorld,
-                              roomService: _roomService,
-                              userId: _currentUserId,
-                              savedRooms: _myRooms,
-                              onPopupOpened: _refreshMyRooms,
-                              onLoadRoom: _loadSavedRoom,
-                              onDeleteRoom: _deleteSavedRoom,
-                            ),
-                            if (_currentRoom!.canEdit(_currentUserId!)) ...[
-                              const SizedBox(width: 8),
-                              _MapEditorButton(
-                                mapEditorState: _mapEditorState,
-                                techWorld: locate<TechWorld>(),
-                              ),
-                            ],
-                            if (kIsWeb || lkPlatformIsDesktop()) ...[
-                              const SizedBox(width: 8),
-                              _ScreenShareButton(
-                                liveKitService: _liveKitService,
-                              ),
-                            ],
-                            const SizedBox(width: 8),
-                            _SpellbookButton(
-                              open: _spellbookOpen,
-                              activePromptChallenge:
-                                  techWorld.activePromptChallenge,
-                            ),
-                            const SizedBox(width: 8),
-                            AuthMenu(
-                              displayName: _currentDisplayName.isNotEmpty
-                                  ? _currentDisplayName
-                                  : snapshot.data!.displayName,
-                              onChangeAvatar: _changeAvatar,
-                              onEditProfile: _editProfile,
-                              profilePictureUrl: _currentProfilePictureUrl,
+                            _MapEditorButton(
+                              mapEditorState: _mapEditorState,
+                              techWorld: locate<TechWorld>(),
                             ),
                           ],
-                        ),
+                          if (kIsWeb || lkPlatformIsDesktop()) ...[
+                            const SizedBox(width: 8),
+                            _ScreenShareButton(
+                              liveKitService: _session?.liveKitService,
+                            ),
+                          ],
+                          const SizedBox(width: 8),
+                          _SpellbookButton(
+                            open: _spellbookOpen,
+                            activePromptChallenge:
+                                techWorld.activePromptChallenge,
+                          ),
+                          const SizedBox(width: 8),
+                          AuthMenu(
+                            displayName: _currentDisplayName,
+                            onChangeAvatar: _changeAvatar,
+                            onEditProfile: _editProfile,
+                            profilePictureUrl: _currentProfilePictureUrl,
+                          ),
+                        ],
                       ),
-                    );
-                      },
-                    );
-                      },
-                    );
-                  },
-                ),
+                    ),
+                  );
+                    },
+                  );
+                    },
+                  ),
                 // Code editor modal overlay — only for code-mode terminals.
-                StreamBuilder<AuthUser>(
-                  stream: locate<AuthService>().authStateChanges,
-                  builder: (context, snapshot) {
-                    if (!snapshot.hasData ||
-                        snapshot.data is SignedOutUser ||
-                        _currentRoom == null ||
-                        _selectedAvatar == null) {
-                      return const SizedBox.shrink();
-                    }
-                    final techWorld = locate<TechWorld>();
-                    if (techWorld.currentMap.value.terminalMode !=
-                        TerminalMode.code) {
-                      return const SizedBox.shrink();
-                    }
-                    return ValueListenableBuilder<CodeChallengeId?>(
-                      valueListenable: techWorld.activeChallenge,
-                      builder: (context, challengeId, _) {
+                if (_currentRoom != null &&
+                    _selectedAvatar != null &&
+                    locate<TechWorld>().currentMap.value.terminalMode ==
+                        TerminalMode.code)
+                  ValueListenableBuilder<CodeChallengeId?>(
+                    valueListenable: locate<TechWorld>().activeChallenge,
+                    builder: (context, challengeId, _) {
                         if (challengeId == null) {
                           return const SizedBox.shrink();
                         }
+                        final techWorld = locate<TechWorld>();
                         final challenge = allChallenges.firstWhere(
                           (c) => c.id == challengeId,
                           orElse: () => allChallenges.first,
@@ -1320,83 +1147,71 @@ class _MyAppState extends State<MyApp> {
                           },
                         );
                       },
-                    );
-                  },
-                ),
+                  ),
                 // Prompt challenge modal overlay — only for prompt-mode terminals.
-                StreamBuilder<AuthUser>(
-                  stream: locate<AuthService>().authStateChanges,
-                  builder: (context, snapshot) {
-                    if (!snapshot.hasData ||
-                        snapshot.data is SignedOutUser ||
-                        _currentRoom == null) {
-                      return const SizedBox.shrink();
-                    }
-                    final techWorld = locate<TechWorld>();
-                    if (techWorld.currentMap.value.terminalMode !=
-                        TerminalMode.prompt) {
-                      return const SizedBox.shrink();
-                    }
-                    return ValueListenableBuilder<PromptChallengeId?>(
-                      valueListenable: techWorld.activePromptChallenge,
-                      builder: (context, challengeId, _) {
-                        if (challengeId == null) {
-                          return const SizedBox.shrink();
-                        }
-                        final challenge = allPromptChallenges.firstWhere(
-                          (c) => c.id == challengeId,
-                          orElse: () => allPromptChallenges.first,
-                        );
-                        final chatService =
-                            Locator.maybeLocate<ChatService>();
-                        return Positioned(
-                          top: 60,
-                          right: 0,
-                          bottom: 0,
-                          width: MediaQuery.of(context).size.width >= 800
-                              ? 400
-                              : 320,
-                          child: PromptChallengePanel(
-                            challenge: challenge,
-                            spellSlotService: _spellSlotService,
-                            onClose: techWorld.closeEditor,
-                            onCast: (prompt) async {
-                              if (chatService == null) {
-                                throw Exception('Chat service not available');
-                              }
-                              final engine =
-                                  ChatEvaluationEngine(chatService);
-                              final result =
-                                  await engine.evaluate(challenge, prompt);
-                              final (_, castResult) = result;
+                if (_currentRoom != null &&
+                    locate<TechWorld>().currentMap.value.terminalMode ==
+                        TerminalMode.prompt)
+                  ValueListenableBuilder<PromptChallengeId?>(
+                    valueListenable:
+                        locate<TechWorld>().activePromptChallenge,
+                    builder: (context, challengeId, _) {
+                      if (challengeId == null) {
+                        return const SizedBox.shrink();
+                      }
+                      final techWorld = locate<TechWorld>();
+                      final challenge = allPromptChallenges.firstWhere(
+                        (c) => c.id == challengeId,
+                        orElse: () => allPromptChallenges.first,
+                      );
+                      final chatService =
+                          Locator.maybeLocate<ChatService>();
+                      return Positioned(
+                        top: 60,
+                        right: 0,
+                        bottom: 0,
+                        width: MediaQuery.of(context).size.width >= 800
+                            ? 400
+                            : 320,
+                        child: PromptChallengePanel(
+                          challenge: challenge,
+                          spellSlotService: _spellSlotService,
+                          onClose: techWorld.closeEditor,
+                          onCast: (prompt) async {
+                            if (chatService == null) {
+                              throw Exception('Chat service not available');
+                            }
+                            final engine =
+                                ChatEvaluationEngine(chatService);
+                            final result =
+                                await engine.evaluate(challenge, prompt);
+                            final (_, castResult) = result;
 
-                              // Persistent side-effects of a successful cast:
-                              // grant the word of power, then mark the
-                              // challenge completed. See applyCastSuccessEffects
-                              // for the rationale on ordering.
-                              if (castResult.passed) {
-                                await applyCastSuccessEffects(
-                                  challengeId: challenge.id,
-                                  spellbook: Locator
-                                      .maybeLocate<SpellbookService>(),
-                                  progress: Locator
-                                      .maybeLocate<ProgressService>(),
-                                );
-                                final doors = techWorld
-                                    .doorsForChallenge(challenge.id);
-                                for (final door in doors) {
-                                  techWorld.unlockDoor(door);
-                                }
+                            // Persistent side-effects of a successful cast:
+                            // grant the word of power, then mark the
+                            // challenge completed. See applyCastSuccessEffects
+                            // for the rationale on ordering.
+                            if (castResult.passed) {
+                              await applyCastSuccessEffects(
+                                challengeId: challenge.id,
+                                spellbook: Locator
+                                    .maybeLocate<SpellbookService>(),
+                                progress: Locator
+                                    .maybeLocate<ProgressService>(),
+                              );
+                              final doors = techWorld
+                                  .doorsForChallenge(challenge.id);
+                              for (final door in doors) {
+                                techWorld.unlockDoor(door);
                               }
+                            }
 
-                              return result;
-                            },
-                          ),
-                        );
-                      },
-                    );
-                  },
-                ),
+                            return result;
+                          },
+                        ),
+                      );
+                    },
+                  ),
                 // Spellbook side panel — toggled by the toolbar button.
                 // Hidden while a prompt challenge is active so the two
                 // right-aligned panels never collide; reappears when the
@@ -1432,54 +1247,61 @@ class _MyAppState extends State<MyApp> {
                 // Voice-cast affordance — proximity-gated mic FAB at
                 // bottom-centre. Visible only when the player is near a
                 // locked door and STT is supported (web). The
-                // OracleService is cached for the LiveKit session so its
+                // OracleService is cached on RoomSession so its
                 // request-sequence counter is meaningful across rebuilds.
-                if (_liveKitService != null && _speechCastService != null)
+                if (_session != null && _speechCastService != null)
                   SpeechCastOverlay(
                     nearbyLockedDoor: locate<TechWorld>().nearbyLockedDoor,
                     speechCast: _speechCastService!,
-                    oracle: _oracleService ??=
-                        OracleService(liveKit: _liveKitService!),
+                    oracle: _session!.oracleService,
                     onCastSuccess: (door) =>
                         locate<TechWorld>().unlockDoor(door),
                   ),
 
                 // Screen share floating panels
-                if (_liveKitService != null)
-                  ScreenShareOverlay(liveKitService: _liveKitService!),
+                if (_session != null)
+                  ScreenShareOverlay(
+                      liveKitService: _session!.liveKitService),
                 // Connection failure banner
-                if (_liveKitConnectionFailed)
-                  Positioned(
-                    bottom: 16,
-                    left: 16,
-                    child: Material(
-                      color: Colors.transparent,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 10,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.orange.shade800,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(Icons.wifi_off, color: Colors.white, size: 18),
-                            const SizedBox(width: 8),
-                            Text(
-                              _connectionFailureMessage ??
-                                  'Video & chat unavailable — connection failed',
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 13,
-                              ),
+                if (_session != null)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _session!.connectionFailed,
+                    builder: (context, failed, _) {
+                      if (!failed) return const SizedBox.shrink();
+                      return Positioned(
+                        bottom: 16,
+                        left: 16,
+                        child: Material(
+                          color: Colors.transparent,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 10,
                             ),
-                          ],
+                            decoration: BoxDecoration(
+                              color: Colors.orange.shade800,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Icons.wifi_off,
+                                    color: Colors.white, size: 18),
+                                const SizedBox(width: 8),
+                                Text(
+                                  _session!.connectionMessage.value ??
+                                      'Video & chat unavailable — connection failed',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 13,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
                         ),
-                      ),
-                    ),
+                      );
+                    },
                   ),
               ],
             );

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:tech_world/chat/chat_message_repository.dart';
+import 'package:tech_world/chat/chat_service.dart';
+import 'package:tech_world/flame/components/bot_status.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+import 'package:tech_world/proximity/proximity_service.dart';
+import 'package:tech_world/rooms/room_data.dart';
+import 'package:tech_world/services/dreamfinder_client.dart';
+import 'package:tech_world/spellbook/oracle_service.dart';
+import 'package:tech_world/utils/locator.dart';
+
+final _log = Logger('RoomSession');
+
+/// Encapsulates the lifecycle of a room session: service creation, LiveKit
+/// connection, reconnection on failure, and teardown.
+///
+/// Replaces the 10+ nullable fields and 3 lifecycle methods that previously
+/// lived in `_MyAppState`. Owned as a single `RoomSession? _session` field.
+///
+/// Usage:
+/// ```dart
+/// _session = RoomSession.create(room: room, userId: userId, ...);
+/// final result = await _session!.connect();
+/// if (result == ConnectionResult.connected) { ... }
+/// // Later:
+/// await _session?.leave();
+/// _session = null;
+/// ```
+class RoomSession {
+  RoomSession._({
+    required this.liveKitService,
+    required this.chatService,
+    required this.chatMessageRepository,
+    required this.proximityService,
+    required this.room,
+    required this.userId,
+    required this.displayName,
+    required void Function() onStateChanged,
+    required Future<void> Function() onReconnectWorld,
+  })  : _onStateChanged = onStateChanged,
+        _onReconnectWorld = onReconnectWorld;
+
+  // --- Final fields (set at construction) ---
+
+  final LiveKitService liveKitService;
+  final ChatService chatService;
+  final ChatMessageRepository chatMessageRepository;
+  final ProximityService proximityService;
+  final RoomData room;
+  final String userId;
+  final String displayName;
+
+  // --- Callbacks ---
+
+  /// Triggers `setState` in the owning widget so the UI rebuilds.
+  final void Function() _onStateChanged;
+
+  /// Re-wires TechWorld's LiveKit subscriptions after a successful reconnect.
+  /// Called with `await` so the game world is ready before media re-enables.
+  final Future<void> Function() _onReconnectWorld;
+
+  // --- Connection state (observable by UI) ---
+
+  /// Whether the LiveKit connection has failed or been lost.
+  final connectionFailed = ValueNotifier<bool>(false);
+
+  /// Human-readable connection failure/reconnection message, or null.
+  final connectionMessage = ValueNotifier<String?>(null);
+
+  // --- Internal state ---
+
+  bool _isReconnecting = false;
+  StreamSubscription<String?>? _connectionLostSub;
+  OracleService? _oracleService;
+
+  /// Lazily-created oracle service for bot-mediated generation (voice cast,
+  /// spell combos). Cached for the session so the request-sequence counter
+  /// (`_seq`) disambiguates microsecond collisions across rebuilds.
+  OracleService get oracleService =>
+      _oracleService ??= OracleService(liveKit: liveKitService);
+
+  // ---------------------------------------------------------------------------
+  // Factory
+  // ---------------------------------------------------------------------------
+
+  /// Create services for a room and register them in the [Locator].
+  ///
+  /// Does not connect to LiveKit — call [connect] next. This separation lets
+  /// callers interleave wire-state tracking between creation and connection
+  /// (the overlay join path).
+  static RoomSession create({
+    required RoomData room,
+    required String userId,
+    required String displayName,
+    required void Function() onStateChanged,
+    required Future<void> Function() onReconnectWorld,
+    @visibleForTesting ChatMessageRepository? chatMessageRepository,
+  }) {
+    final liveKit = LiveKitService(
+      userId: userId,
+      displayName: displayName,
+      roomName: room.id,
+    );
+    final chatRepo = chatMessageRepository ?? ChatMessageRepository();
+    final chat = ChatService(
+      liveKitService: liveKit,
+      repository: chatRepo,
+      dreamfinderClient: DreamfinderClient(
+        baseUrl: 'https://dreamfinder.imagineering.cc',
+        apiKey: const String.fromEnvironment(
+          'DREAMFINDER_API_KEY',
+          defaultValue:
+              '2aa0e9ab3207b197dc0d392fe6e35e8cbe8bfa78f72ce7f9',
+        ),
+      ),
+    );
+    final proximity = ProximityService();
+
+    Locator.add<LiveKitService>(liveKit);
+    Locator.add<ChatService>(chat);
+    Locator.add<ProximityService>(proximity);
+
+    return RoomSession._(
+      liveKitService: liveKit,
+      chatService: chat,
+      chatMessageRepository: chatRepo,
+      proximityService: proximity,
+      room: room,
+      userId: userId,
+      displayName: displayName,
+      onStateChanged: onStateChanged,
+      onReconnectWorld: onReconnectWorld,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection
+  // ---------------------------------------------------------------------------
+
+  /// Connect to LiveKit and start listening for connection loss.
+  ///
+  /// On failure, sets [connectionFailed] and [connectionMessage] so the UI
+  /// can show a banner. Returns the [ConnectionResult] so callers can act on
+  /// it (e.g. skip camera/mic setup on failure).
+  Future<ConnectionResult> connect() async {
+    final result = await liveKitService.connect();
+    _log.info('LiveKit connection result for room ${room.id}: $result');
+
+    if (result == ConnectionResult.connected) {
+      _listenForConnectionLoss();
+    } else if (result != ConnectionResult.alreadyConnected) {
+      connectionFailed.value = true;
+      connectionMessage.value = failureMessageFor(result);
+    }
+    return result;
+  }
+
+  /// Enable camera and microphone.
+  Future<void> enableMedia() async {
+    await Future.wait([
+      liveKitService.setCameraEnabled(true),
+      liveKitService.setMicrophoneEnabled(true),
+    ]);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reconnection
+  // ---------------------------------------------------------------------------
+
+  void _listenForConnectionLoss() {
+    _connectionLostSub?.cancel();
+    _connectionLostSub =
+        liveKitService.connectionLost.listen(_handleConnectionLost);
+  }
+
+  Future<void> _handleConnectionLost(String? reason) async {
+    _log.warning('LiveKit connection lost: $reason');
+    if (_isReconnecting) return;
+    _isReconnecting = true;
+
+    // Show failure banner immediately.
+    connectionFailed.value = true;
+    connectionMessage.value = 'Connection lost — reconnecting…';
+    botStatusNotifier.value = BotStatus.absent;
+    _onStateChanged();
+
+    // TechWorld's own connectionLost listener calls disconnectFromLiveKit(),
+    // which clears its subscriptions and nulls its service reference. That
+    // enables re-initialization when connectToLiveKit() is called again.
+
+    try {
+      await Future.delayed(const Duration(seconds: 2));
+
+      final result = await liveKitService.connect();
+      _log.info('Reconnection attempt result: $result');
+
+      if (result == ConnectionResult.connected) {
+        await _onReconnectWorld();
+        _listenForConnectionLoss();
+        await enableMedia();
+
+        connectionFailed.value = false;
+        connectionMessage.value = null;
+        _log.info('Reconnected successfully');
+      } else {
+        connectionMessage.value =
+            'Video & chat unavailable — connection lost';
+      }
+      _onStateChanged();
+    } finally {
+      _isReconnecting = false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error messages
+  // ---------------------------------------------------------------------------
+
+  /// Map a [ConnectionResult] to a human-readable failure message.
+  static String failureMessageFor(ConnectionResult result) => switch (result) {
+        ConnectionResult.tokenAuthError =>
+          'Session expired — please sign in again',
+        ConnectionResult.tokenNetworkError =>
+          'Could not reach server — check your connection',
+        ConnectionResult.roomFailed =>
+          'Room connection failed — try again later',
+        _ => 'Video & chat unavailable — connection failed',
+      };
+
+  // ---------------------------------------------------------------------------
+  // Teardown
+  // ---------------------------------------------------------------------------
+
+  /// Leave the room — dispose services in dependency order.
+  ///
+  /// Disposal order: cancel reconnection listener, then consumers before
+  /// producers (ChatService → ProximityService → LiveKitService).
+  Future<void> leave() async {
+    _connectionLostSub?.cancel();
+    _connectionLostSub = null;
+    _isReconnecting = false;
+
+    chatService.dispose();
+    proximityService.dispose();
+    await liveKitService.dispose();
+    _oracleService = null;
+
+    connectionFailed.dispose();
+    connectionMessage.dispose();
+
+    Locator.remove<LiveKitService>();
+    Locator.remove<ChatService>();
+    Locator.remove<ProximityService>();
+  }
+}

--- a/test/rooms/room_session_test.dart
+++ b/test/rooms/room_session_test.dart
@@ -1,0 +1,164 @@
+import 'dart:math';
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/chat/chat_message_repository.dart';
+import 'package:tech_world/chat/chat_service.dart';
+import 'package:tech_world/flame/maps/game_map.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+import 'package:tech_world/proximity/proximity_service.dart';
+import 'package:tech_world/rooms/room_data.dart';
+import 'package:tech_world/rooms/room_session.dart';
+import 'package:tech_world/utils/locator.dart';
+
+const _testMap = GameMap(
+  id: 'test_map',
+  name: 'Test Map',
+  barriers: [Point(1, 2)],
+);
+
+const _testRoom = RoomData(
+  id: 'test-room',
+  name: 'Test Room',
+  ownerId: 'user-1',
+  ownerDisplayName: 'User 1',
+  mapData: _testMap,
+);
+
+/// Create a [RoomSession] with a fake Firestore-backed [ChatMessageRepository]
+/// to avoid Firebase initialization in tests.
+RoomSession _createSession({
+  RoomData room = _testRoom,
+  String userId = 'user-1',
+  String displayName = 'User 1',
+  void Function()? onStateChanged,
+  Future<void> Function()? onReconnectWorld,
+}) {
+  return RoomSession.create(
+    room: room,
+    userId: userId,
+    displayName: displayName,
+    onStateChanged: onStateChanged ?? () {},
+    onReconnectWorld: onReconnectWorld ?? () async {},
+    chatMessageRepository:
+        ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+  );
+}
+
+void main() {
+  tearDown(() {
+    Locator.remove<LiveKitService>();
+    Locator.remove<ChatService>();
+    Locator.remove<ProximityService>();
+  });
+
+  group('RoomSession.create', () {
+    test('registers LiveKitService, ChatService, ProximityService in Locator',
+        () {
+      final session = _createSession();
+
+      expect(Locator.maybeLocate<LiveKitService>(), isNotNull);
+      expect(Locator.maybeLocate<ChatService>(), isNotNull);
+      expect(Locator.maybeLocate<ProximityService>(), isNotNull);
+      expect(
+          session.liveKitService, same(Locator.maybeLocate<LiveKitService>()));
+      expect(session.chatService, same(Locator.maybeLocate<ChatService>()));
+      expect(session.proximityService,
+          same(Locator.maybeLocate<ProximityService>()));
+
+      session.chatService.dispose();
+      session.proximityService.dispose();
+    });
+
+    test('sets room, userId, displayName', () {
+      final session = _createSession();
+
+      expect(session.room.id, 'test-room');
+      expect(session.userId, 'user-1');
+      expect(session.displayName, 'User 1');
+
+      session.chatService.dispose();
+      session.proximityService.dispose();
+    });
+
+    test('creates LiveKitService with correct roomName', () {
+      final session = _createSession();
+
+      expect(session.liveKitService.roomName, 'test-room');
+
+      session.chatService.dispose();
+      session.proximityService.dispose();
+    });
+  });
+
+  group('failureMessageFor', () {
+    test('maps tokenAuthError to session-expired message', () {
+      expect(
+        RoomSession.failureMessageFor(ConnectionResult.tokenAuthError),
+        contains('Session expired'),
+      );
+    });
+
+    test('maps tokenNetworkError to connection message', () {
+      expect(
+        RoomSession.failureMessageFor(ConnectionResult.tokenNetworkError),
+        contains('connection'),
+      );
+    });
+
+    test('maps roomFailed to room-specific message', () {
+      expect(
+        RoomSession.failureMessageFor(ConnectionResult.roomFailed),
+        contains('Room connection failed'),
+      );
+    });
+
+    test('maps unknown result to generic message', () {
+      expect(
+        RoomSession.failureMessageFor(ConnectionResult.tokenUnknownError),
+        contains('connection failed'),
+      );
+    });
+  });
+
+  group('oracleService', () {
+    test('creates lazily on first access and returns same instance', () {
+      final session = _createSession();
+
+      final oracle1 = session.oracleService;
+      final oracle2 = session.oracleService;
+      expect(oracle1, same(oracle2));
+
+      session.chatService.dispose();
+      session.proximityService.dispose();
+    });
+  });
+
+  group('leave', () {
+    test('removes all three services from Locator', () async {
+      final session = _createSession();
+
+      expect(Locator.maybeLocate<LiveKitService>(), isNotNull);
+      expect(Locator.maybeLocate<ChatService>(), isNotNull);
+      expect(Locator.maybeLocate<ProximityService>(), isNotNull);
+
+      await session.leave();
+
+      expect(Locator.maybeLocate<LiveKitService>(), isNull);
+      expect(Locator.maybeLocate<ChatService>(), isNull);
+      expect(Locator.maybeLocate<ProximityService>(), isNull);
+    });
+  });
+
+  group('connectionFailed', () {
+    test('starts as false with null message', () {
+      final session = _createSession();
+
+      expect(session.connectionFailed.value, isFalse);
+      expect(session.connectionMessage.value, isNull);
+
+      session.chatService.dispose();
+      session.proximityService.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Extract `RoomSession` class (`lib/rooms/room_session.dart`, 258 lines) encapsulating room-scoped service lifecycle (LiveKit, Chat, Proximity, Oracle)
- Replace 10 nullable fields in `_MyAppState` with single `RoomSession? _session`
- Eliminate 4 redundant `StreamBuilder<AuthUser>` guards → simple null checks
- Delete 3 methods: `_createServices`, `_setupLiveKit`, `_handleConnectionLost`
- `main.dart`: 1734 → 1556 lines (-10%)

## Design decisions

1. **`create()` / `connect()` / `enableMedia()` split** — the overlay join path needs wire-state tracking between steps; a single `join()` factory would hide the orchestration
2. **Two callbacks** (`onStateChanged`, `onReconnectWorld`) — keeps RoomSession independent of TechWorld for testability
3. **ValueNotifiers** for `connectionFailed` / `connectionMessage` — reactive UI updates without setState
4. **StreamBuilder guard: `_currentRoom != null`** not `_session != null` — preserves `_onCreateRoom` flow where map editor shows before LiveKit connects

## Test plan

- [x] 10 new tests for RoomSession (creation, Locator registration, failure messages, oracle lazy init, leave cleanup, initial state)
- [x] All 1430 tests pass (1420 original + 10 new)
- [x] `flutter analyze --fatal-infos` clean
- [ ] Manual: sign in → join room → chat → leave → create room → editor → save

🤖 Generated with [Claude Code](https://claude.com/claude-code)