### PR TITLE
fix(livekit): default adaptiveStream to false in developer connect page

### DIFF
--- a/lib/livekit/pages/connect.dart
+++ b/lib/livekit/pages/connect.dart
@@ -35,7 +35,8 @@ class _ConnectPageState extends State<ConnectPage> {
   final _tokenCtrl = TextEditingController();
   final _sharedKeyCtrl = TextEditingController();
   bool _simulcast = true;
-  bool _adaptiveStream = true;
+  // Must be false — Flame canvas doesn't signal demand to the SFU.
+  bool _adaptiveStream = false;
   bool _dynacast = true;
   bool _busy = true;
   bool _e2ee = false;
@@ -90,7 +91,8 @@ class _ConnectPageState extends State<ConnectPage> {
     _tokenCtrl.text = 'retrieving...';
     setState(() {
       _simulcast = prefs.getBool(_storeKeySimulcast) ?? true;
-      _adaptiveStream = prefs.getBool(_storeKeyAdaptiveStream) ?? true;
+      // Must be false — Flame canvas doesn't signal demand to the SFU.
+      _adaptiveStream = prefs.getBool(_storeKeyAdaptiveStream) ?? false;
       _dynacast = prefs.getBool(_storeKeyDynacast) ?? true;
       _e2ee = prefs.getBool(_storeKeyE2EE) ?? false;
       _multiCodec = prefs.getBool(_storeKeyMultiCodec) ?? false;

--- a/lib/livekit/pages/prejoin.dart
+++ b/lib/livekit/pages/prejoin.dart
@@ -14,7 +14,8 @@ class JoinArgs {
     this.e2ee = false,
     this.e2eeKey,
     this.simulcast = true,
-    this.adaptiveStream = true,
+    // Must be false — Flame canvas doesn't signal demand to the SFU.
+    this.adaptiveStream = false,
     this.dynacast = true,
     this.preferredCodec = 'VP8',
     this.enableBackupVideoCodec = true,


### PR DESCRIPTION
## Summary

- `connect.dart` field `_adaptiveStream` initialised to `false` (was `true`)
- `connect.dart` SharedPreferences fallback changed to `false` (was `true`)
- `JoinArgs.adaptiveStream` default parameter changed to `false` (was `true`)
- Each changed line has a comment: `// Must be false — Flame canvas doesn't signal demand to the SFU.`

## Problem

`adaptiveStream: true` tells the LiveKit SFU to use demand-based forwarding — it only sends video when a `VideoTrackRenderer` widget signals that it needs frames. The Flame canvas reads video via FFI shared memory (macOS) or a `MediaStreamTrackProcessor` pipeline (web), never through a `VideoTrackRenderer`. With no demand signal, the SFU stops forwarding video after a few seconds.

The production path (`RoomSession`) already hard-codes `adaptiveStream: false`. This PR brings the developer/debug connect page into parity.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests passed

Phase 4b platform parity audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)