### PR TITLE
fix(ffi): add error field check and buffer size guards to getPixels

### DIFF
--- a/lib/native/video_frame_ffi.dart
+++ b/lib/native/video_frame_ffi.dart
@@ -242,7 +242,14 @@ class VideoFrameCapture {
   Uint8List? getPixels() {
     if (_disposed || _buffer == null || _buffer == nullptr) return null;
     final buf = _buffer!.ref;
+    if (buf.error != 0) return null;
     if (buf.ready != 1) return null;
+    if (buf.width == 0 ||
+        buf.height == 0 ||
+        buf.height > 4096 ||
+        buf.bytesPerRow > 16384) {
+      return null;
+    }
 
     _lastFrameNumber = buf.frameNumber;
 


### PR DESCRIPTION
## Summary
- Check `buf.error != 0` before reading pixels — a native-side error with `ready=1` would previously read from an invalid buffer
- Reject extreme dimensions (`height > 4096`, `bytesPerRow > 16384`) to prevent `asTypedList` from wrapping absurdly large memory

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] All 1474 tests pass
- [ ] Verify video bubbles still render on macOS (defensive guard — normal frames unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)