### PR TITLE
refactor(video): change createFromVideoElement param from dynamic to Object

### DIFF
--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -644,7 +644,7 @@ class VideoElementCapture implements FrameSource {
   /// Create a capture instance from an existing HTMLVideoElement.
   ///
   /// This is used when we have direct access to a video element (e.g., from RTCVideoRenderer).
-  static VideoElementCapture? createFromVideoElement(dynamic videoElement) {
+  static VideoElementCapture? createFromVideoElement(Object videoElement) {
     try {
       final video = videoElement as web.HTMLVideoElement;
       final width = video.videoWidth;


### PR DESCRIPTION
## Summary

- Changes `dynamic videoElement` to `Object videoElement` in `VideoElementCapture.createFromVideoElement` in `lib/native/video_frame_web_v2.dart`
- The stub (`video_frame_web_v2_stub.dart`) already used `Object` — this brings the real implementation into alignment
- `dynamic` dispatch is a WASM code smell; the method immediately casts to `web.HTMLVideoElement`, so `Object` is the correct boundary type — it forces an explicit typed cast rather than allowing silent dynamic dispatch
- No callers pass untyped values; this is a pure type-annotation tightening

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 1474 tests pass

Phase 4b platform parity audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)