### PR TITLE
security: remove hardcoded DREAMFINDER_API_KEY default

### DIFF
--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -132,11 +132,7 @@ class RoomSession {
       repository: chatRepo,
       dreamfinderClient: DreamfinderClient(
         baseUrl: 'https://dreamfinder.imagineering.cc',
-        apiKey: const String.fromEnvironment(
-          'DREAMFINDER_API_KEY',
-          defaultValue:
-              '2aa0e9ab3207b197dc0d392fe6e35e8cbe8bfa78f72ce7f9',
-        ),
+        apiKey: const String.fromEnvironment('DREAMFINDER_API_KEY'),
       ),
     );
     final proximity = ProximityService();

--- a/lib/services/dreamfinder_client.dart
+++ b/lib/services/dreamfinder_client.dart
@@ -50,6 +50,10 @@ class DreamfinderClient {
     required String senderName,
     required Map<String, dynamic> payload,
   }) async {
+    if (apiKey.isEmpty) {
+      _log.warning('DREAMFINDER_API_KEY not set — skipping event "$topic"');
+      return;
+    }
     try {
       final response = await _client
           .post(


### PR DESCRIPTION
## Summary

- Removes the hardcoded 48-char hex key from `String.fromEnvironment('DREAMFINDER_API_KEY', defaultValue: '...')` in `lib/rooms/room_session.dart` — `defaultValue` is now `''` (the Dart default, same as omitting the parameter)
- Adds an early-return guard in `DreamfinderClient.sendEvent` so builds without the key silently skip API calls and log a warning, rather than firing auth-failing HTTP requests

## Why

On web builds, the `defaultValue` string is baked literally into the compiled JS output and is readable by anyone with DevTools. Anyone with the key can impersonate the game server to the Dreamfinder API.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1474 tests pass
- [ ] Build without `--dart-define=DREAMFINDER_API_KEY=...` and confirm no network requests are sent to dreamfinder.imagineering.cc (log warning appears instead)
- [ ] Build with key set and confirm events still reach Dreamfinder normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)