### PR TITLE
feat(audit): wire DataTopic enum into all production topic sites

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -9,6 +9,7 @@ import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/bots/bot_config.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/services/dreamfinder_client.dart';
 import 'package:tech_world/services/tts_service.dart';
@@ -163,15 +164,15 @@ class ChatService {
     // Listen for group chat messages and bot responses
     _chatSubscription = _liveKitService.dataReceived
         .where((msg) =>
-            msg.topic == 'chat' ||
-            msg.topic == 'chat-response' ||
-            msg.topic == 'dm' ||
-            msg.topic == 'dm-response')
+            msg.topic == DataTopic.chat.wireName ||
+            msg.topic == DataTopic.chatResponse.wireName ||
+            msg.topic == DataTopic.dm.wireName ||
+            msg.topic == DataTopic.dmResponse.wireName)
         .listen(_handleMessage);
 
     // Listen for help-response messages from the bot
     _helpResponseSubscription = _liveKitService.dataReceived
-        .where((msg) => msg.topic == 'help-response')
+        .where((msg) => msg.topic == DataTopic.helpResponse.wireName)
         .listen(_handleHelpResponse);
   }
 
@@ -237,12 +238,12 @@ class ChatService {
     if (ownId != null) _markSeen(ownId);
 
     final isDm =
-        message.topic == 'dm' || message.topic == 'dm-response';
+        message.topic == DataTopic.dm.wireName || message.topic == DataTopic.dmResponse.wireName;
 
     // Skip our own outgoing group messages (we add them locally).
     // DMs from self are also added locally in sendDm, so skip those too.
     final isFromSelf = message.senderId == _liveKitService.userId;
-    if (isFromSelf && (message.topic == 'chat' || message.topic == 'dm')) {
+    if (isFromSelf && (message.topic == DataTopic.chat.wireName || message.topic == DataTopic.dm.wireName)) {
       return;
     }
 
@@ -255,9 +256,9 @@ class ChatService {
         text: text,
         senderName: senderName,
         senderId: senderId ?? 'unknown',
-        isResponse: message.topic == 'dm-response',
+        isResponse: message.topic == DataTopic.dmResponse.wireName,
       );
-    } else if (message.topic == 'chat-response') {
+    } else if (message.topic == DataTopic.chatResponse.wireName) {
       // Bot response — use sender info from payload (supports multiple bots).
       botStatusNotifier.value = BotStatus.idle;
       _messages.add(ChatMessage(
@@ -410,7 +411,7 @@ class ChatService {
         metadata?.entries.where((e) => !reservedKeys.contains(e.key));
 
     final payload = {
-      'type': 'chat',
+      'type': DataTopic.chat.wireName,
       'id': messageId,
       'text': text,
       'senderName': _liveKitService.displayName,
@@ -420,7 +421,7 @@ class ChatService {
 
     await _liveKitService.publishJson(
       payload,
-      topic: 'chat',
+      topic: DataTopic.chat.wireName,
       // No destinationIdentities = broadcast to all
     );
 
@@ -618,7 +619,7 @@ class ChatService {
 
     // Send via LiveKit targeted data channel.
     final payload = {
-      'type': 'dm',
+      'type': DataTopic.dm.wireName,
       'id': messageId,
       'text': text,
       'senderName': _liveKitService.displayName,
@@ -628,7 +629,7 @@ class ChatService {
 
     await _liveKitService.publishJson(
       payload,
-      topic: 'dm',
+      topic: DataTopic.dm.wireName,
       destinationIdentities: [peerId],
     );
 
@@ -773,7 +774,7 @@ class ChatService {
     _pendingHelpRequests[requestId] = completer;
 
     final payload = {
-      'type': 'help-request',
+      'type': DataTopic.helpRequest.wireName,
       'id': requestId,
       'challengeId': challengeId,
       'challengeTitle': challengeTitle,
@@ -787,7 +788,7 @@ class ChatService {
 
     await _liveKitService.publishJson(
       payload,
-      topic: 'help-request',
+      topic: DataTopic.helpRequest.wireName,
       destinationIdentities: [_activeBotIdentity],
     );
 
@@ -855,7 +856,7 @@ class ChatService {
         roomId,
         conversationId: convId,
         participants: participants,
-        type: 'dm',
+        type: DataTopic.dm.wireName,
         lastMessageText: message.text,
       )
           .catchError((Object e) {

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -48,7 +48,6 @@ import 'package:tech_world/flame/tech_world_game.dart';
 import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/infra/infra_health_service.dart';
 import 'package:tech_world/avatar/predefined_avatars.dart';
-import 'package:tech_world/livekit/dreamfinder_avatar_bridge.dart';
 import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/progress/progress_service.dart';

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -48,6 +48,8 @@ import 'package:tech_world/flame/tech_world_game.dart';
 import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/infra/infra_health_service.dart';
 import 'package:tech_world/avatar/predefined_avatars.dart';
+import 'package:tech_world/livekit/dreamfinder_avatar_bridge.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/progress/progress_service.dart';
 import 'package:tech_world/utils/locator.dart';
@@ -772,7 +774,7 @@ class TechWorld extends World with TapCallbacks {
 
     // Subscribe to speech transcripts for in-game speech bubbles.
     _speechTranscriptSubscription = _liveKitService!.dataReceived
-        .where((msg) => msg.topic == 'speech-transcript')
+        .where((msg) => msg.topic == DataTopic.speechTranscript.wireName)
         .listen(_handleSpeechTranscript);
 
     // Subscribe to door-unlock events from other players so doors they
@@ -1348,11 +1350,11 @@ class TechWorld extends World with TapCallbacks {
     // Broadcast to other players.
     _liveKitService?.publishJson(
       {
-        'type': 'door-unlock',
+        'type': DataTopic.doorUnlock.wireName,
         'doorX': door.position.x,
         'doorY': door.position.y,
       },
-      topic: 'door-unlock',
+      topic: DataTopic.doorUnlock.wireName,
     );
 
     _log.info('Door unlocked at (${door.position.x}, ${door.position.y})');

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -780,7 +780,7 @@ class TechWorld extends World with TapCallbacks {
     // Subscribe to door-unlock events from other players so doors they
     // unlock become passable locally (barrier removed, proximity updated).
     _doorUnlockSubscription = _liveKitService!.dataReceived
-        .where((msg) => msg.topic == 'door-unlock')
+        .where((msg) => msg.topic == DataTopic.doorUnlock.wireName)
         .listen(_handleRemoteDoorUnlock);
 
     // Infrastructure health monitoring.

--- a/lib/infra/infra_health_service.dart
+++ b/lib/infra/infra_health_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:tech_world/infra/infra_health_state.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
 final _log = Logger('InfraHealthService');
@@ -20,15 +21,15 @@ class InfraHealthService {
   InfraHealthService({required LiveKitService liveKitService})
       : _liveKitService = liveKitService {
     _healthSubscription = _liveKitService.dataReceived
-        .where((msg) => msg.topic == 'infra-health')
+        .where((msg) => msg.topic == DataTopic.infraHealth.wireName)
         .listen(_onHealthMessage);
 
     _healResultSubscription = _liveKitService.dataReceived
-        .where((msg) => msg.topic == 'infra-heal-result')
+        .where((msg) => msg.topic == DataTopic.infraHealResult.wireName)
         .listen(_onHealResult);
 
     _bootSubscription = _liveKitService.dataReceived
-        .where((msg) => msg.topic == 'infra-boot')
+        .where((msg) => msg.topic == DataTopic.infraBoot.wireName)
         .listen(_onBootMessage);
 
     // Mark all services as unknown if no heartbeat arrives within 2× the
@@ -111,7 +112,7 @@ class InfraHealthService {
     _log.info('Requesting heal for $serviceId');
     await _liveKitService.publishJson(
       {'service': serviceId, 'action': 'restart'},
-      topic: 'infra-heal',
+      topic: DataTopic.infraHeal.wireName,
     );
   }
 

--- a/lib/livekit/data_topic.dart
+++ b/lib/livekit/data_topic.dart
@@ -21,6 +21,7 @@
 enum DataTopic {
   // ── Player presence ────────────────────────────────────────────────────────
   position('position'),
+  positionHeartbeat('position-heartbeat'),
   avatar('avatar'),
 
   // ── Chat ───────────────────────────────────────────────────────────────────
@@ -34,6 +35,7 @@ enum DataTopic {
   // ── Map & Navigation ───────────────────────────────────────────────────────
   mapInfo('map-info'),
   mapInfoRequest('map-info-request'),
+  mapSwitch('map-switch'),
   mapEdit('map-edit'),
   mapEditSync('map-edit-sync'),
 

--- a/lib/livekit/data_topic.dart
+++ b/lib/livekit/data_topic.dart
@@ -1,0 +1,77 @@
+/// Typed identifiers for LiveKit data-channel topics.
+///
+/// Replaces scattered string literals with a single exhaustive enum.
+/// Wire names are preserved verbatim for protocol compatibility.
+///
+/// Usage at a **producer** site:
+/// ```dart
+/// await publishJson(message, topic: DataTopic.chat.wireName);
+/// ```
+///
+/// Usage at a **consumer** site (filter):
+/// ```dart
+/// dataReceived.where((msg) => msg.topic == DataTopic.position.wireName)
+/// ```
+///
+/// Usage at a **consumer** site (switch dispatch):
+/// ```dart
+/// final topic = DataTopic.parse(msg.topic);
+/// if (topic == DataTopic.chat) { ... }
+/// ```
+enum DataTopic {
+  // ── Player presence ────────────────────────────────────────────────────────
+  position('position'),
+  avatar('avatar'),
+
+  // ── Chat ───────────────────────────────────────────────────────────────────
+  chat('chat'),
+  chatResponse('chat-response'),
+  dm('dm'),
+  dmResponse('dm-response'),
+  helpRequest('help-request'),
+  helpResponse('help-response'),
+
+  // ── Map & Navigation ───────────────────────────────────────────────────────
+  mapInfo('map-info'),
+  mapInfoRequest('map-info-request'),
+  mapEdit('map-edit'),
+  mapEditSync('map-edit-sync'),
+
+  // ── Game events ────────────────────────────────────────────────────────────
+  terminalActivity('terminal-activity'),
+  doorUnlock('door-unlock'),
+  speechTranscript('speech-transcript'),
+
+  // ── Connectivity ──────────────────────────────────────────────────────────
+  ping('ping'),
+  pong('pong'),
+
+  // ── Infrastructure ────────────────────────────────────────────────────────
+  infraHealth('infra-health'),
+  infraHeal('infra-heal'),
+  infraHealResult('infra-heal-result'),
+  infraBoot('infra-boot'),
+
+  // ── Oracle (bot-mediated generation) ─────────────────────────────────────
+  oracleRequest('oracle-request'),
+  oracleResponse('oracle-response'),
+
+  // ── Dreamfinder avatar bridge ─────────────────────────────────────────────
+  dreamfinderAudio('dreamfinder-audio'),
+  dreamfinderMood('dreamfinder-mood'),
+  ;
+
+  const DataTopic(this.wireName);
+
+  /// The exact string sent over the LiveKit data channel.
+  final String wireName;
+
+  /// Parse a wire string into a [DataTopic], or return `null` if unknown.
+  static DataTopic? parse(String? wire) {
+    if (wire == null) return null;
+    for (final topic in values) {
+      if (topic.wireName == wire) return topic;
+    }
+    return null;
+  }
+}

--- a/lib/livekit/dreamfinder_avatar_bridge_web.dart
+++ b/lib/livekit/dreamfinder_avatar_bridge_web.dart
@@ -23,6 +23,7 @@ import 'package:web/web.dart' as web;
 
 import '../bots/bot_config.dart';
 import '../native/canvas_capture_web.dart';
+import 'data_topic.dart';
 import 'livekit_service.dart';
 
 final _log = Logger('DreamfinderAvatarBridge');
@@ -226,7 +227,7 @@ class DreamfinderAvatarBridge {
     // Audio: raw PCM16 bytes → base64-encode → __onAudioChunk(base64)
     _audioSubscription = _liveKitService.dataReceived
         .where((msg) =>
-            msg.topic == 'dreamfinder-audio' &&
+            msg.topic == DataTopic.dreamfinderAudio.wireName &&
             msg.senderId != null &&
             isDreamfinderIdentity(msg.senderId!))
         .listen(_forwardAudio);
@@ -234,7 +235,7 @@ class DreamfinderAvatarBridge {
     // Mood: JSON → __setMood(mood) or __interruptPlayback()
     _moodSubscription = _liveKitService.dataReceived
         .where((msg) =>
-            msg.topic == 'dreamfinder-mood' &&
+            msg.topic == DataTopic.dreamfinderMood.wireName &&
             msg.senderId != null &&
             isDreamfinderIdentity(msg.senderId!))
         .listen(_forwardMood);

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -139,7 +139,7 @@ class LiveKitService {
   /// Heartbeats carry a single grid position with reliable delivery,
   /// correcting stale positions caused by dropped unreliable path updates.
   Stream<PositionHeartbeat> get positionHeartbeatReceived => dataReceived
-      .where((msg) => msg.topic == 'position-heartbeat')
+      .where((msg) => msg.topic == DataTopic.positionHeartbeat.wireName)
       .map((msg) {
         final json = msg.json;
         if (json == null) return null;
@@ -161,7 +161,7 @@ class LiveKitService {
   /// client can load the same map. Own messages (matching [userId]) and
   /// messages from bots are excluded.
   Stream<String> get mapSwitchReceived => dataReceived
-      .where((msg) => msg.topic == 'map-switch')
+      .where((msg) => msg.topic == DataTopic.mapSwitch.wireName)
       .map((msg) {
         if (msg.json case {'senderId': String senderId, 'mapId': String mapId}
             when senderId != userId) {
@@ -513,7 +513,7 @@ class LiveKitService {
       'senderId': userId,
       'mapId': mapId,
     };
-    await publishJson(message, topic: 'map-switch');
+    await publishJson(message, topic: DataTopic.mapSwitch.wireName);
   }
 
   /// Publish the local player's position to other participants.
@@ -563,7 +563,7 @@ class LiveKitService {
             'y': pos.y,
             'type': 'heartbeat',
           },
-          topic: 'position-heartbeat',
+          topic: DataTopic.positionHeartbeat.wireName,
           reliable: true,
         );
       },

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -13,6 +13,7 @@ import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/shared/constants.dart';
 import 'package:tech_world/flame/shared/direction.dart';
 import 'package:tech_world/flame/shared/player_path.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 
 /// Result of a [LiveKitService.connect] attempt.
 enum ConnectionResult {
@@ -124,7 +125,7 @@ class LiveKitService {
   ///
   /// Filters dataReceived for 'position' topic and parses into PlayerPath.
   Stream<PlayerPath> get positionReceived => dataReceived
-      .where((msg) => msg.topic == 'position')
+      .where((msg) => msg.topic == DataTopic.position.wireName)
       .map((msg) {
         final json = msg.json;
         if (json == null) return null;
@@ -152,7 +153,7 @@ class LiveKitService {
   /// Bots publish a `map-info-request` message when they connect and are
   /// ready to receive data. The client responds by sending the current map.
   Stream<void> get mapInfoRequested =>
-      dataReceived.where((msg) => msg.topic == 'map-info-request');
+      dataReceived.where((msg) => msg.topic == DataTopic.mapInfoRequest.wireName);
 
   /// Stream of map-switch notifications from other human players.
   ///
@@ -176,7 +177,7 @@ class LiveKitService {
   /// Filters [dataReceived] for the `avatar` topic and parses into
   /// [AvatarUpdate]. Own messages (matching [userId]) are excluded.
   Stream<AvatarUpdate> get avatarReceived => dataReceived
-      .where((msg) => msg.topic == 'avatar')
+      .where((msg) => msg.topic == DataTopic.avatar.wireName)
       .map((msg) {
         final json = msg.json;
         if (json == null) return null;
@@ -197,7 +198,7 @@ class LiveKitService {
       'avatarId': avatar.id,
       'spriteAsset': avatar.spriteAsset,
     };
-    await publishJson(message, topic: 'avatar');
+    await publishJson(message, topic: DataTopic.avatar.wireName);
   }
 
   PlayerPath? _parsePlayerPath(Map<String, dynamic> json) {
@@ -498,7 +499,7 @@ class LiveKitService {
     };
     await publishJson(
       message,
-      topic: 'map-info',
+      topic: DataTopic.mapInfo.wireName,
       destinationIdentities: allBotIdentities.toList(),
     );
   }
@@ -530,7 +531,7 @@ class LiveKitService {
 
     await publishJson(
       message,
-      topic: 'position',
+      topic: DataTopic.position.wireName,
       reliable: false, // Positions can use unreliable for lower latency
     );
   }
@@ -590,7 +591,7 @@ class LiveKitService {
     int? terminalY,
   }) async {
     final message = <String, dynamic>{
-      'type': 'terminal-activity',
+      'type': DataTopic.terminalActivity.wireName,
       'action': action,
       'playerId': userId,
       'playerName': displayName,
@@ -606,7 +607,7 @@ class LiveKitService {
 
     await publishJson(
       message,
-      topic: 'terminal-activity',
+      topic: DataTopic.terminalActivity.wireName,
       destinationIdentities: const ['bot-claude'],
     );
   }
@@ -620,14 +621,14 @@ class LiveKitService {
   }) async {
     final pingId = DateTime.now().millisecondsSinceEpoch.toString();
     final pingMessage = {
-      'type': 'ping',
+      'type': DataTopic.ping.wireName,
       'id': pingId,
       'timestamp': DateTime.now().toIso8601String(),
     };
 
     // Listen for pong response with matching ID
     final pongFuture = dataReceived
-        .where((msg) => msg.topic == 'pong')
+        .where((msg) => msg.topic == DataTopic.pong.wireName)
         .where((msg) {
           final json = msg.json;
           return json != null &&
@@ -639,7 +640,7 @@ class LiveKitService {
     // Send the ping
     await publishJson(
       pingMessage,
-      topic: 'ping',
+      topic: DataTopic.ping.wireName,
       destinationIdentities: ['bot-claude'],
     );
     _log.fine('Sent ping with id: $pingId');

--- a/lib/map_editor/map_sync_service.dart
+++ b/lib/map_editor/map_sync_service.dart
@@ -5,6 +5,7 @@ import 'package:tech_world/flame/maps/barrier_occlusion.dart'
     show buildWallTilesForRegion;
 import 'package:tech_world/flame/shared/constants.dart';
 import 'package:tech_world/flame/tiles/tile_ref.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/map_editor/crdt/cell_version_map.dart';
 import 'package:tech_world/map_editor/crdt/map_edit_op.dart';
@@ -31,8 +32,8 @@ class MapSyncService {
         .listen(_onDataReceived);
   }
 
-  static const _editTopic = 'map-edit';
-  static const _syncTopic = 'map-edit-sync';
+  static final _editTopic = DataTopic.mapEdit.wireName;
+  static final _syncTopic = DataTopic.mapEditSync.wireName;
 
   final LiveKitService _liveKitService;
   final MapEditorState _editorState;

--- a/lib/services/dreamfinder_client.dart
+++ b/lib/services/dreamfinder_client.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 
 final _log = Logger('DreamfinderClient');
 
@@ -16,8 +17,8 @@ final _log = Logger('DreamfinderClient');
 ///
 /// These match the LiveKit data channel topics used throughout the game.
 abstract final class GameEventTopic {
-  static const chat = 'chat';
-  static const helpRequest = 'help-request';
+  static String get chat => DataTopic.chat.wireName;
+  static String get helpRequest => DataTopic.helpRequest.wireName;
   static const playerJoin = 'player-join';
   static const playerLeave = 'player-leave';
 }

--- a/lib/services/dreamfinder_client.dart
+++ b/lib/services/dreamfinder_client.dart
@@ -19,6 +19,13 @@ final _log = Logger('DreamfinderClient');
 abstract final class GameEventTopic {
   static String get chat => DataTopic.chat.wireName;
   static String get helpRequest => DataTopic.helpRequest.wireName;
+
+  /// HTTP event type strings forwarded to Dreamfinder's REST API.
+  ///
+  /// These are **not** LiveKit data-channel topics and are therefore
+  /// deliberately absent from [DataTopic]. Player join/leave events are
+  /// signalled by the LiveKit room itself and forwarded to Dreamfinder over
+  /// HTTP, so there is no corresponding wire name on the data channel.
   static const playerJoin = 'player-join';
   static const playerLeave = 'player-leave';
 }

--- a/lib/spellbook/oracle_service.dart
+++ b/lib/spellbook/oracle_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:logging/logging.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
 final _log = Logger('OracleService');
@@ -106,7 +107,7 @@ class OracleService {
     // Subscribe BEFORE publishing so we don't miss a fast reply. The
     // future is consumed in the try-block below.
     final responseFuture = _liveKit.dataReceived
-        .where((m) => m.topic == 'oracle-response')
+        .where((m) => m.topic == DataTopic.oracleResponse.wireName)
         .map((m) => m.json)
         .where((json) => json != null && json['requestId'] == requestId)
         .map((json) => json!['text'])
@@ -126,7 +127,7 @@ class OracleService {
           'kind': kind,
           'context': context,
         },
-        topic: 'oracle-request',
+        topic: DataTopic.oracleRequest.wireName,
         destinationIdentities: [botIdentity],
       );
     } catch (e) {

--- a/test/avatar/avatar_broadcast_test.dart
+++ b/test/avatar/avatar_broadcast_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/avatar/predefined_avatars.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
 void main() {
@@ -38,7 +39,7 @@ void main() {
     test('parses valid avatar message from DataChannelMessage', () {
       final message = DataChannelMessage(
         senderId: 'user-456',
-        topic: 'avatar',
+        topic: DataTopic.avatar.wireName,
         data: utf8.encode(jsonEncode({
           'playerId': 'user-456',
           'avatarId': 'npc13',
@@ -46,7 +47,7 @@ void main() {
         })),
       );
 
-      expect(message.topic, equals('avatar'));
+      expect(message.topic, equals(DataTopic.avatar.wireName));
       final json = message.json!;
       expect(json['playerId'], equals('user-456'));
       expect(json['avatarId'], equals('npc13'));
@@ -56,7 +57,7 @@ void main() {
     test('ignores malformed message (missing fields)', () {
       final message = DataChannelMessage(
         senderId: 'user-789',
-        topic: 'avatar',
+        topic: DataTopic.avatar.wireName,
         data: utf8.encode(jsonEncode({'playerId': 'user-789'})),
       );
 

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -17,6 +17,7 @@ import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/chat_service.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
@@ -75,12 +76,12 @@ void main() {
       expect(fakeLiveKit.publishedMessages.length, equals(1));
 
       final published = fakeLiveKit.publishedMessages.first;
-      expect(published['topic'], equals('chat'));
+      expect(published['topic'], equals(DataTopic.chat.wireName));
       // Shared chat broadcasts to all (no destinationIdentities)
       expect(published['destinationIdentities'], isNull);
 
       final payload = published['payload'] as Map<String, dynamic>;
-      expect(payload['type'], equals('chat'));
+      expect(payload['type'], equals(DataTopic.chat.wireName));
       expect(payload['text'], equals('Test message'));
       expect(payload['id'], isNotNull);
       expect(payload['senderName'], equals('Test User'));
@@ -439,7 +440,7 @@ void main() {
         expect(fakeLiveKit.publishedMessages.length, equals(1));
 
         final published = fakeLiveKit.publishedMessages.first;
-        expect(published['topic'], equals('dm'));
+        expect(published['topic'], equals(DataTopic.dm.wireName));
         expect(
           published['destinationIdentities'],
           equals(['peer-uid']),
@@ -902,7 +903,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateResponse(Map<String, dynamic> response) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: 'bot-claude',
-      topic: 'chat-response',
+      topic: DataTopic.chatResponse.wireName,
       data: utf8.encode(jsonEncode(response)),
     ));
   }
@@ -910,7 +911,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateInvalidResponse(String invalidData) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: 'bot-claude',
-      topic: 'chat-response',
+      topic: DataTopic.chatResponse.wireName,
       data: utf8.encode(invalidData),
     ));
   }
@@ -928,7 +929,7 @@ class FakeLiveKitService implements LiveKitService {
       String id, Map<String, dynamic> response) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: 'bot-claude',
-      topic: 'chat-response',
+      topic: DataTopic.chatResponse.wireName,
       data: utf8.encode(jsonEncode(response)),
     ));
   }
@@ -937,7 +938,7 @@ class FakeLiveKitService implements LiveKitService {
       String senderId, Map<String, dynamic> message) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: senderId,
-      topic: 'chat',
+      topic: DataTopic.chat.wireName,
       data: utf8.encode(jsonEncode(message)),
     ));
   }
@@ -945,7 +946,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateChatFromSelf(Map<String, dynamic> message) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: userId, // Same as our userId
-      topic: 'chat',
+      topic: DataTopic.chat.wireName,
       data: utf8.encode(jsonEncode(message)),
     ));
   }
@@ -954,7 +955,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateDm(String senderId, Map<String, dynamic> message) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: senderId,
-      topic: 'dm',
+      topic: DataTopic.dm.wireName,
       data: utf8.encode(jsonEncode(message)),
     ));
   }
@@ -964,7 +965,7 @@ class FakeLiveKitService implements LiveKitService {
       String senderId, Map<String, dynamic> message) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: senderId,
-      topic: 'dm-response',
+      topic: DataTopic.dmResponse.wireName,
       data: utf8.encode(jsonEncode(message)),
     ));
   }

--- a/test/livekit/data_topic_test.dart
+++ b/test/livekit/data_topic_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/livekit/data_topic.dart';
+
+void main() {
+  group('DataTopic.parse', () {
+    group('round-trips all values', () {
+      for (final topic in DataTopic.values) {
+        test('round-trips ${topic.name}', () {
+          expect(DataTopic.parse(topic.wireName), equals(topic));
+        });
+      }
+    });
+
+    test('returns null for unknown wire name', () {
+      expect(DataTopic.parse('unknown'), isNull);
+    });
+
+    test('returns null for empty string', () {
+      expect(DataTopic.parse(''), isNull);
+    });
+
+    test('returns null for null input', () {
+      expect(DataTopic.parse(null), isNull);
+    });
+  });
+}

--- a/test/map_editor/map_sync_service_test.dart
+++ b/test/map_editor/map_sync_service_test.dart
@@ -9,6 +9,7 @@ import 'package:tech_world/avatar/avatar.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/shared/direction.dart';
 import 'package:tech_world/flame/shared/player_path.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/flame/tiles/tile_ref.dart';
 import 'package:tech_world/map_editor/map_editor_state.dart';
@@ -45,7 +46,7 @@ void main() {
       expect(fakeLiveKit.publishedMessages, hasLength(1));
 
       final msg = fakeLiveKit.publishedMessages.first;
-      expect(msg['topic'], 'map-edit');
+      expect(msg['topic'], DataTopic.mapEdit.wireName);
       final payload = msg['payload'] as Map<String, dynamic>;
       expect(payload['type'], 'edit');
       expect(payload['playerId'], 'alice');
@@ -277,7 +278,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final syncMessages = fakeLiveKit.publishedMessages
-          .where((m) => m['topic'] == 'map-edit-sync')
+          .where((m) => m['topic'] == DataTopic.mapEditSync.wireName)
           .toList();
       expect(syncMessages, hasLength(1));
 
@@ -302,7 +303,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final syncMessages = fakeLiveKit.publishedMessages
-          .where((m) => m['topic'] == 'map-edit-sync')
+          .where((m) => m['topic'] == DataTopic.mapEditSync.wireName)
           .toList();
       expect(syncMessages, hasLength(1));
 
@@ -416,7 +417,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final syncMessages = fakeLiveKit.publishedMessages
-          .where((m) => m['topic'] == 'map-edit-sync')
+          .where((m) => m['topic'] == DataTopic.mapEditSync.wireName)
           .toList();
       expect(syncMessages, hasLength(1));
 
@@ -502,7 +503,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateMapEdit(Map<String, dynamic> json) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: json['playerId'] as String,
-      topic: 'map-edit',
+      topic: DataTopic.mapEdit.wireName,
       data: utf8.encode(jsonEncode(json)),
     ));
   }
@@ -510,7 +511,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateMapEditFrom(String senderId, Map<String, dynamic> json) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: senderId,
-      topic: 'map-edit',
+      topic: DataTopic.mapEdit.wireName,
       data: utf8.encode(jsonEncode(json)),
     ));
   }
@@ -518,7 +519,7 @@ class FakeLiveKitService implements LiveKitService {
   void simulateMapSync(Map<String, dynamic> json, {String? senderId}) {
     _dataReceivedController.add(DataChannelMessage(
       senderId: senderId,
-      topic: 'map-edit-sync',
+      topic: DataTopic.mapEditSync.wireName,
       data: utf8.encode(jsonEncode(json)),
     ));
   }

--- a/test/spellbook/oracle_service_test.dart
+++ b/test/spellbook/oracle_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
+import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/spellbook/oracle_service.dart';
 
 void main() {
@@ -29,7 +30,7 @@ void main() {
 
       expect(fake.published, hasLength(1));
       final pub = fake.published.single;
-      expect(pub.topic, 'oracle-request');
+      expect(pub.topic, DataTopic.oracleRequest.wireName);
       expect(pub.destinationIdentities, ['bot-claude']);
 
       final payload = pub.payload;
@@ -205,7 +206,7 @@ class _FakeLiveKit implements LiveKitService {
   void simulateResponse(Map<String, dynamic> response) {
     _controller.add(DataChannelMessage(
       senderId: 'bot-claude',
-      topic: 'oracle-response',
+      topic: DataTopic.oracleResponse.wireName,
       data: utf8.encode(jsonEncode(response)),
     ));
   }


### PR DESCRIPTION
## Summary

- Centralises all 27 LiveKit data-channel topic strings into the existing `DataTopic` enum (`lib/livekit/data_topic.dart`)
- Adds two topics that were missing from the enum: `positionHeartbeat` (`position-heartbeat`) and `mapSwitch` (`map-switch`)
- Fixes the one remaining raw string in `tech_world.dart` (`door-unlock`) that was missed in the earlier pass
- No wire format changes — all `wireName` values are identical to the previous string literals

## Files changed

- `lib/livekit/data_topic.dart` — adds `positionHeartbeat` and `mapSwitch` entries (27 total)
- `lib/livekit/livekit_service.dart` — 4 raw strings replaced: `positionHeartbeatReceived` filter, `mapSwitchReceived` filter, `publishMapSwitch` publish, heartbeat timer publish
- `lib/flame/tech_world.dart` — 1 raw string replaced: `door-unlock` filter
- Also carries forward the 3 commits from `audit/data-topic-enum`: dead LiveKit sample-app UI deletion (~1800 lines), the main enum wiring across chat/infra/oracle/map-sync, and the `DataTopic.parse` test

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests passed
- [x] `grep -rn "topic.*==.*'" lib/` returns no raw topic comparisons (only `DataTopic.X.wireName` or local variable aliases backed by the enum)
- [x] `grep -rn "topic:.*'" lib/` returns only log statements (no raw topic publish calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)