### PR TITLE
docs(readme): drop DREAMFINDER_API_KEY incident from war stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ The bugs that have shipped and the bugs that have been caught are both worth kno
 - **Door unlock auth bypass** — any participant (including bots, or null senders) could broadcast `door-unlock` and unlock doors for every client without completing the challenge. Fix: three-check guard (null sender / bot identity / unknown participant). PR #431.
 - **Dreamfinder protobuf publish failure** — four days of `[infra] Failed to publish health` log spam traced to a missing `reliable: false` on a proto3 `PublishDataRequest` field. proto3 required fields with no default fail silently when omitted. Fixed in `imagineering-infra` PR #52.
 - **CanvasKit `createImageFromImageBitmap` crash** — Skia WASM crashed on this entire code path. The `decodeImageFromPixels` rewrite cost a measurable performance penalty but is the only path that compiles. Skia issue 14637.
-- **DREAMFINDER_API_KEY exposed for 30 days** — leaked in PR #227, rotated 2026-05-09 after detection. The leak was small (no observed exploitation) but the response time was three weeks longer than the SLA. Generalisable lesson: secret-scanning CI should run on every PR, not just main.
 - **CRDT map editor thundering herd** — every editor responded to every sync-request with a full snapshot. Multiple responses clobbered the version map. Fix: first-response-wins flag in `MapSyncService`. Audit fork PR #16.
 
 If you find yourself in a long debugging session and the symptom matches any of these, check the linked PR first.


### PR DESCRIPTION
## Summary

Single-line removal from the war-stories section. The DREAMFINDER_API_KEY exposure is a real incident — it just doesn't belong in a public README. A README that names a credential exposure is doing free reconnaissance for anyone evaluating the project's security maturity (grant assessors, casual readers). The lesson lives in project memory (`project_pr227_leak_incident.md`).

## Why this and not #441

PR #441 was opened against the same branch I'd been rewriting the README on (`docs/readme-mobile-deep-dive`). While I had it parked, the rewrite landed as PR #439 directly to main — so my branch's first commit became a duplicate of what's on main, creating a 117-line conflict surface for what should be a one-line change. #441 is closed in favor of this clean cherry-pick onto current main.

## Test plan

- [ ] Verify line 168 is gone, eight technical war stories remain intact
- [ ] No mermaid / table / anchor regressions (single-line removal, low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)