### PR TITLE
fix: exponential backoff for LiveKit reconnection

### DIFF
--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -217,6 +217,14 @@ class RoomSession {
         liveKitService.connectionLost.listen(_handleConnectionLost);
   }
 
+  // Backoff schedule: 2s, 4s, 8s.
+  static const _maxReconnectAttempts = 3;
+  static const _reconnectDelays = [
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+    Duration(seconds: 8),
+  ];
+
   Future<void> _handleConnectionLost(String? reason) async {
     _log.warning('LiveKit connection lost: $reason');
     if (_isReconnecting || _disposed) return;
@@ -233,29 +241,47 @@ class RoomSession {
     // enables re-initialization when connectToLiveKit() is called again.
 
     try {
-      await Future.delayed(const Duration(seconds: 2));
-      // Bail if the user left during the delay — services and notifiers
-      // are disposed and any further work would be use-after-free.
-      if (_disposed) return;
+      for (int attempt = 0; attempt < _maxReconnectAttempts; attempt++) {
+        final delay = _reconnectDelays[attempt];
+        _log.info('Reconnect attempt ${attempt + 1}/$_maxReconnectAttempts '
+            'in ${delay.inSeconds}s');
+        connectionMessage.value = 'Connection lost — reconnecting '
+            '(${attempt + 1}/$_maxReconnectAttempts)…';
+        _onStateChanged();
 
-      final result = await liveKitService.connect();
-      if (_disposed) return;
-      _log.info('Reconnection attempt result: $result');
-
-      if (result == ConnectionResult.connected) {
-        await _onReconnectWorld();
-        if (_disposed) return;
-        _listenForConnectionLoss();
-        await enableMedia();
+        await Future.delayed(delay);
+        // Bail if the user left during the delay — services and notifiers
+        // are disposed and any further work would be use-after-free.
         if (_disposed) return;
 
-        connectionFailed.value = false;
-        connectionMessage.value = null;
-        _log.info('Reconnected successfully');
-      } else {
-        connectionMessage.value =
-            'Video & chat unavailable — connection lost';
+        final result = await liveKitService.connect();
+        if (_disposed) return;
+        _log.info('Reconnection attempt ${attempt + 1} result: $result');
+
+        if (result == ConnectionResult.connected) {
+          await _onReconnectWorld();
+          if (_disposed) return;
+          _listenForConnectionLoss();
+          await enableMedia();
+          if (_disposed) return;
+
+          connectionFailed.value = false;
+          connectionMessage.value = null;
+          _log.info('Reconnected successfully on attempt ${attempt + 1}');
+          _onStateChanged();
+          return;
+        }
+
+        // Auth errors won't resolve with retries — stop immediately.
+        if (result == ConnectionResult.tokenAuthError) {
+          _log.warning('Auth error — aborting reconnection');
+          break;
+        }
       }
+
+      // All attempts exhausted or auth error.
+      connectionMessage.value =
+          'Video & chat unavailable — connection lost';
       _onStateChanged();
     } finally {
       _isReconnecting = false;

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -43,10 +43,12 @@ class RoomSession {
     required void Function() onStateChanged,
     required Future<void> Function() onReconnectWorld,
     required void Function() onRoomDeleted,
+    List<Duration>? reconnectDelays,
   })  : _firestore = firestore,
         _onStateChanged = onStateChanged,
         _onReconnectWorld = onReconnectWorld,
-        _onRoomDeleted = onRoomDeleted;
+        _onRoomDeleted = onRoomDeleted,
+        _reconnectDelays = reconnectDelays ?? _defaultReconnectDelays;
 
   // --- Final fields (set at construction) ---
 
@@ -119,6 +121,7 @@ class RoomSession {
     @visibleForTesting ChatMessageRepository? chatMessageRepository,
     @visibleForTesting LiveKitService? liveKitService,
     @visibleForTesting FirebaseFirestore? firestore,
+    @visibleForTesting List<Duration>? reconnectDelays,
   }) {
     final liveKit = liveKitService ??
         LiveKitService(
@@ -157,6 +160,7 @@ class RoomSession {
       onStateChanged: onStateChanged,
       onReconnectWorld: onReconnectWorld,
       onRoomDeleted: onRoomDeleted,
+      reconnectDelays: reconnectDelays,
     );
   }
 
@@ -217,36 +221,36 @@ class RoomSession {
         liveKitService.connectionLost.listen(_handleConnectionLost);
   }
 
-  // Backoff schedule: 2s, 4s, 8s.
-  static const _maxReconnectAttempts = 3;
-  static const _reconnectDelays = [
+  // Backoff schedule: 2s, 4s, 8s. Loop bound derived from list length.
+  static const _defaultReconnectDelays = [
     Duration(seconds: 2),
     Duration(seconds: 4),
     Duration(seconds: 8),
   ];
+
+  final List<Duration> _reconnectDelays;
 
   Future<void> _handleConnectionLost(String? reason) async {
     _log.warning('LiveKit connection lost: $reason');
     if (_isReconnecting || _disposed) return;
     _isReconnecting = true;
 
-    // Show failure banner immediately.
+    // Show failure banner and reset bot status.
     connectionFailed.value = true;
-    connectionMessage.value = 'Connection lost — reconnecting…';
     botStatusNotifier.value = BotStatus.absent;
-    _onStateChanged();
 
     // TechWorld's own connectionLost listener calls disconnectFromLiveKit(),
     // which clears its subscriptions and nulls its service reference. That
     // enables re-initialization when connectToLiveKit() is called again.
 
     try {
-      for (int attempt = 0; attempt < _maxReconnectAttempts; attempt++) {
+      final maxAttempts = _reconnectDelays.length;
+      for (int attempt = 0; attempt < maxAttempts; attempt++) {
         final delay = _reconnectDelays[attempt];
-        _log.info('Reconnect attempt ${attempt + 1}/$_maxReconnectAttempts '
+        _log.info('Reconnect attempt ${attempt + 1}/$maxAttempts '
             'in ${delay.inSeconds}s');
         connectionMessage.value = 'Connection lost — reconnecting '
-            '(${attempt + 1}/$_maxReconnectAttempts)…';
+            '(${attempt + 1}/$maxAttempts)…';
         _onStateChanged();
 
         await Future.delayed(delay);
@@ -275,11 +279,15 @@ class RoomSession {
         // Auth errors won't resolve with retries — stop immediately.
         if (result == ConnectionResult.tokenAuthError) {
           _log.warning('Auth error — aborting reconnection');
-          break;
+          connectionMessage.value = failureMessageFor(result);
+          _onStateChanged();
+          return;
         }
+
+        // Network errors may be transient — keep retrying.
       }
 
-      // All attempts exhausted or auth error.
+      // All attempts exhausted.
       connectionMessage.value =
           'Video & chat unavailable — connection lost';
       _onStateChanged();

--- a/test/rooms/room_session_test.dart
+++ b/test/rooms/room_session_test.dart
@@ -275,4 +275,149 @@ void main() {
       await lostCtrl.close();
     });
   });
+
+  group('reconnection backoff', () {
+    // Zero-duration delays for fast testing.
+    const _zeroDelays = [Duration.zero, Duration.zero, Duration.zero];
+
+    test('retries up to 3 times then shows failure message', () async {
+      final liveKit = _FakeLiveKit();
+      final stubs = _stubLiveKit(liveKit);
+      final lostCtrl = stubs.connectionLost;
+      var connectCalls = 0;
+      var initialConnectDone = false;
+      when(liveKit.connect).thenAnswer((_) async {
+        connectCalls++;
+        // First call is the initial connect — succeed so the loss listener
+        // is wired up. All subsequent calls (reconnection) fail.
+        if (!initialConnectDone) {
+          initialConnectDone = true;
+          return ConnectionResult.connected;
+        }
+        return ConnectionResult.tokenNetworkError;
+      });
+
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        onStateChanged: () {},
+        onReconnectWorld: () async {},
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        reconnectDelays: _zeroDelays,
+      );
+
+      await session.connect();
+      expect(connectCalls, 1, reason: 'initial connect');
+      connectCalls = 0;
+
+      // Fire connection loss and let the handler run to completion.
+      lostCtrl.add('peer-disconnected');
+      // Give async handler time to run all 3 zero-delay attempts.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(connectCalls, 3, reason: 'should attempt 3 reconnections');
+      expect(session.connectionFailed.value, isTrue);
+      expect(session.connectionMessage.value, contains('connection lost'));
+
+      await session.leave();
+      await lostCtrl.close();
+    });
+
+    test('aborts immediately on tokenAuthError with session-expired message',
+        () async {
+      final liveKit = _FakeLiveKit();
+      final stubs = _stubLiveKit(liveKit);
+      final lostCtrl = stubs.connectionLost;
+      var connectCalls = 0;
+      var initialConnectDone = false;
+      when(liveKit.connect).thenAnswer((_) async {
+        connectCalls++;
+        if (!initialConnectDone) {
+          initialConnectDone = true;
+          return ConnectionResult.connected;
+        }
+        return ConnectionResult.tokenAuthError;
+      });
+
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        onStateChanged: () {},
+        onReconnectWorld: () async {},
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        reconnectDelays: _zeroDelays,
+      );
+
+      await session.connect();
+      connectCalls = 0;
+
+      lostCtrl.add('auth-expired');
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(connectCalls, 1, reason: 'auth error should abort after 1 try');
+      expect(session.connectionMessage.value, contains('Session expired'));
+
+      await session.leave();
+      await lostCtrl.close();
+    });
+
+    test('succeeds on second attempt and clears failure state', () async {
+      final liveKit = _FakeLiveKit();
+      final stubs = _stubLiveKit(liveKit);
+      final lostCtrl = stubs.connectionLost;
+      var connectCalls = 0;
+      var initialConnectDone = false;
+      var reconnectAttempts = 0;
+      when(liveKit.connect).thenAnswer((_) async {
+        connectCalls++;
+        if (!initialConnectDone) {
+          initialConnectDone = true;
+          return ConnectionResult.connected;
+        }
+        reconnectAttempts++;
+        // First reconnect attempt fails, second succeeds.
+        if (reconnectAttempts == 1) return ConnectionResult.tokenNetworkError;
+        return ConnectionResult.connected;
+      });
+
+      var reconnectWorldCalls = 0;
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        onStateChanged: () {},
+        onReconnectWorld: () async => reconnectWorldCalls++,
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        reconnectDelays: _zeroDelays,
+      );
+
+      await session.connect();
+      connectCalls = 0;
+
+      lostCtrl.add('network-blip');
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(connectCalls, 2, reason: 'should try twice');
+      expect(reconnectWorldCalls, 1);
+      expect(session.connectionFailed.value, isFalse);
+      expect(session.connectionMessage.value, isNull);
+
+      await session.leave();
+      await lostCtrl.close();
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Replace single-attempt reconnection with 3-attempt exponential backoff (2s → 4s → 8s)
- Show attempt count in UI banner: "Connection lost — reconnecting (2/3)…"
- Abort immediately on auth errors (won't resolve with retries)
- All existing `_disposed` guards preserved at every await point
- Falls through to permanent "connection lost" after all attempts fail

Previously a network blip lasting >2 seconds caused permanent disconnection with no further recovery.

## Test plan

- [x] `flutter analyze` — no new issues
- [x] `flutter test` — 1474 tests pass (existing reconnection tests still pass)
- [ ] Simulate network drop: verify 3 retry attempts with increasing delays
- [ ] Verify successful reconnection mid-retry restores video/chat
- [ ] Verify leaving room during retry delay does not cause use-after-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)