### PR TITLE
fix(map-editor): guard MapEditBatch.fromJson against malformed messages

### DIFF
--- a/lib/map_editor/map_sync_service.dart
+++ b/lib/map_editor/map_sync_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
 import 'package:tech_world/flame/maps/barrier_occlusion.dart'
     show buildWallTilesForRegion;
 import 'package:tech_world/flame/shared/constants.dart';
@@ -10,6 +11,8 @@ import 'package:tech_world/map_editor/crdt/cell_version_map.dart';
 import 'package:tech_world/map_editor/crdt/map_edit_op.dart';
 import 'package:tech_world/map_editor/crdt/undo_manager.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
+
+final _log = Logger('MapSyncService');
 
 /// Orchestrates collaborative map editing over LiveKit data channels.
 ///
@@ -577,7 +580,13 @@ class MapSyncService {
     if (json == null) return;
 
     if (msg.topic == _editTopic) {
-      final batch = MapEditBatch.fromJson(json);
+      final MapEditBatch batch;
+      try {
+        batch = MapEditBatch.fromJson(json);
+      } catch (e, stack) {
+        _log.warning('Ignoring malformed map-edit message', e, stack);
+        return;
+      }
       if (batch.ops.isEmpty) return;
       if (_isSyncing) {
         _syncBuffer.add(batch);


### PR DESCRIPTION
## Summary
- Wraps `MapEditBatch.fromJson` in try/catch in the data channel stream listener
- A single malformed `map-edit` message from any participant would previously throw and permanently kill collaborative editing for the session
- Now logs a warning and returns early, matching the `tryParse` pattern used by `PositionHeartbeat` and `AvatarUpdate`

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] All 1474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)