### PR TITLE
fix(dreamfinder): fail-fast and loud-once when apiKey is empty

### DIFF
--- a/lib/services/dreamfinder_client.dart
+++ b/lib/services/dreamfinder_client.dart
@@ -35,7 +35,18 @@ class DreamfinderClient {
     required this.baseUrl,
     required this.apiKey,
     http.Client? httpClient,
-  }) : _client = httpClient ?? http.Client();
+  }) : _client = httpClient ?? http.Client() {
+    if (!isEnabled) {
+      // Loud once at startup so misconfigured builds are obvious. Without
+      // this, an empty key produces silent 401s on every event AND callers
+      // (e.g. ChatService) hang for 30-60s on response Completers that
+      // never resolve because the bot never received the event.
+      _log.severe(
+        'DreamfinderClient: apiKey is empty — client is disabled. '
+        'Set DREAMFINDER_API_KEY via --dart-define before building.',
+      );
+    }
+  }
 
   /// Base URL of the Dreamfinder HTTP server (e.g., `https://dreamfinder.imagineering.cc`).
   final String baseUrl;
@@ -45,12 +56,19 @@ class DreamfinderClient {
 
   final http.Client _client;
 
+  /// Whether this client has a non-empty API key. Callers can check this to
+  /// avoid scheduling Completers/awaiting responses when the client cannot
+  /// actually reach Dreamfinder.
+  bool get isEnabled => apiKey.isNotEmpty;
+
   /// Forwards a game event to Dreamfinder.
   ///
   /// Fire-and-forget — network and timeout errors are silently logged so
   /// the game never breaks due to Dreamfinder being unreachable. Auth and
   /// format errors are logged at a higher level since they indicate
   /// misconfiguration rather than transient issues.
+  ///
+  /// Fast-returns when [isEnabled] is false (no HTTP request, no log spam).
   Future<void> sendEvent({
     required String topic,
     required String roomName,
@@ -58,6 +76,7 @@ class DreamfinderClient {
     required String senderName,
     required Map<String, dynamic> payload,
   }) async {
+    if (!isEnabled) return;
     try {
       final response = await _client
           .post(

--- a/test/services/dreamfinder_client_test.dart
+++ b/test/services/dreamfinder_client_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tech_world/services/dreamfinder_client.dart';
+
+void main() {
+  group('DreamfinderClient.isEnabled', () {
+    test('false when apiKey is empty', () {
+      final client = DreamfinderClient(
+        baseUrl: 'https://example.com',
+        apiKey: '',
+        httpClient: MockClient((_) async => http.Response('', 200)),
+      );
+      expect(client.isEnabled, isFalse);
+      client.dispose();
+    });
+
+    test('true when apiKey is non-empty', () {
+      final client = DreamfinderClient(
+        baseUrl: 'https://example.com',
+        apiKey: 'k',
+        httpClient: MockClient((_) async => http.Response('', 200)),
+      );
+      expect(client.isEnabled, isTrue);
+      client.dispose();
+    });
+  });
+
+  group('DreamfinderClient.sendEvent fail-fast when disabled', () {
+    test('does not make an HTTP request when apiKey is empty', () async {
+      // Regression: empty apiKey previously produced silent 401s and ChatService
+      // hung 30-60s on response Completers that never resolved.
+      var calls = 0;
+      final mockClient = MockClient((_) async {
+        calls++;
+        return http.Response('', 200);
+      });
+      final client = DreamfinderClient(
+        baseUrl: 'https://example.com',
+        apiKey: '',
+        httpClient: mockClient,
+      );
+
+      await client.sendEvent(
+        topic: 'chat',
+        roomName: 'r',
+        senderId: 's',
+        senderName: 'n',
+        payload: const {},
+      );
+
+      expect(calls, equals(0),
+          reason: 'sendEvent must fast-return without making an HTTP request '
+              'when isEnabled is false');
+      client.dispose();
+    });
+
+    test('makes an HTTP request when apiKey is non-empty', () async {
+      var calls = 0;
+      final mockClient = MockClient((req) async {
+        calls++;
+        expect(req.headers['Authorization'], equals('Bearer k'));
+        return http.Response('', 200);
+      });
+      final client = DreamfinderClient(
+        baseUrl: 'https://example.com',
+        apiKey: 'k',
+        httpClient: mockClient,
+      );
+
+      await client.sendEvent(
+        topic: 'chat',
+        roomName: 'r',
+        senderId: 's',
+        senderName: 'n',
+        payload: const {},
+      );
+
+      expect(calls, equals(1));
+      client.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Carnot's medium finding from cage-match of #382. When \`apiKey\` is empty (misconfigured build, missing \`--dart-define=DREAMFINDER_API_KEY\`), the previous behavior was:
1. Silent per-event 401s buried in logs
2. \`ChatService\` waiting 30-60s on response Completers that never resolved (because the bot never received the event)

## Fix

Two parts in \`DreamfinderClient\`:
1. \`bool get isEnabled => apiKey.isNotEmpty\` — public predicate so callers can avoid scheduling Completers when client can't reach the bot
2. **Loud-once startup log** if \`apiKey\` is empty — operators see "DreamfinderClient: apiKey is empty — client is disabled" the moment the app boots
3. \`sendEvent\` fast-returns when not enabled — no HTTP request, no log spam per event

## Test plan
- [x] \`isEnabled\` returns false on empty key, true on non-empty
- [x] \`sendEvent\` does not call the underlying http.Client when disabled
- [x] \`sendEvent\` does call http.Client (with correct Authorization header) when enabled
- [x] Verified by breaking: removed the guard, confirmed the fail-fast test fails; restored, all green

## Future work (separate PR)
\`ChatService\` could check \`DreamfinderClient.isEnabled\` before scheduling response Completers — that would close the timeout-hang concern entirely. Out of scope here; this PR makes the misconfiguration *obvious* via the startup log, which is the main UX issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)