### PR TITLE
chore: misc cleanup from Phase 3 audits

### DIFF
--- a/lib/flame/maps/barrier_occlusion.dart
+++ b/lib/flame/maps/barrier_occlusion.dart
@@ -2,6 +2,10 @@ import 'package:tech_world/flame/tiles/tile_layer_data.dart';
 import 'package:tech_world/flame/tiles/tile_ref.dart';
 import 'package:tech_world/flame/tiles/wall_style_def.dart';
 
+/// Maximum horizontal distance (in tiles) scanned when searching for the
+/// closing wall of a doorway gap. Doors wider than this are not recognised.
+const _maxDoorwayScanDistance = 10;
+
 /// Compute priority overrides from a barrier set for y-based depth sorting.
 ///
 /// Detects patterns that need non-default priority:
@@ -56,7 +60,7 @@ Map<(int, int), int> computePriorityOverrides(Set<(int, int)> barriers) {
     if (!barriers.contains((x + 1, y))) {
       // There's a gap starting at x+1. Scan to find where wall resumes.
       var gapEnd = x + 1;
-      while (gapEnd < x + 10 && !barriers.contains((gapEnd, y))) {
+      while (gapEnd < x + _maxDoorwayScanDistance && !barriers.contains((gapEnd, y))) {
         gapEnd++;
       }
       // gapEnd is now the x of the barrier on the right side of the gap.
@@ -104,7 +108,7 @@ Set<(int, int)> computeLintelOverlayPositions(Set<(int, int)> barriers) {
   for (final (x, y) in barriers) {
     if (!barriers.contains((x + 1, y))) {
       var gapEnd = x + 1;
-      while (gapEnd < x + 10 && !barriers.contains((gapEnd, y))) {
+      while (gapEnd < x + _maxDoorwayScanDistance && !barriers.contains((gapEnd, y))) {
         gapEnd++;
       }
       if (barriers.contains((gapEnd, y))) {
@@ -245,7 +249,7 @@ TileLayerData buildObjectLayerFromWalls(Map<(int, int), String> walls) {
     // Place cap tiles above the gap so the wall top continues over the door.
     if (!wallPositions.contains((x + 1, y))) {
       var gapEnd = x + 1;
-      while (gapEnd < x + 10 && !wallPositions.contains((gapEnd, y))) {
+      while (gapEnd < x + _maxDoorwayScanDistance && !wallPositions.contains((gapEnd, y))) {
         gapEnd++;
       }
       if (wallPositions.contains((gapEnd, y))) {
@@ -337,7 +341,7 @@ Map<(int, int), TileRef?> buildWallTilesForRegion(
     // Place cap tiles above the gap so the wall top continues over the door.
     if (!wallPositions.contains((x + 1, y))) {
       var gapEnd = x + 1;
-      while (gapEnd < x + 10 && !wallPositions.contains((gapEnd, y))) {
+      while (gapEnd < x + _maxDoorwayScanDistance && !wallPositions.contains((gapEnd, y))) {
         gapEnd++;
       }
       if (wallPositions.contains((gapEnd, y))) {

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:math';
 import 'dart:ui' as ui;
 
@@ -691,11 +692,11 @@ class TechWorld extends World with TapCallbacks {
 
       // BFS from startKey.
       final group = <String>[startKey];
-      final queue = <String>[startKey];
+      final queue = Queue<String>()..add(startKey);
       visited.add(startKey);
 
       while (queue.isNotEmpty) {
-        final current = queue.removeAt(0);
+        final current = queue.removeFirst();
         final currentCenter = bubbles[current]!.center;
 
         for (final candidateKey in keys) {

--- a/lib/native/video_frame_ffi.dart
+++ b/lib/native/video_frame_ffi.dart
@@ -13,7 +13,8 @@ import 'package:ffi/ffi.dart';
 /// operations will return null/no-op.
 
 /// Whether the current platform supports FFI video capture.
-final bool _isSupported = Platform.isMacOS;
+/// Starts as true on macOS; set to false if native symbols are missing.
+bool _isSupported = Platform.isMacOS;
 
 // Lazy-load the native library to avoid crashes on unsupported platforms
 DynamicLibrary? _nativeLib;
@@ -91,20 +92,25 @@ void _ensureFunctionsLoaded() {
   final lib = _getNativeLib();
   if (lib == null) return;
 
-  _create ??= lib.lookupFunction<_VideoFrameCaptureCreateNative,
-      _VideoFrameCaptureCreate>('video_frame_capture_create');
-  _getBuffer ??= lib.lookupFunction<_VideoFrameCaptureGetBufferNative,
-      _VideoFrameCaptureGetBuffer>('video_frame_capture_get_buffer');
-  _markConsumed ??= lib.lookupFunction<_VideoFrameCaptureMarkConsumedNative,
-      _VideoFrameCaptureMarkConsumed>('video_frame_capture_mark_consumed');
-  _isActive ??= lib.lookupFunction<_VideoFrameCaptureIsActiveNative,
-      _VideoFrameCaptureIsActive>('video_frame_capture_is_active');
-  _destroy ??= lib.lookupFunction<_VideoFrameCaptureDestroyNative,
-      _VideoFrameCaptureDestroy>('video_frame_capture_destroy');
-  _listTracks ??= lib.lookupFunction<_VideoFrameCaptureListTracksNative,
-      _VideoFrameCaptureListTracks>('video_frame_capture_list_tracks');
-  _init ??= lib.lookupFunction<_VideoFrameCaptureInitNative,
-      _VideoFrameCaptureInit>('video_frame_capture_init');
+  try {
+    _create ??= lib.lookupFunction<_VideoFrameCaptureCreateNative,
+        _VideoFrameCaptureCreate>('video_frame_capture_create');
+    _getBuffer ??= lib.lookupFunction<_VideoFrameCaptureGetBufferNative,
+        _VideoFrameCaptureGetBuffer>('video_frame_capture_get_buffer');
+    _markConsumed ??= lib.lookupFunction<_VideoFrameCaptureMarkConsumedNative,
+        _VideoFrameCaptureMarkConsumed>('video_frame_capture_mark_consumed');
+    _isActive ??= lib.lookupFunction<_VideoFrameCaptureIsActiveNative,
+        _VideoFrameCaptureIsActive>('video_frame_capture_is_active');
+    _destroy ??= lib.lookupFunction<_VideoFrameCaptureDestroyNative,
+        _VideoFrameCaptureDestroy>('video_frame_capture_destroy');
+    _listTracks ??= lib.lookupFunction<_VideoFrameCaptureListTracksNative,
+        _VideoFrameCaptureListTracks>('video_frame_capture_list_tracks');
+    _init ??= lib.lookupFunction<_VideoFrameCaptureInitNative,
+        _VideoFrameCaptureInit>('video_frame_capture_init');
+  } catch (e) {
+    stderr.writeln('VideoFrameCapture: native symbols not found: $e');
+    _isSupported = false;
+  }
 }
 
 /// Video frame buffer structure matching the native C struct.

--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -434,6 +434,8 @@ class DirectTrackCapture {
     stopCapture();
     _currentFrame?.dispose();
     _currentFrame = null;
+    _readbackCanvas = null;
+    _readbackCtx = null;
     _log.info('DirectTrackCapture: Disposed');
   }
 }
@@ -867,6 +869,8 @@ class VideoElementCapture implements FrameSource {
     stopCapture();
     _currentFrame?.dispose();
     _currentFrame = null;
+    _readbackCanvas = null;
+    _readbackCtx = null;
 
     // Only clean up video element if we created it
     if (ownsElement) {


### PR DESCRIPTION
## Summary
- Null `_readbackCanvas`/`_readbackCtx` on dispose for earlier GC (~1.17 MB per capture)
- Wrap FFI symbol lookup in try/catch — graceful degradation when plugin not linked
- Replace magic `10` with `_maxDoorwayScanDistance` constant in barrier occlusion (4 sites)
- Use `Queue<String>` instead of `List.removeAt(0)` for BFS merge detection

## Severity
LOW — memory, robustness, readability improvements

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1420 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)