### PR TITLE
audit: add v:1 protocol version to all LiveKit data channel messages

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -36,6 +36,9 @@ enum ConnectionResult {
 
 final _log = Logger('LiveKitService');
 
+/// Protocol version stamped on every outgoing LiveKit data channel message.
+const kProtocolVersion = 1;
+
 /// Service that manages LiveKit room connection and participant tracking.
 ///
 /// This service:
@@ -438,7 +441,7 @@ class LiveKitService {
     List<String>? destinationIdentities,
     String? topic,
   }) async {
-    final versioned = {'v': 1, ...json};
+    final versioned = {'v': kProtocolVersion, ...json};
     final data = utf8.encode(jsonEncode(versioned));
     await publishData(
       data,

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -426,13 +426,20 @@ class LiveKitService {
   /// Publish a JSON message to the room via data channel.
   ///
   /// Convenience method that encodes [json] as UTF-8 bytes.
+  ///
+  /// A `v: 1` protocol version field is automatically added to every outgoing
+  /// message. Old clients that don't recognise the field will ignore it
+  /// (forward-compatible). Receivers should NOT reject messages that lack
+  /// the field, so backward-compatibility with pre-versioned clients is
+  /// maintained.
   Future<void> publishJson(
     Map<String, dynamic> json, {
     bool reliable = true,
     List<String>? destinationIdentities,
     String? topic,
   }) async {
-    final data = utf8.encode(jsonEncode(json));
+    final versioned = {'v': 1, ...json};
+    final data = utf8.encode(jsonEncode(versioned));
     await publishData(
       data,
       reliable: reliable,

--- a/test/livekit/livekit_service_test.dart
+++ b/test/livekit/livekit_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
@@ -161,6 +162,70 @@ void main() {
       });
     });
 
+    group('protocol version field', () {
+      test('publishJson injects v:1 into every outgoing message', () async {
+        // Capture the bytes that would be sent via publishData.
+        List<int>? capturedData;
+        final service = _CapturingLiveKitService(
+          userId: 'test-user',
+          displayName: 'Test',
+          onPublishData: (data) => capturedData = data,
+        );
+
+        await service.publishJson({'key': 'value'}, topic: 'test');
+
+        expect(capturedData, isNotNull);
+        final decoded = jsonDecode(utf8.decode(capturedData!)) as Map<String, dynamic>;
+        expect(decoded['v'], equals(1),
+            reason: 'Every outgoing message must carry v:1');
+        expect(decoded['key'], equals('value'),
+            reason: 'Original payload fields must be preserved');
+
+        await service.dispose();
+      });
+
+      test('publishJson preserves caller fields and does not double-version',
+          () async {
+        List<int>? capturedData;
+        final service = _CapturingLiveKitService(
+          userId: 'test-user',
+          displayName: 'Test',
+          onPublishData: (data) => capturedData = data,
+        );
+
+        await service.publishJson(
+          {'type': 'heartbeat', 'playerId': 'u1'},
+          topic: 'position-heartbeat',
+        );
+
+        final decoded = jsonDecode(utf8.decode(capturedData!)) as Map<String, dynamic>;
+        expect(decoded['v'], equals(1));
+        expect(decoded['type'], equals('heartbeat'));
+        expect(decoded['playerId'], equals('u1'));
+        // Exactly one 'v' key — no duplicate
+        expect(decoded.keys.where((k) => k == 'v'), hasLength(1));
+
+        await service.dispose();
+      });
+
+      test('DataChannelMessage.json does not reject messages without v field',
+          () {
+        // Old clients that don't include 'v' should still be parseable.
+        final legacyBytes = utf8.encode(jsonEncode({'playerId': 'old-client', 'x': 5}));
+        final msg = DataChannelMessage(
+          senderId: 'old-client',
+          topic: 'position-heartbeat',
+          data: legacyBytes,
+        );
+
+        final json = msg.json;
+        expect(json, isNotNull);
+        expect(json!['playerId'], equals('old-client'));
+        // No 'v' field is fine — backward compatibility
+        expect(json.containsKey('v'), isFalse);
+      });
+    });
+
     group('setCameraEnabled without connection', () {
       test('returns early when not connected', () async {
         final service = LiveKitService(
@@ -235,4 +300,27 @@ void main() {
       });
     });
   });
+}
+
+/// A [LiveKitService] subclass that intercepts [publishData] calls so tests
+/// can inspect the encoded bytes without requiring a live LiveKit connection.
+class _CapturingLiveKitService extends LiveKitService {
+  _CapturingLiveKitService({
+    required super.userId,
+    required super.displayName,
+    required void Function(List<int> data) onPublishData,
+  }) : _onPublishData = onPublishData;
+
+  final void Function(List<int> data) _onPublishData;
+
+  @override
+  Future<void> publishData(
+    List<int> data, {
+    bool reliable = true,
+    List<String>? destinationIdentities,
+    String? topic,
+  }) async {
+    // Capture the bytes instead of sending them to a real room.
+    _onPublishData(data);
+  }
 }


### PR DESCRIPTION
## Summary

- Injects `v: 1` automatically in `publishJson`, so every outgoing data channel message carries a protocol version field without touching any call site.
- Old clients that don't recognise `v` will ignore it (forward-compatible).
- Receivers do not reject messages without `v` (backward-compatible with pre-versioned bots and clients).

## What changed

**`lib/livekit/livekit_service.dart`**
- `publishJson` now builds `{'v': 1, ...json}` before encoding. Single injection point covers all 9 call sites (`publishAvatar`, `publishMapInfo`, `publishMapSwitch`, `publishPosition`, `startPositionHeartbeat`, `publishTerminalActivity`, `sendPing`, and any future additions).

**`test/livekit/livekit_service_test.dart`**
- New `protocol version field` group with 3 tests:
  1. `publishJson injects v:1 into every outgoing message` — verifies the field is present and payload fields are preserved.
  2. `publishJson preserves caller fields and does not double-version` — verifies no duplicate `v` key when caller also passes structured fields.
  3. `DataChannelMessage.json does not reject messages without v field` — confirms backward-compatibility with old clients.
- Added `_CapturingLiveKitService` test helper that overrides `publishData` to intercept bytes without a live connection.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 72/72 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)