### PR TITLE
ci: serialize prod deploys via concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,12 @@ jobs:
       always() &&
       needs.changes.outputs.docs_only != 'true' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
+    # Serialize deploys: rsync --delete to /srv/tech-world races with sibling tmp
+    # files when bursts of merges trigger concurrent runs (observed 2026-05-09).
+    # Latest commit always wins; older runs are cancelled mid-flight.
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `concurrency: { group: deploy-prod, cancel-in-progress: true }` to the `build_and_deploy` job
- Bursts of merges to main (observed 2026-05-09 during the audit-pushback wave) triggered concurrent `rsync --delete` to `/srv/tech-world`, racing on sibling tmp files; two deploys failed that day
- Test and changes jobs remain parallel — only the deploy step serializes
- Latest commit always wins; older runs are cancelled mid-flight (rsync is fast + idempotent on retry)

## Test plan

- [ ] PR triggers normal CI (test + analyze)
- [ ] Verify on next merge burst: only one `build_and_deploy` run is active at a time on main
- [ ] Older deploy runs show as cancelled when newer commits arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)