### PR TITLE
fix(firestore): restrict private room reads to owner and editors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,11 +13,15 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // Rooms — any authenticated user can read (public listing + joining).
-    // Private room filtering is handled client-side; the query itself
-    // filters on isPublic so private rooms won't appear in browse results.
+    // Rooms — public rooms are readable by any authenticated user (for browse
+    // listing). Private rooms are only readable by their owner and editors.
+    // The listPublicRooms() query filters on isPublic == true so it satisfies
+    // this rule. listMyRooms() queries on ownerId so those docs also pass.
     match /rooms/{roomId} {
-      allow read: if request.auth != null;
+      allow read: if request.auth != null &&
+        (resource.data.isPublic == true ||
+         request.auth.uid == resource.data.ownerId ||
+         request.auth.uid in resource.data.editorIds);
 
       // Anyone signed in can create (must set themselves as owner)
       allow create: if request.auth != null &&


### PR DESCRIPTION
## Summary
- Private rooms were readable by any authenticated user via direct document access
- Client-side `isPublic` filtering only hid them from the browse UI, not Firestore
- Now `allow read` requires `isPublic == true || uid == ownerId || uid in editorIds`

Existing queries are unaffected:
- `listPublicRooms()` filters on `isPublic == true` — passes the new rule
- `listMyRooms()` queries on `ownerId == uid` — passes the new rule
- Editors joining by room ID — passes via `editorIds` check

## Test plan
- [ ] Verify public room browse still works
- [ ] Verify private room access by owner works
- [ ] Verify private room access by non-member is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)