### PR TITLE
fix(flame): guard bot spawn index for agent-* identities

### DIFF
--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -431,6 +431,10 @@ class TechWorld extends World with TapCallbacks {
       // so reconnecting bots always land in the same position.
       final botIndex =
           allBotIdentities.toList().indexOf(participant.identity);
+      // Guard against -1: agent-* identities (LiveKit Agents SDK) are not in
+      // allBotIdentities. Fall back to length so an unknown bot stacks after
+      // all known bots rather than colliding at spawn.x + 0.
+      final safeBotIndex = botIndex >= 0 ? botIndex : allBotIdentities.length;
 
       if (isDreamfinderIdentity(participant.identity) &&
           _pathComponent == null) {
@@ -475,7 +479,7 @@ class TechWorld extends World with TapCallbacks {
         if (!_otherPlayerComponentsMap.containsKey(participant.identity)) {
           final playerComp = PlayerComponent(
             position: Vector2(
-              (spawn.x + botIndex + 1) * gridSquareSizeDouble,
+              (spawn.x + safeBotIndex + 1) * gridSquareSizeDouble,
               spawn.y * gridSquareSizeDouble,
             ),
             id: participant.identity,
@@ -491,7 +495,7 @@ class TechWorld extends World with TapCallbacks {
         if (!_botCharacterComponents.containsKey(participant.identity)) {
           final botComp = BotCharacterComponent(
             position: Vector2(
-              (spawn.x + botIndex + 1) * gridSquareSizeDouble,
+              (spawn.x + safeBotIndex + 1) * gridSquareSizeDouble,
               spawn.y * gridSquareSizeDouble,
             ),
             id: participant.identity,


### PR DESCRIPTION
## Summary

- `allBotIdentities.indexOf` returns `-1` for `agent-*` identities assigned by the LiveKit Agents SDK
- With `-1`, the spawn calculation `spawn.x + botIndex + 1` resolves to `spawn.x + 0`, colliding with the first registered bot
- Add `safeBotIndex` that falls back to `allBotIdentities.length` when `indexOf` returns `-1`, placing unknown agent-SDK bots after all known bots
- Dreamfinder is routed before this math so it is unaffected; this guards any future agent-SDK bot that reaches the generic spawn path

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1474 tests passed
- [x] Change is additive: `botIndex` preserved for debugging, `safeBotIndex` used in both `PlayerComponent` and `BotCharacterComponent` spawn paths

Phase 4b bot integration audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)