### PR TITLE
fix: invalidate JPS pathfinding grid on door unlock

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -369,6 +369,7 @@ class TechWorld extends World with TapCallbacks {
   StreamSubscription<String?>? _connectionLostSubscription;
   StreamSubscription<void>? _mapInfoRequestedSubscription;
   StreamSubscription<DataChannelMessage>? _speechTranscriptSubscription;
+  StreamSubscription<DataChannelMessage>? _doorUnlockSubscription;
   InfraHealthService? _infraHealthService;
 
   // Avatar tracking — stores updates for players not yet created
@@ -1236,6 +1237,11 @@ class TechWorld extends World with TapCallbacks {
         .where((msg) => msg.topic == 'speech-transcript')
         .listen(_handleSpeechTranscript);
 
+    // Subscribe to remote door-unlock broadcasts from other players.
+    _doorUnlockSubscription = _liveKitService!.dataReceived
+        .where((msg) => msg.topic == 'door-unlock')
+        .listen(_handleRemoteDoorUnlock);
+
     // Infrastructure health monitoring.
     _infraHealthService = InfraHealthService(
       liveKitService: _liveKitService!,
@@ -1912,6 +1918,9 @@ class TechWorld extends World with TapCallbacks {
 
     // Remove the barrier at the door position so the player can walk through.
     _barriersComponent.removeBarrierAt(door.position);
+    // Invalidate the JPS pathfinding grid so the next pathfind rebuilds it
+    // without the now-removed barrier cell.
+    _pathComponent?.invalidateGrid();
 
     // The unlocked door must drop out of the proximity signal — otherwise
     // the mic FAB lingers over an open doorway.
@@ -1928,6 +1937,31 @@ class TechWorld extends World with TapCallbacks {
     );
 
     _log.info('Door unlocked at (${door.position.x}, ${door.position.y})');
+  }
+
+  /// Handle a remote door-unlock broadcast from another player.
+  ///
+  /// Finds the matching door by grid position, marks it unlocked, removes the
+  /// barrier, and invalidates the pathfinding grid — mirroring [unlockDoor].
+  void _handleRemoteDoorUnlock(DataChannelMessage msg) {
+    final json = msg.json;
+    if (json == null) return;
+    final x = json['doorX'] as int?;
+    final y = json['doorY'] as int?;
+    if (x == null || y == null) return;
+
+    final door = currentMap.value.doors.where(
+      (d) => d.position.x == x && d.position.y == y && !d.isUnlocked,
+    ).firstOrNull;
+    if (door == null) return;
+
+    door.isUnlocked = true;
+    _barriersComponent.removeBarrierAt(door.position);
+    // Invalidate the JPS pathfinding grid so remote unlock takes effect
+    // immediately — same fix as the local path in [unlockDoor].
+    _pathComponent?.invalidateGrid();
+    _recomputeNearbyLockedDoor();
+    _log.info('Remote door unlock applied at ($x, $y)');
   }
 
   /// Recompute [nearbyLockedDoor] given the current player position and
@@ -2017,6 +2051,8 @@ class TechWorld extends World with TapCallbacks {
     _mapInfoRequestedSubscription = null;
     _speechTranscriptSubscription?.cancel();
     _speechTranscriptSubscription = null;
+    _doorUnlockSubscription?.cancel();
+    _doorUnlockSubscription = null;
 
     // Dispose infrastructure health monitoring.
     _infraHealthService?.dispose();

--- a/test/flame/components/path_component_test.dart
+++ b/test/flame/components/path_component_test.dart
@@ -192,6 +192,29 @@ void main() {
 
         expect(pathComponent.largeGridPoints, isNotEmpty);
       });
+
+      test('invalidateGrid allows new grid to be built after barriers change', () {
+        // Populate the grid via the first calculatePath call.
+        pathComponent.calculatePath(start: (0, 0), end: (5, 0));
+        expect(pathComponent.largeGridPoints, isNotEmpty);
+
+        // Simulate a door-unlock: swap in a new BarriersComponent with fewer
+        // barriers, then invalidate so the next path uses the updated layout.
+        final newBarriers = BarriersComponent(barriers: const []);
+        pathComponent.barriers = newBarriers; // setter also calls invalidateGrid
+
+        // invalidateGrid alone (without the setter) should also work.
+        pathComponent.invalidateGrid();
+
+        // After invalidation the component should still calculate paths normally.
+        pathComponent.calculatePath(start: (0, 0), end: (5, 0));
+        expect(pathComponent.largeGridPoints, isNotEmpty);
+      });
+
+      test('invalidateGrid on fresh component does not throw', () {
+        // Should be safe to invalidate before any calculatePath call.
+        expect(() => pathComponent.invalidateGrid(), returnsNormally);
+      });
     });
 
     group('edge cases', () {


### PR DESCRIPTION
## Summary
- After unlocking a door, `BarriersComponent.removeBarrierAt` removed the barrier but `PathComponent._grid` (cached JPS grid) still marked the cell as impassable
- Players could not path through unlocked doors without reloading the map
- Added `_pathComponent?.invalidateGrid()` in both `unlockDoor` and `_handleRemoteDoorUnlock`
- Added remote door-unlock handler + LiveKit subscription wiring (was missing entirely)
- Cage-match: APPROVED WITH NITS — added 2 regression tests for `invalidateGrid()`

## Severity
HIGH — gameplay bug affecting door unlock pathfinding

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1422 tests pass (2 new)
- [ ] Manual: unlock a door in-game, verify player can path through it

🤖 Generated with [Claude Code](https://claude.com/claude-code)