### PR TITLE
fix: make Firestore room saves atomic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -575,10 +575,10 @@ class _MyAppState extends State<MyApp> {
         _currentRoom!.isOwner(userId);
 
     if (isOwnedRoom) {
-      // Update existing room the user owns.
-      await _roomService!.updateRoomMap(existingRoomId, gameMap);
-      await _roomService!.updateRoomName(
+      // Update existing room the user owns (single atomic Firestore write).
+      await _roomService!.updateRoomMapAndName(
         existingRoomId,
+        gameMap,
         _mapEditorState.mapName,
       );
       // Update local state.

--- a/lib/rooms/room_service.dart
+++ b/lib/rooms/room_service.dart
@@ -70,6 +70,19 @@ class RoomService {
     });
   }
 
+  /// Atomically update both map data and name in a single Firestore write.
+  Future<void> updateRoomMapAndName(
+    String roomId,
+    GameMap map,
+    String name,
+  ) async {
+    await _collection.doc(roomId).update({
+      'mapData': _mapDataJson(map),
+      'name': name,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
   /// Delete a room. Only the owner should call this.
   Future<void> deleteRoom(String roomId) async {
     await _collection.doc(roomId).delete();
@@ -155,23 +168,27 @@ class RoomService {
       if (storedVersion == wizardsTowerVersion) return; // Already up-to-date.
 
       _log.info('Updating Wizard\'s Tower: $storedVersion → $wizardsTowerVersion');
-      await updateRoomMap(doc.id, wizardsTower);
       await _collection.doc(doc.id).update({
+        'mapData': _mapDataJson(wizardsTower),
         'mapVersion': wizardsTowerVersion,
+        'updatedAt': FieldValue.serverTimestamp(),
       });
       return;
     }
 
     _log.info('Seeding "The Wizard\'s Tower" room');
-    final room = await createRoom(
+    final room = RoomData(
+      id: '',
       name: "The Wizard's Tower",
       ownerId: ownerId,
       ownerDisplayName: ownerDisplayName,
-      map: wizardsTower,
       isPublic: true,
+      mapData: wizardsTower,
     );
-    await _collection.doc(room.id).update({
-      'mapVersion': wizardsTowerVersion,
-    });
+    final data = room.toFirestore();
+    data['createdAt'] = FieldValue.serverTimestamp();
+    data['updatedAt'] = FieldValue.serverTimestamp();
+    data['mapVersion'] = wizardsTowerVersion;
+    await _collection.add(data);
   }
 }

--- a/test/rooms/save_room_fork_test.dart
+++ b/test/rooms/save_room_fork_test.dart
@@ -59,9 +59,8 @@ void main() {
       final isOwnedRoom = room.id.isNotEmpty && room.isOwner('user-1');
       expect(isOwnedRoom, isTrue);
 
-      // Owner updates in place.
-      await service.updateRoomMap(room.id, updatedMap);
-      await service.updateRoomName(room.id, 'Updated Map');
+      // Owner updates in place (single atomic write).
+      await service.updateRoomMapAndName(room.id, updatedMap, 'Updated Map');
 
       final fetched = await service.getRoom(room.id);
       expect(fetched!.name, equals('Updated Map'));


### PR DESCRIPTION
## Summary

- Add `RoomService.updateRoomMapAndName()` — single Firestore write for map data + name, replacing the two-call pattern that could leave inconsistent state on network failure
- Fix `seedWizardsTower` update path: combine `updateRoomMap` + `mapVersion` update into one write
- Fix `seedWizardsTower` create path: include `mapVersion` in the initial document, eliminating a create-then-update race window
- Update `_saveRoom` in `main.dart` and `save_room_fork_test.dart` to use the atomic method

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1474 tests pass
- [ ] Verify room save still works in-app (name + map persist together)
- [ ] Verify Wizard's Tower seeding on fresh account

🤖 Generated with [Claude Code](https://claude.com/claude-code)