### PR TITLE
fix(multiplayer): defensive PositionHeartbeat parser

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -868,12 +868,17 @@ class PositionHeartbeat {
 
   /// Try to parse a [PositionHeartbeat] from a JSON map. Returns null if
   /// required fields are missing or have wrong types.
+  ///
+  /// Uses `is` checks rather than `as` casts so a malformed packet from
+  /// any participant returns null rather than throwing — a thrown error
+  /// inside the stream's `.map` would propagate and tear down the
+  /// heartbeat-reception stream for the rest of the session.
   static PositionHeartbeat? tryParse(Map<String, dynamic>? json) {
     if (json == null) return null;
-    final playerId = json['playerId'] as String?;
-    final x = json['x'] as int?;
-    final y = json['y'] as int?;
-    if (playerId == null || x == null || y == null) return null;
+    final playerId = json['playerId'];
+    final x = json['x'];
+    final y = json['y'];
+    if (playerId is! String || x is! int || y is! int) return null;
     return PositionHeartbeat(playerId: playerId, x: x, y: y);
   }
 }

--- a/test/livekit/position_heartbeat_test.dart
+++ b/test/livekit/position_heartbeat_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+
+void main() {
+  // PositionHeartbeat ships in the audit/position-heartbeat branch as the
+  // wire-format type for the reliable 2-second position correction. The
+  // parser is the single source of truth for what a valid heartbeat
+  // payload looks like — every dropped/malformed packet flows through
+  // tryParse and either teleports a remote player to a new position or
+  // silently drops. A bug here either:
+  //   - rejects valid payloads (remote players freeze in stale positions)
+  //   - accepts wrong-shaped payloads (player teleports to (null,null) or
+  //     to coordinates from another player's frame).
+  //
+  // The Dart type system can't express "this Map matches this shape" so
+  // these failure modes are exactly what tests should catch.
+
+  group('PositionHeartbeat.tryParse', () {
+    test('parses a well-formed heartbeat', () {
+      final hb = PositionHeartbeat.tryParse({
+        'playerId': 'user-42',
+        'x': 7,
+        'y': 3,
+      });
+      expect(hb, isNotNull);
+      expect(hb!.playerId, 'user-42');
+      expect(hb.x, 7);
+      expect(hb.y, 3);
+    });
+
+    test('returns null for null map (defensive against malformed JSON)', () {
+      expect(PositionHeartbeat.tryParse(null), isNull);
+    });
+
+    test('returns null when playerId is missing', () {
+      expect(PositionHeartbeat.tryParse({'x': 1, 'y': 2}), isNull);
+    });
+
+    test('returns null when x is missing', () {
+      expect(
+        PositionHeartbeat.tryParse({'playerId': 'u', 'y': 2}),
+        isNull,
+      );
+    });
+
+    test('returns null when y is missing', () {
+      expect(
+        PositionHeartbeat.tryParse({'playerId': 'u', 'x': 1}),
+        isNull,
+      );
+    });
+
+    test('returns null when playerId is the wrong type', () {
+      // A bot or older client could publish a numeric id; the receiver
+      // must drop it rather than crash.
+      expect(
+        PositionHeartbeat.tryParse({'playerId': 42, 'x': 1, 'y': 2}),
+        isNull,
+      );
+    });
+
+    test('returns null when x is a double rather than int', () {
+      // Heartbeat is grid-quantized; a fractional coordinate is malformed
+      // and must not be silently truncated. This pins the int contract
+      // so a future loosening to "num" is an explicit decision, not a
+      // surprise that lets continuous-position drift through.
+      expect(
+        PositionHeartbeat.tryParse({'playerId': 'u', 'x': 1.5, 'y': 2}),
+        isNull,
+      );
+    });
+
+    test('accepts negative coordinates (off-origin maps are valid)', () {
+      // The grid origin is not always (0,0) — some maps extend into
+      // negative coordinates. A naive `x >= 0` check would silently drop
+      // these.
+      final hb = PositionHeartbeat.tryParse({
+        'playerId': 'u',
+        'x': -5,
+        'y': -3,
+      });
+      expect(hb, isNotNull);
+      expect(hb!.x, -5);
+      expect(hb.y, -3);
+    });
+
+    test('accepts zero coordinates', () {
+      final hb = PositionHeartbeat.tryParse({
+        'playerId': 'u',
+        'x': 0,
+        'y': 0,
+      });
+      expect(hb, isNotNull);
+    });
+
+    test('returns null for empty map', () {
+      expect(PositionHeartbeat.tryParse(<String, dynamic>{}), isNull);
+    });
+
+    test('ignores extra fields rather than rejecting (forward-compat)', () {
+      // If a future client adds an `avatar` or `version` field, older
+      // clients should still teleport, not freeze.
+      final hb = PositionHeartbeat.tryParse({
+        'playerId': 'u',
+        'x': 1,
+        'y': 2,
+        'avatarId': 'wizard',
+        'version': 2,
+      });
+      expect(hb, isNotNull);
+      expect(hb!.x, 1);
+      expect(hb.y, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Hotfix for a regression in #322 (just merged today). The `PositionHeartbeat.tryParse` implementation uses `as int?` casts, which throw `TypeError` on wrong-typed payloads (e.g. a fractional `x` coordinate) instead of returning `null` as the docstring promises.

That throw propagates up through the broadcast stream's `.map` and tears down `positionHeartbeatReceived` for the rest of the session — so **one malformed packet from any participant permanently disables the heartbeat correction the PR was meant to provide.** The bug nullifies #322's user-visible benefit on the first wrong-typed payload from any client, ever.

## What changed

- `lib/livekit/livekit_service.dart`: `PositionHeartbeat.tryParse` switched from `as int?` casts to `is` type-tests, matching the docstring's "returns null... if fields have wrong types"
- `test/livekit/position_heartbeat_test.dart`: 11 new tests, one per documented failure mode (missing field, wrong type, fractional coordinate, empty map, null input, plus forward-compat for unknown extra fields)

## How the bug was found

Audit pass over the test suite asking "would this catch a real bug?" of every test, and which features had no tests. The just-shipped heartbeat had zero coverage despite being a wire-format parser with several null-return failure modes. Writing those tests against the actual implementation made the bug visible: the `fractional x` test would fail against the original code with a `TypeError`, not a graceful `null`.

## Test plan

- [x] `flutter test test/livekit/position_heartbeat_test.dart` — 11/11 pass
- [x] `flutter test` — full suite green (1442/1442)
- [ ] Manual verification: connect two clients, publish a deliberately-wrong-typed heartbeat from devtools, confirm the receiving client logs the drop rather than freezing all subsequent heartbeats

🤖 Generated with [Claude Code](https://claude.com/claude-code)