### PR TITLE
fix(video): cancel pending unmute before disposing web capture

### DIFF
--- a/lib/flame/components/video_bubble_component.dart
+++ b/lib/flame/components/video_bubble_component.dart
@@ -354,7 +354,8 @@ class VideoBubbleComponent extends PositionComponent {
     _capture?.dispose();
     _capture = null;
 
-    // Dispose web captures (local and remote)
+    // Cancel any pending unmute wait before disposing (avoids orphaned completer).
+    direct_capture.DirectTrackCapture.cancelPendingUnmute();
     _webCapture?.dispose();
     _webCapture = null;
 


### PR DESCRIPTION
## Summary

- `_disposeCapture()` now calls `direct_capture.DirectTrackCapture.cancelPendingUnmute()` before `_webCapture?.dispose()`
- Without this, if a `VideoBubbleComponent` is removed while `_waitForUnmute()` is suspended on its `Completer`, the async continuation resumes against a disposed object
- `cancelPendingUnmute()` completes the `Completer` with `false`, causing the `await` to return cleanly and the async chain to unwind safely

**Implementation note:** `cancelPendingUnmute()` is a static method on `DirectTrackCapture` (it guards a static `_pendingUnmute` field), so the call is `DirectTrackCapture.cancelPendingUnmute()` rather than on the instance.

Found during cage-match review of PR #359.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1423 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)