### PR TITLE
fix(infra): target infra-heal message at Dreamfinder agent only

### DIFF
--- a/lib/infra/infra_health_service.dart
+++ b/lib/infra/infra_health_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:tech_world/bots/bot_config.dart';
 import 'package:tech_world/infra/infra_health_state.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
@@ -112,6 +113,7 @@ class InfraHealthService {
     await _liveKitService.publishJson(
       {'service': serviceId, 'action': 'restart'},
       topic: 'infra-heal',
+      destinationIdentities: [dreamfinderBot.identity],
     );
   }
 


### PR DESCRIPTION
## Summary

- `requestHeal` in `InfraHealthService` was calling `publishJson` without `destinationIdentities`, broadcasting the `infra-heal` restart command to all room participants
- Added `destinationIdentities: [dreamfinderBot.identity]` to restrict delivery exclusively to `bot-dreamfinder`
- Added `import 'package:tech_world/bots/bot_config.dart'` to reference the constant

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)