### PR TITLE
fix(security): prevent editor privilege escalation in Firestore room update rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,10 +23,13 @@ service cloud.firestore {
       allow create: if request.auth != null &&
         request.auth.uid == request.resource.data.ownerId;
 
-      // Owner and editors can update
+      // Owner and editors can update.
+      // Editors cannot modify ownerId or editorIds (prevents privilege escalation).
       allow update: if request.auth != null &&
         (request.auth.uid == resource.data.ownerId ||
-         request.auth.uid in resource.data.editorIds);
+         (request.auth.uid in resource.data.editorIds &&
+          !request.resource.data.diff(resource.data).affectedKeys()
+           .hasAny(['ownerId', 'editorIds'])));
 
       // Only owner can delete
       allow delete: if request.auth != null &&


### PR DESCRIPTION
## Summary

- Editors could call `.update({ownerId: theirUid})` to steal ownership of any room they had edit access to
- Added field-level constraints using `affectedKeys().hasAny(['ownerId', 'editorIds'])` so editors cannot modify those fields
- Owners retain full update rights (including transferring ownership or changing editor lists)

## Change

`firestore.rules` lines 26–32: tightened the `allow update` rule for `/rooms/{roomId}`.

**Before:** any editor could update any field, including `ownerId`  
**After:** editors can update all fields *except* `ownerId` and `editorIds`

## Test plan

- [ ] Verify owner can still update all room fields (name, isPublic, map, etc.)
- [ ] Verify owner can transfer ownership by changing `ownerId`
- [ ] Verify owner can add/remove editors via `editorIds`
- [ ] Verify editor can update non-sensitive fields (e.g. room name)
- [ ] Verify editor `.update({ownerId: editorUid})` is rejected by the rules emulator
- [ ] Verify editor `.update({editorIds: [...]})` is rejected by the rules emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)