### PR TITLE
fix(flame): remove bot tap toggle that mutates global botStatusNotifier

### DIFF
--- a/lib/flame/components/bot_character_component.dart
+++ b/lib/flame/components/bot_character_component.dart
@@ -3,17 +3,14 @@ import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
-import 'package:flame/events.dart';
 import 'package:flutter/painting.dart';
-import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/shared/constants.dart';
 import 'package:tech_world/flame/tech_world_game.dart';
 
 /// A Flame component that renders the Clawd mascot as a character sprite.
 /// Unlike PlayerComponent which uses sprite sheets, this renders a static image.
-/// Tap on the bot to toggle the thinking indicator (for demo purposes).
 class BotCharacterComponent extends PositionComponent
-    with TapCallbacks, HasGameReference<TechWorldGame> {
+    with HasGameReference<TechWorldGame> {
   BotCharacterComponent({
     required Vector2 position,
     required this.id,
@@ -119,13 +116,4 @@ class BotCharacterComponent extends PositionComponent
     );
   }
 
-  @override
-  void onTapDown(TapDownEvent event) {
-    // Toggle between idle and thinking status
-    if (botStatusNotifier.value == BotStatus.idle) {
-      botStatusNotifier.value = BotStatus.thinking;
-    } else {
-      botStatusNotifier.value = BotStatus.idle;
-    }
-  }
 }

--- a/test/flame/components/bot_character_component_integration_test.dart
+++ b/test/flame/components/bot_character_component_integration_test.dart
@@ -77,35 +77,6 @@ void main() {
     );
 
     testWithGame<TestGameWithMockImages>(
-      'onTapDown toggles bot status',
-      TestGameWithMockImages.new,
-      (game) async {
-        final bot = BotCharacterComponent(
-          position: Vector2(100, 100),
-          id: 'bot-claude',
-          displayName: 'Claude',
-        );
-
-        await game.world.add(bot);
-        await game.ready();
-
-        // Initial status should be idle
-        expect(botStatusNotifier.value, equals(BotStatus.idle));
-
-        // Create a mock tap event using flame_test helper
-        final event = createTapDownEvents(game: game);
-
-        // Simulate tap down - should toggle to thinking
-        bot.onTapDown(event);
-        expect(botStatusNotifier.value, equals(BotStatus.thinking));
-
-        // Another tap - should toggle back to idle
-        bot.onTapDown(event);
-        expect(botStatusNotifier.value, equals(BotStatus.idle));
-      },
-    );
-
-    testWithGame<TestGameWithMockImages>(
       'multiple bots can be added to game',
       TestGameWithMockImages.new,
       (game) async {


### PR DESCRIPTION
## Summary

- Removes the `onTapDown` handler from `BotCharacterComponent` that let players tap the Clawd sprite to toggle `botStatusNotifier` between `idle` and `thinking`
- A player tapping during a real bot evaluation could dismiss the thinking indicator mid-evaluation or trigger a false thinking state, corrupting real feedback
- Also removes the now-unused `TapCallbacks` mixin from the `with` clause, and the `flame/events.dart` and `bot_status.dart` imports

## Changes

**`lib/flame/components/bot_character_component.dart`**
- Removed `onTapDown` override (9 lines)
- Removed `TapCallbacks` from `with` clause
- Removed `import 'package:flame/events.dart'`
- Removed `import 'package:tech_world/flame/components/bot_status.dart'`
- Updated class docstring (removed "Tap on the bot to toggle the thinking indicator (for demo purposes)")

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1420 tests passed

Phase 4b bot integration audit finding M2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)