### PR TITLE
fix(security): block conversations participants escalation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -62,12 +62,24 @@ service cloud.firestore {
           resource.data.senderId == request.auth.uid;
       }
 
-      // Conversation metadata subcollection
+      // Conversation metadata subcollection.
+      //
+      // Update guard mirrors the room editor-escalation guard above:
+      // existing participants can update non-participants fields, but
+      // nobody can add themselves (or anyone else) to participants on an
+      // existing conversation. Without this, an attacker could update any
+      // conversation doc to insert their UID into participants, then read
+      // every message under that conversationId via the participant-
+      // membership rule on /messages.
       match /conversations/{conversationId} {
         allow read: if request.auth != null &&
           request.auth.uid in resource.data.participants;
-        allow create, update: if request.auth != null &&
+        allow create: if request.auth != null &&
           request.auth.uid in request.resource.data.participants;
+        allow update: if request.auth != null &&
+          request.auth.uid in resource.data.participants &&
+          !request.resource.data.diff(resource.data).affectedKeys()
+           .hasAny(['participants']);
       }
     }
   }


### PR DESCRIPTION
## Summary

Found by Carnot during cage-match of #389 — separate concern from that PR's spoofing fix; this gap was sitting in already-merged #386.

The conversations metadata rule allowed any authenticated user to \`update\` an existing conversation doc as long as the new participants array contained the caller. There was no existing-membership check and no immutable-participants guard, so an attacker could update any conversation to add themselves to participants — then read every message under that conversationId via the participant-membership rule on \`/messages\`.

## Fix

Mirror the editor-escalation guard pattern from #386 (rooms):
- \`create\`: caller must appear in the new participants array (unchanged)
- \`update\`: caller must **already** be in the existing participants AND cannot mutate the \`participants\` field

## Test plan
- [ ] Existing participant can update non-participants fields (e.g. lastMessageAt)
- [ ] Existing participant cannot add a new UID to participants
- [ ] Non-participant cannot update at all (rejected before the diff check)
- [ ] Deploy to Firebase rules simulator before live deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)