### PR TITLE
fix: deterministic depth-sort tie-breaking for same-y entities

### DIFF
--- a/lib/flame/components/bot_character_component.dart
+++ b/lib/flame/components/bot_character_component.dart
@@ -85,7 +85,8 @@ class BotCharacterComponent extends PositionComponent with TapCallbacks {
   @override
   void update(double dt) {
     super.update(dt);
-    priority = position.y.round() ~/ gridSquareSize;
+    priority = (position.y.round() ~/ gridSquareSize) * kPriorityStride +
+        (position.x.round().abs() % kPriorityStride);
   }
 
   /// Returns mini grid position as Point (for proximity detection)

--- a/lib/flame/components/dreamfinder_component.dart
+++ b/lib/flame/components/dreamfinder_component.dart
@@ -74,7 +74,8 @@ class DreamfinderComponent
   @override
   void update(double dt) {
     super.update(dt);
-    priority = position.y.round() ~/ gridSquareSize;
+    priority = (position.y.round() ~/ gridSquareSize) * kPriorityStride +
+        (position.x.round().abs() % kPriorityStride);
 
     // Tick the wander cooldown when idle/working and not otherwise occupied.
     if (!_isWandering && !_isGreeting && !_serverControlled &&

--- a/lib/flame/components/player_component.dart
+++ b/lib/flame/components/player_component.dart
@@ -135,7 +135,8 @@ class PlayerComponent extends SpriteAnimationGroupComponent<Direction>
   @override
   void update(double dt) {
     super.update(dt);
-    priority = position.y.round() ~/ gridSquareSize;
+    priority = (position.y.round() ~/ gridSquareSize) * kPriorityStride +
+        (position.x.round().abs() % kPriorityStride);
   }
 
   // We round the player position before calculating the miniGrid position,

--- a/lib/flame/shared/constants.dart
+++ b/lib/flame/shared/constants.dart
@@ -4,6 +4,14 @@ const int gridSize = 50;
 const int gridSquareSize = 32;
 const double gridSquareSizeDouble = 32;
 
+/// Stride between depth-sort rows for Flame component priority.
+///
+/// Priorities are `row * kPriorityStride + tieBreaker` where tieBreaker is
+/// in [0, kPriorityStride). Must be large enough that bubbles (+1) never
+/// cross the row boundary: kPriorityStride > 1. Using 1000 leaves 999 slots
+/// for intra-row ordering.
+const int kPriorityStride = 1000;
+
 /// Gold accent used for completed-challenge indicators (terminals, editor
 /// badge, etc.).
 const Color completedGold = Color(0xFFFFD700);

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -610,7 +610,7 @@ class TechWorld extends World with TapCallbacks {
 
     // 3. Collect centres for the metaball field.
     final centres = <Vector2>[];
-    int lowestPriority = 999;
+    int lowestPriority = 0x7fffffff; // max int; replaced by first bubble's priority
     for (final entry in _playerBubbles.entries) {
       centres.add(entry.value.center);
       if (entry.value.priority < lowestPriority) {


### PR DESCRIPTION
## Summary
- Two players at the same y-grid-row got identical priorities → non-deterministic render order (flickering)
- Added `position.x` sub-key: `priority = (y ~/ gridSquareSize) * kPriorityStride + (x.abs() % kPriorityStride)`
- Applied consistently across PlayerComponent, BotCharacterComponent, DreamfinderComponent
- Cage-match found 2 real bugs:
  1. `lowestPriority = 999` sentinel broke with `* 1000` stride → merged video bubble rendered under characters. Fixed: `0x7fffffff`
  2. `id.hashCode.abs()` can return negative on Dart VM for `int.minValue`. Switched to `position.x` tie-breaker
- Added shared `kPriorityStride` constant in `constants.dart`

## Severity
MEDIUM — visual flickering + cage-match caught rendering regression

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1420 tests pass
- [ ] Manual: two players at same y — verify stable render order

🤖 Generated with [Claude Code](https://claude.com/claude-code)