### PR TITLE
fix(chat): reduce help request timeout from 60s to 30s

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -804,7 +804,7 @@ class ChatService {
 
     try {
       return await completer.future.timeout(
-        const Duration(seconds: 60),
+        const Duration(seconds: 30),
         onTimeout: () {
           _log.warning('Help request timeout');
           _pendingHelpRequests.remove(requestId);


### PR DESCRIPTION
## Summary

- Reduces the `requestHelp` timeout in `lib/chat/chat_service.dart` from 60 seconds to 30 seconds
- Aligns with the existing 30-second chat response timeout (the oracle is 5s)
- 60s was excessive for a hint — the player waited a full minute with no intermediate feedback before the help button re-enabled

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1474 tests passed

Phase 4b bot integration audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)