### PR TITLE
refactor(bots): centralise agent- prefix convention in bot_config

### DIFF
--- a/lib/bots/bot_config.dart
+++ b/lib/bots/bot_config.dart
@@ -78,13 +78,20 @@ final botsByIdentity = <String, BotConfig>{
 /// All bot identities as a set, for efficient lookups.
 final allBotIdentities = botsByIdentity.keys.toSet();
 
+/// Identity prefixes used by the LiveKit agents SDK.
+///
+/// The `@livekit/agents` SDK assigns identities like `agent-{jobId}` when
+/// the worker doesn't override the identity. Only Dreamfinder uses this SDK.
+/// Add entries here (not ad-hoc `startsWith` checks) when new bots adopt it.
+const _agentPrefixes = ['agent-'];
+
 /// Returns `true` if [identity] belongs to a registered bot.
 ///
-/// Also matches `agent-` prefixed identities from the `@livekit/agents`
-/// SDK, which assigns identities like `agent-{jobId}` when the worker
-/// doesn't override the identity via `requestFunc`.
+/// Checks the [allBotIdentities] set for exact matches and the
+/// [_agentPrefixes] list for LiveKit agents SDK identities.
 bool isBotIdentity(String identity) =>
-    botsByIdentity.containsKey(identity) || identity.startsWith('agent-');
+    allBotIdentities.contains(identity) ||
+    _agentPrefixes.any((prefix) => identity.startsWith(prefix));
 
 /// Returns `true` if [identity] belongs to Dreamfinder, including the
 /// auto-generated `agent-*` identities used by the LiveKit agents SDK.
@@ -97,8 +104,11 @@ bool isDreamfinderIdentity(String identity) =>
 
 /// Returns the [BotConfig] for [identity], or [clawdBot] as fallback.
 ///
-/// Identities starting with `agent-` are mapped to [dreamfinderBot],
-/// since only Dreamfinder uses the `@livekit/agents` SDK directly.
+/// Identities matching an [_agentPrefixes] entry are mapped to
+/// [dreamfinderBot], since only Dreamfinder uses the `@livekit/agents`
+/// SDK directly.
 BotConfig getBotConfig(String identity) =>
     botsByIdentity[identity] ??
-    (identity.startsWith('agent-') ? dreamfinderBot : clawdBot);
+    (_agentPrefixes.any((prefix) => identity.startsWith(prefix))
+        ? dreamfinderBot
+        : clawdBot);


### PR DESCRIPTION
## Summary

- Replaces two ad-hoc `identity.startsWith('agent-')` checks in `isBotIdentity` and `getBotConfig` with a single documented `_agentPrefixes` constant
- Adds dartdoc explaining which SDK uses this prefix (LiveKit `@livekit/agents`) and which bot owns it (Dreamfinder)
- Makes it trivially easy to add a second prefix entry when a future bot adopts the agents SDK — no hunting for scattered magic strings

## Motivation

The `'agent-'` string was a magic literal duplicated in two places. The convention existed (only Dreamfinder uses the LiveKit agents SDK) but wasn't explicit anywhere. A future maintainer adding a second bot would have to know to update both call sites, with no hint that they are coupled.

The `_agentPrefixes` constant makes the convention a first-class artefact: one place to update, one place to read the explanation.

## Behaviour change

None. Both functions produce identical results for all inputs. The refactor is purely structural.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests pass

Cage-match follow-up from PR #394 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)