### PR TITLE
fix(livekit): whitelist spriteAsset in AvatarUpdate to prevent cache crash

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:logging/logging.dart';
 import 'package:tech_world/avatar/avatar.dart';
+import 'package:tech_world/avatar/predefined_avatars.dart';
 import 'package:tech_world/bots/bot_config.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/shared/constants.dart';
@@ -833,13 +834,20 @@ class AvatarUpdate {
   final String spriteAsset;
 
   /// Try to parse an [AvatarUpdate] from a JSON map. Returns null if required
-  /// fields are missing or have wrong types.
+  /// fields are missing, have wrong types, or contain an unknown sprite asset.
   ///
   /// Uses Dart 3 map patterns so a wrong-typed value returns null rather
   /// than throwing — a thrown error inside the stream's `.map` callback
   /// would tear down avatar reception for the rest of the session.
+  ///
+  /// The [spriteAsset] value is validated against [predefinedAvatars] to
+  /// prevent a malicious participant from supplying an unknown asset name that
+  /// would cause `game.images.fromCache` to throw a [StateError] and crash
+  /// rendering for that player component.
   static AvatarUpdate? tryParse(Map<String, dynamic>? json) {
     if (json case {'playerId': String playerId, 'spriteAsset': String spriteAsset}) {
+      final knownAssets = predefinedAvatars.map((a) => a.spriteAsset).toSet();
+      if (!knownAssets.contains(spriteAsset)) return null;
       final avatarId = switch (json['avatarId']) { String s => s, _ => '' };
       return AvatarUpdate(
         playerId: playerId,

--- a/test/livekit/avatar_update_test.dart
+++ b/test/livekit/avatar_update_test.dart
@@ -3,22 +3,62 @@ import 'package:tech_world/livekit/livekit_service.dart';
 
 void main() {
   group('AvatarUpdate.tryParse', () {
-    test('parses well-formed update', () {
+    test('parses well-formed update with known sprite asset', () {
       final update = AvatarUpdate.tryParse({
         'playerId': 'user-1',
-        'avatarId': 'wizard',
-        'spriteAsset': 'assets/wizard.png',
+        'avatarId': 'npc11',
+        'spriteAsset': 'NPC11.png',
       });
       expect(update, isNotNull);
       expect(update!.playerId, 'user-1');
-      expect(update.avatarId, 'wizard');
-      expect(update.spriteAsset, 'assets/wizard.png');
+      expect(update.avatarId, 'npc11');
+      expect(update.spriteAsset, 'NPC11.png');
+    });
+
+    test('accepts all predefined sprite assets', () {
+      for (final asset in ['NPC11.png', 'NPC12.png', 'NPC13.png']) {
+        final update = AvatarUpdate.tryParse({
+          'playerId': 'user-1',
+          'spriteAsset': asset,
+        });
+        expect(update, isNotNull, reason: 'Expected $asset to be accepted');
+      }
+    });
+
+    test('rejects unknown sprite asset', () {
+      expect(
+        AvatarUpdate.tryParse({
+          'playerId': 'user-1',
+          'spriteAsset': 'malicious_asset.png',
+        }),
+        isNull,
+      );
+    });
+
+    test('rejects path-traversal attempt in sprite asset', () {
+      expect(
+        AvatarUpdate.tryParse({
+          'playerId': 'user-1',
+          'spriteAsset': '../../etc/passwd',
+        }),
+        isNull,
+      );
+    });
+
+    test('rejects empty string sprite asset', () {
+      expect(
+        AvatarUpdate.tryParse({
+          'playerId': 'user-1',
+          'spriteAsset': '',
+        }),
+        isNull,
+      );
     });
 
     test('defaults avatarId to empty string when missing', () {
       final update = AvatarUpdate.tryParse({
         'playerId': 'user-1',
-        'spriteAsset': 'assets/wizard.png',
+        'spriteAsset': 'NPC11.png',
       });
       expect(update, isNotNull);
       expect(update!.avatarId, '');
@@ -28,7 +68,7 @@ void main() {
       final update = AvatarUpdate.tryParse({
         'playerId': 'user-1',
         'avatarId': 42,
-        'spriteAsset': 'assets/wizard.png',
+        'spriteAsset': 'NPC11.png',
       });
       expect(update, isNotNull);
       expect(update!.avatarId, '');
@@ -40,7 +80,7 @@ void main() {
 
     test('returns null when playerId is missing', () {
       expect(
-        AvatarUpdate.tryParse({'spriteAsset': 'assets/wizard.png'}),
+        AvatarUpdate.tryParse({'spriteAsset': 'NPC11.png'}),
         isNull,
       );
     });
@@ -56,7 +96,7 @@ void main() {
       expect(
         AvatarUpdate.tryParse({
           'playerId': 123,
-          'spriteAsset': 'assets/wizard.png',
+          'spriteAsset': 'NPC11.png',
         }),
         isNull,
       );
@@ -75,8 +115,8 @@ void main() {
     test('ignores extra fields (forward-compat)', () {
       final update = AvatarUpdate.tryParse({
         'playerId': 'user-1',
-        'avatarId': 'wizard',
-        'spriteAsset': 'assets/wizard.png',
+        'avatarId': 'npc12',
+        'spriteAsset': 'NPC12.png',
         'version': 2,
         'color': 'blue',
       });


### PR DESCRIPTION
## Summary

- A malicious participant could broadcast an `avatar` topic message with an arbitrary `spriteAsset` string, causing `game.images.fromCache` to throw a `StateError` and crash rendering for that player component.
- `AvatarUpdate.tryParse` now validates `spriteAsset` against the set of known assets in `predefinedAvatars` before accepting the update. Any unknown value returns `null`, which the stream silently drops — consistent with the existing null-return pattern for malformed messages.
- 5 new tests cover the whitelist (valid assets accepted, unknown rejected, path-traversal rejected, empty string rejected), and existing tests updated to use real asset names.

## Test plan

- [x] `flutter test test/livekit/avatar_update_test.dart` — all 14 tests pass
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1478 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)