### PR TITLE
fix: use Object? instead of dynamic for WASM type safety

### DIFF
--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -469,7 +469,7 @@ class VideoElementCapture implements FrameSource {
   ///
   /// If jsStream is provided, uses it directly. Otherwise falls back to creating
   /// a MediaStream from the track.
-  static Future<VideoElementCapture?> createFromStream(dynamic jsStream, dynamic jsTrack) async {
+  static Future<VideoElementCapture?> createFromStream(Object? jsStream, Object? jsTrack) async {
     try {
       web.MediaStream? stream;
 


### PR DESCRIPTION
## Summary
- `VideoElementCapture.createFromStream(dynamic, dynamic)` lost compile-time type guarantees in dart2wasm
- Changed to `Object?` parameters — preserves runtime behavior, adds static type info
- Matches the stub file which already used `Object?`

## Severity
HIGH — type safety for WASM builds

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1420 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)