### PR TITLE
chore(deps): switch code_forge_web from git pin to pub.dev

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -188,12 +188,11 @@ packages:
   code_forge_web:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "51f0e2b"
-      resolved-ref: "51f0e2bcdd197b9cef505555907257d085f27eaa"
-      url: "https://github.com/nickmeinhold/code_forge_web.git"
-    source: git
-    version: "1.4.1"
+      name: code_forge_web
+      sha256: "1b6b5a61b1aa5cc9a06dbc310dba513d6b4dfa98c96d355a6339b1cdfd696db5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   collection:
     dependency: "direct main"
     description:
@@ -1590,5 +1589,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.8 <4.0.0"
+  dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,10 +29,7 @@ dependencies:
   collection: ^1.19.1
   ffi: ^2.1.5
   web: ^1.1.0 # For web video capture APIs
-  code_forge_web:
-    git:
-      url: https://github.com/nickmeinhold/code_forge_web.git
-      ref: 51f0e2b
+  code_forge_web: ^2.9.0
   re_highlight: ^0.0.3
   tiled: ^0.11.1 # TMX/TSX parser only — no rendering
   xml: ^6.6.1


### PR DESCRIPTION
## Summary
- Replace git-pinned `code_forge_web` (commit `51f0e2b` on nickmeinhold/code_forge_web.git) with `^2.9.0` from pub.dev
- The package is already published on pub.dev as of April 12, 2026
- Eliminates a CI single-point-of-failure (personal repo going private/deleted)
- Enables vulnerability tracking via pub.dev advisory feed

## Test plan
- [x] `flutter pub get` resolves cleanly
- [x] `flutter analyze --fatal-infos` — no issues
- [ ] Verify code editor panel renders correctly in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)