### PR TITLE
feat: add Firebase Crashlytics for production crash reporting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 import 'dart:ui' as ui;
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/foundation.dart' show ValueListenable, kIsWeb;
 import 'package:flutter/material.dart';
@@ -59,10 +60,33 @@ import 'package:tech_world/widgets/loading_screen.dart';
 import 'firebase_options.dart';
 import 'package:tech_world/utils/locator.dart';
 
-void main() {
-  WidgetsFlutterBinding.ensureInitialized();
-  _initLogging();
-  runApp(const MyApp());
+void main() async {
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    _initLogging();
+
+    // Firebase must be initialized before Crashlytics can record errors.
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+
+    // Crashlytics is not supported on web.
+    if (!kIsWeb) {
+      FlutterError.onError =
+          FirebaseCrashlytics.instance.recordFlutterFatalError;
+      ui.PlatformDispatcher.instance.onError = (error, stack) {
+        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+        return true;
+      };
+    }
+
+    runApp(const MyApp());
+  }, (error, stack) {
+    _log.severe('Uncaught error', error, stack);
+    if (!kIsWeb) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    }
+  });
 }
 
 /// Subscription for the root logger — stored so it can be cancelled if needed
@@ -160,15 +184,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _initializeApp() async {
-    // Stage 1: Initialize Firebase
-    setState(() {
-      _loadingMessage = 'Connecting to Firebase...';
-      _progress = 0.2;
-    });
-
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    // Firebase is already initialized in main().
 
     // Stage 2: Initialize services
     setState(() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -442,6 +442,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      sha256: "8d52022ee6fdd224e92c042f297d1fd0ec277195c49f39fa61b8cc500a639f00"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.6"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      sha256: "97c6a97b35e3d3dafe38fb053a65086a1efb125022d292161405848527cc25a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.16"
   firebase_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   pathfinding: ^3.0.1
   firebase_core: ^4.1.1
   cloud_firestore: ^6.0.2
+  firebase_crashlytics: ^5.0.6
   firebase_auth: ^6.1.0
   sign_in_with_apple: ^7.0.1
   crypto: ^3.0.6


### PR DESCRIPTION
## Summary

- Add `firebase_crashlytics: ^5.0.6` to dependencies
- Move `Firebase.initializeApp()` from widget lifecycle to `main()` so Crashlytics is ready before any widget code runs
- Set `FlutterError.onError` → Crashlytics (catches framework errors like render overflows, setState-after-dispose)
- Set `PlatformDispatcher.instance.onError` → Crashlytics (catches async platform errors)
- Wrap `runApp` in `runZonedGuarded` → Crashlytics (catches uncaught zone errors)
- All handlers skip on web (`kIsWeb` guard) since Crashlytics is native-only
- Uncaught errors also route through `_log.severe` for structured dev logging

**Note:** Nick will need to run `flutterfire configure` to add the Crashlytics Gradle plugin and `GoogleService-Info.plist`/`google-services.json` if not already present from the existing Firebase setup.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests pass
- [ ] Verify crash appears in Firebase Console → Crashlytics after a test throw
- [ ] Verify web build still works (Crashlytics gracefully skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)