### PR TITLE
fix: ensure map generators always produce walkable spawn point

### DIFF
--- a/lib/flame/maps/generators/cave_generator.dart
+++ b/lib/flame/maps/generators/cave_generator.dart
@@ -21,8 +21,24 @@ GameMap generateCave({required int seed, required GeneratorConfig config}) {
     _smooth(grid);
   }
 
-  final region = largestOpenRegion(grid);
+  var region = largestOpenRegion(grid);
   removeDisconnectedRegions(grid, region);
+
+  if (region.isEmpty) {
+    // Degenerate config produced all walls — carve a small safe zone.
+    final cx = gridSize ~/ 2;
+    final cy = gridSize ~/ 2;
+    for (var dy = -1; dy <= 1; dy++) {
+      for (var dx = -1; dx <= 1; dx++) {
+        grid[cy + dy][cx + dx] = false; // false = open
+      }
+    }
+    region = {
+      for (var dy = -1; dy <= 1; dy++)
+        for (var dx = -1; dx <= 1; dx++) Point(cx + dx, cy + dy),
+    };
+  }
+
   final spawn = findSpawnPoint(grid, region);
 
   final layers = buildTileLayers(grid, floorTileIndex: floorTileBrownEarth);

--- a/lib/flame/maps/generators/dungeon_generator.dart
+++ b/lib/flame/maps/generators/dungeon_generator.dart
@@ -38,6 +38,19 @@ GameMap generateDungeon({required int seed, required GeneratorConfig config}) {
     }
   }
 
+  if (rooms.isEmpty) {
+    // No rooms placed — force one room at center.
+    // Use at least 3 so that zero/negative dungeonMinRoomSize cannot produce
+    // an uncarveable room and leave spawn on a wall.
+    final cx = gridSize ~/ 2;
+    final cy = gridSize ~/ 2;
+    final w = config.dungeonMinRoomSize.clamp(3, gridSize - 2);
+    final h = config.dungeonMinRoomSize.clamp(3, gridSize - 2);
+    final room = Rectangle(cx - w ~/ 2, cy - h ~/ 2, w, h);
+    rooms.add(room);
+    _carveRoom(grid, room);
+  }
+
   // Sort rooms by center position for consistent corridor connection.
   rooms.sort((a, b) {
     final cmp = _centerY(a).compareTo(_centerY(b));

--- a/test/flame/maps/generators/cave_generator_test.dart
+++ b/test/flame/maps/generators/cave_generator_test.dart
@@ -110,6 +110,22 @@ void main() {
       expect(map.objectLayer!.isEmpty, isFalse);
     });
 
+    test('degenerate caveFillChance=1.0 does not spawn inside a wall', () {
+      // fillChance=1.0 + many smoothing passes fills the grid with walls.
+      // The guard must carve a safe zone so spawn is not on a barrier.
+      final map = generateMap(
+        algorithm: MapAlgorithm.cave,
+        config: const GeneratorConfig(
+          seed: 42,
+          caveFillChance: 1.0,
+          caveSmoothingIterations: 20,
+        ),
+      );
+      final barrierSet = map.barriers.toSet();
+      expect(barrierSet.contains(map.spawnPoint), isFalse,
+          reason: 'spawn must not be inside a wall for degenerate fill config');
+    });
+
     test('10 seeds without invariant violations', () {
       for (var seed = 0; seed < 10; seed++) {
         final map = generateMap(

--- a/test/flame/maps/generators/dungeon_generator_test.dart
+++ b/test/flame/maps/generators/dungeon_generator_test.dart
@@ -104,6 +104,37 @@ void main() {
       expect(map.objectLayer!.isEmpty, isFalse);
     });
 
+    test('degenerate config with impossible rooms does not spawn inside a wall',
+        () {
+      // maxRooms=0 means no room placement is attempted; the guard must
+      // force-place one room at center so spawn is not on a barrier.
+      final map = generateMap(
+        algorithm: MapAlgorithm.dungeon,
+        config: const GeneratorConfig(seed: 42, dungeonMaxRooms: 0),
+      );
+      final barrierSet = map.barriers.toSet();
+      expect(barrierSet.contains(map.spawnPoint), isFalse,
+          reason: 'spawn must not be inside a wall when no rooms are placed');
+    });
+
+    test(
+        'degenerate config with zero minRoomSize and no rooms does not spawn '
+        'inside a wall', () {
+      // dungeonMinRoomSize=0 would produce a zero-size room if used directly;
+      // the guard must clamp to a minimum carve size so spawn is never on a wall.
+      final map = generateMap(
+        algorithm: MapAlgorithm.dungeon,
+        config: const GeneratorConfig(
+          seed: 42,
+          dungeonMaxRooms: 0,
+          dungeonMinRoomSize: 0,
+        ),
+      );
+      final barrierSet = map.barriers.toSet();
+      expect(barrierSet.contains(map.spawnPoint), isFalse,
+          reason: 'spawn must not be inside a wall when minRoomSize is 0');
+    });
+
     test('10 seeds without invariant violations', () {
       for (var seed = 0; seed < 10; seed++) {
         final map = generateMap(


### PR DESCRIPTION
## Summary
- Cave generator: `caveFillChance` near 1.0 → all walls → spawn inside barrier
- Dungeon generator: all room placements fail → empty rooms → wall spawn
- Cave fix: carve 3x3 safe zone at grid center when region is empty
- Dungeon fix: force-place one room at center when rooms list is empty, size clamped to `max(3, dungeonMinRoomSize)`
- Cage-match: found and fixed edge case where `dungeonMinRoomSize: 0` produced uncarveable room

## Severity
MEDIUM — edge case map generation bug

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 48 generator tests pass (3 new)
- [ ] Manual: generate cave/dungeon maps with extreme configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)