### PR TITLE
refactor(events): typed ChallengeRef replaces stringly-typed challengeId

### DIFF
--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -8,6 +8,7 @@ import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/bots/bot_config.dart';
+import 'package:tech_world/editor/challenge.dart' show CodeChallengeId;
 import 'package:tech_world/events/dispatch.dart';
 import 'package:tech_world/events/types.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
@@ -451,9 +452,10 @@ class ChatService {
     ));
 
     _log.info('Sent message (id=$messageId, len=${text.length})');
+    final challengeWire = metadata?['challengeId'] as String?;
     dispatch([GroupMessageSent(
       messageId: messageId,
-      challengeId: metadata?['challengeId'] as String?,
+      challengeId: challengeWire == null ? null : ChallengeRef.parse(challengeWire),
     )]);
 
     // Persist to Firestore.
@@ -773,8 +775,12 @@ class ChatService {
   ///
   /// Publishes a `help-request` message targeted to the bot and waits for a
   /// `help-response` containing a hint. Returns `null` on timeout or error.
+  ///
+  /// [challengeId] is [CodeChallengeId] because help requests only fire
+  /// from the code editor (prompt challenges use voice-cast / spellbook,
+  /// not a hint affordance).
   Future<String?> requestHelp({
-    required String challengeId,
+    required CodeChallengeId challengeId,
     required String challengeTitle,
     required String challengeDescription,
     required String code,
@@ -798,7 +804,7 @@ class ChatService {
     final payload = {
       'type': DataTopic.helpRequest.wireName,
       'id': requestId,
-      'challengeId': challengeId,
+      'challengeId': challengeId.wireName,
       'challengeTitle': challengeTitle,
       'challengeDescription': challengeDescription,
       'code': code,
@@ -824,7 +830,7 @@ class ChatService {
     ));
 
     _log.info('Sent help-request $requestId');
-    dispatch([HelpRequested(challengeId: challengeId)]);
+    dispatch([HelpRequested(challengeId: CodeRef(challengeId))]);
 
     try {
       return await completer.future.timeout(

--- a/lib/events/sinks/console_sink.dart
+++ b/lib/events/sinks/console_sink.dart
@@ -16,7 +16,7 @@ void consoleSink(AppEvent event) {
     WordLearned(:final wordId, :final challengeId) =>
       'WordLearned: ${wordId.name} (${challengeId.wireName})',
     ChallengeCompleted(:final challengeId) =>
-      'ChallengeCompleted: $challengeId',
+      'ChallengeCompleted: ${challengeId.wireName}',
     SpellCastFailed(:final reason, :final transcript) =>
       'SpellCastFailed: ${reason.name}${transcript != null ? ' "$transcript"' : ''}',
     // Game world
@@ -25,7 +25,7 @@ void consoleSink(AppEvent event) {
     PlayerMoved(:final destX, :final destY) =>
       'PlayerMoved: → ($destX, $destY)',
     TerminalOpened(:final challengeId, :final terminalX, :final terminalY) =>
-      'TerminalOpened: $challengeId at ($terminalX, $terminalY)',
+      'TerminalOpened: ${challengeId.wireName} at ($terminalX, $terminalY)',
     TerminalClosed() => 'TerminalClosed',
     AvatarSelected(:final avatarId) => 'AvatarSelected: $avatarId',
     MapEditorEntered(:final mapId, :final mapName) =>
@@ -51,7 +51,7 @@ void consoleSink(AppEvent event) {
       'ProfileUpdated: $displayName',
     // Code
     CodeSubmitted(:final challengeId, :final result) =>
-      'CodeSubmitted: $challengeId → ${result.name}',
+      'CodeSubmitted: ${challengeId.wireName} → ${result.name}',
     // Map editor
     MapEdited(:final action, :final x, :final y) =>
       'MapEdited: ${action.name} at ($x, $y)',
@@ -68,13 +68,13 @@ void consoleSink(AppEvent event) {
     LiveKitDisconnected(:final reason) =>
       'LiveKitDisconnected${reason != null ? ': $reason' : ''}',
     HelpRequested(:final challengeId) =>
-      'HelpRequested: $challengeId',
+      'HelpRequested: ${challengeId.wireName}',
     MediaEnabled() => 'MediaEnabled',
     RemoteDoorUnlocked(:final doorX, :final doorY) =>
       'RemoteDoorUnlocked: ($doorX, $doorY)',
     // Chat
     GroupMessageSent(:final messageId, :final challengeId) =>
-      'GroupMessageSent: $messageId${challengeId != null ? ' (challenge: $challengeId)' : ''}',
+      'GroupMessageSent: $messageId${challengeId != null ? ' (challenge: ${challengeId.wireName})' : ''}',
     DmSent(:final peerId) => 'DmSent: → $peerId',
     BotSpoke(:final text, :final context) =>
       'BotSpoke [${context.name}]: "${text.length > 60 ? '${text.substring(0, 60)}...' : text}"',

--- a/lib/events/types.dart
+++ b/lib/events/types.dart
@@ -1,8 +1,60 @@
+import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/prompt/prompt_challenge.dart';
 import 'package:tech_world/spellbook/word_of_power.dart';
 
 /// Return type for business functions that produce events alongside a result.
 typedef WithEvents<T> = (T, List<AppEvent>);
+
+/// Sealed wrapper for the union of code and prompt challenge identifiers.
+///
+/// Both [CodeChallengeId] and [PromptChallengeId] serialize to disjoint
+/// wire names in the same Firestore `completedChallenges` array
+/// (disjointness pinned by `code_challenge_id_test.dart`). The sealed
+/// wrapper lets event consumers pattern-match on which kind they have
+/// instead of stringly-comparing wire names.
+///
+/// Wire format unchanged — serialize via [wireName].
+sealed class ChallengeRef {
+  const ChallengeRef();
+  String get wireName;
+
+  /// Parse a wire-format challenge ID. Tries code first (23 entries) then
+  /// prompt (18). Returns null for unknown wire values — caller decides
+  /// whether to drop, log, or treat as a soft error.
+  static ChallengeRef? parse(String wire) {
+    final code = CodeChallengeId.parse(wire);
+    if (code != null) return CodeRef(code);
+    final prompt = PromptChallengeId.parse(wire);
+    if (prompt != null) return PromptRef(prompt);
+    return null;
+  }
+}
+
+final class CodeRef extends ChallengeRef {
+  const CodeRef(this.id);
+  final CodeChallengeId id;
+  @override
+  String get wireName => id.wireName;
+  @override
+  bool operator ==(Object other) => other is CodeRef && other.id == id;
+  @override
+  int get hashCode => Object.hash('CodeRef', id);
+  @override
+  String toString() => 'CodeRef(${id.name})';
+}
+
+final class PromptRef extends ChallengeRef {
+  const PromptRef(this.id);
+  final PromptChallengeId id;
+  @override
+  String get wireName => id.wireName;
+  @override
+  bool operator ==(Object other) => other is PromptRef && other.id == id;
+  @override
+  int get hashCode => Object.hash('PromptRef', id);
+  @override
+  String toString() => 'PromptRef(${id.name})';
+}
 
 /// Base type for all application events — sealed for exhaustive matching
 /// in sinks.
@@ -51,17 +103,17 @@ final class ChallengeCompleted extends AppEvent {
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
-  /// Wire-format challenge ID (matches Firestore `completedChallenges` array).
-  /// String because this is a union of CodeChallengeId and PromptChallengeId
-  /// — both serialize to disjoint wire names in the same Firestore array.
-  final String challengeId;
+  /// Typed challenge ID. Serializes to wire name (matches Firestore
+  /// `completedChallenges` array) — the union of [CodeChallengeId] and
+  /// [PromptChallengeId] is expressed via [ChallengeRef], not String.
+  final ChallengeRef challengeId;
   @override
   final DateTime timestamp;
 
   @override
   Map<String, dynamic> toJson() => {
         'type': 'challenge_completed',
-        'challengeId': challengeId,
+        'challengeId': challengeId.wireName,
         'timestamp': timestamp.toIso8601String(),
       };
 }
@@ -151,7 +203,7 @@ final class TerminalOpened extends AppEvent {
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
-  final String challengeId;
+  final ChallengeRef challengeId;
   final int terminalX;
   final int terminalY;
   @override
@@ -160,7 +212,7 @@ final class TerminalOpened extends AppEvent {
   @override
   Map<String, dynamic> toJson() => {
         'type': 'terminal_opened',
-        'challengeId': challengeId,
+        'challengeId': challengeId.wireName,
         'terminalX': terminalX,
         'terminalY': terminalY,
         'timestamp': timestamp.toIso8601String(),
@@ -537,6 +589,10 @@ enum CodeSubmitResult {
 }
 
 /// Player submitted code for a challenge.
+///
+/// [challengeId] is [CodeChallengeId] (not [ChallengeRef]) because code
+/// submission is strictly a code-challenge concern — prompt challenges
+/// fire [ChallengeCompleted] from `cast_effects`, never this event.
 final class CodeSubmitted extends AppEvent {
   CodeSubmitted({
     required this.challengeId,
@@ -544,7 +600,7 @@ final class CodeSubmitted extends AppEvent {
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
-  final String challengeId;
+  final CodeChallengeId challengeId;
   final CodeSubmitResult result;
   @override
   final DateTime timestamp;
@@ -552,7 +608,7 @@ final class CodeSubmitted extends AppEvent {
   @override
   Map<String, dynamic> toJson() => {
         'type': 'code_submitted',
-        'challengeId': challengeId,
+        'challengeId': challengeId.wireName,
         'result': result.name,
         'timestamp': timestamp.toIso8601String(),
       };
@@ -626,14 +682,14 @@ final class HelpRequested extends AppEvent {
   HelpRequested({required this.challengeId, DateTime? timestamp})
       : timestamp = timestamp ?? DateTime.now();
 
-  final String challengeId;
+  final ChallengeRef challengeId;
   @override
   final DateTime timestamp;
 
   @override
   Map<String, dynamic> toJson() => {
         'type': 'help_requested',
-        'challengeId': challengeId,
+        'challengeId': challengeId.wireName,
         'timestamp': timestamp.toIso8601String(),
       };
 }
@@ -686,7 +742,7 @@ final class GroupMessageSent extends AppEvent {
   final String messageId;
 
   /// Non-null when this message is a challenge submission.
-  final String? challengeId;
+  final ChallengeRef? challengeId;
   @override
   final DateTime timestamp;
 
@@ -694,7 +750,7 @@ final class GroupMessageSent extends AppEvent {
   Map<String, dynamic> toJson() => {
         'type': 'group_message_sent',
         'messageId': messageId,
-        if (challengeId != null) 'challengeId': challengeId,
+        if (challengeId != null) 'challengeId': challengeId!.wireName,
         'timestamp': timestamp.toIso8601String(),
       };
 }

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -1302,7 +1302,7 @@ class TechWorld extends World with TapCallbacks {
         terminalY: terminalPos.y,
       );
       dispatch([TerminalOpened(
-        challengeId: challenge.id.wireName,
+        challengeId: CodeRef(challenge.id),
         terminalX: terminalPos.x,
         terminalY: terminalPos.y,
       )]);
@@ -1331,7 +1331,7 @@ class TechWorld extends World with TapCallbacks {
       activePromptChallenge.value = challenge.id;
       activeTerminalPosition.value = terminalPos;
       dispatch([TerminalOpened(
-        challengeId: challenge.id.wireName,
+        challengeId: PromptRef(challenge.id),
         terminalX: terminalPos.x,
         terminalY: terminalPos.y,
       )]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1241,7 +1241,7 @@ class _MyAppState extends State<MyApp> {
                             final terminalPos =
                                 techWorld.activeTerminalPosition.value;
                             return chatService.requestHelp(
-                              challengeId: challenge.id.wireName,
+                              challengeId: challenge.id,
                               challengeTitle: challenge.title,
                               challengeDescription: challenge.description,
                               code: code,
@@ -1269,7 +1269,7 @@ class _MyAppState extends State<MyApp> {
                               response?['challengeResult'] as String?,
                             );
                             dispatch([CodeSubmitted(
-                              challengeId: challenge.id.wireName,
+                              challengeId: challenge.id,
                               result: codeResult,
                             )]);
                             if (codeResult == CodeSubmitResult.pass) {

--- a/lib/spellbook/cast_effects.dart
+++ b/lib/spellbook/cast_effects.dart
@@ -20,7 +20,7 @@ List<AppEvent> castSuccessEvents(PromptChallengeId challengeId) {
   if (word != null) {
     events.add(WordLearned(wordId: word.id, challengeId: challengeId));
   }
-  events.add(ChallengeCompleted(challengeId: challengeId.wireName));
+  events.add(ChallengeCompleted(challengeId: PromptRef(challengeId)));
   return events;
 }
 

--- a/test/e2e/event_pipeline_test.dart
+++ b/test/e2e/event_pipeline_test.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/events/dispatch.dart';
+import 'package:tech_world/editor/challenge.dart';
 import 'package:tech_world/events/types.dart';
 import 'package:tech_world/progress/progress_service.dart';
 import 'package:tech_world/prompt/prompt_challenge.dart';
@@ -21,7 +22,7 @@ List<AppEvent> allSampleEvents() => [
         wordId: WordId.ignis,
         challengeId: PromptChallengeId.evocationFizzbuzz,
       ),
-      ChallengeCompleted(challengeId: 'evocation_fizzbuzz'),
+      ChallengeCompleted(challengeId: PromptRef(PromptChallengeId.evocationFizzbuzz)),
       SpellCastFailed(
         reason: CastFailureReason.noMatch,
         transcript: 'flambe',
@@ -31,7 +32,7 @@ List<AppEvent> allSampleEvents() => [
       RemoteDoorUnlocked(doorX: 30, doorY: 15),
       PlayerMoved(destX: 25, destY: 10),
       TerminalOpened(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptRef(PromptChallengeId.evocationFizzbuzz),
         terminalX: 15,
         terminalY: 10,
       ),
@@ -50,7 +51,7 @@ List<AppEvent> allSampleEvents() => [
       ProfileUpdated(displayName: 'Alice the Magnificent'),
       // Code
       CodeSubmitted(
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: CodeChallengeId.helloDart,
         result: CodeSubmitResult.pass,
       ),
       // Map editor
@@ -68,7 +69,7 @@ List<AppEvent> allSampleEvents() => [
       // Chat
       GroupMessageSent(messageId: '1715178785123456'),
       DmSent(peerId: 'user_456', conversationId: 'user_abc_user_456'),
-      HelpRequested(challengeId: 'evocation_countdown'),
+      HelpRequested(challengeId: PromptRef(PromptChallengeId.evocationCountdown)),
       BotSpoke(text: 'Welcome, wizard!', context: BotSpokeContext.group),
       // Log bridge
       AppLogRecord(
@@ -145,8 +146,8 @@ void main() {
 
   group('ChallengeCompleted', () {
     test('serializes wire-format challengeId', () {
-      dispatch([ChallengeCompleted(challengeId: 'conjuration_sort')]);
-      expect(captured[0].toJson()['challengeId'], 'conjuration_sort');
+      dispatch([ChallengeCompleted(challengeId: PromptRef(PromptChallengeId.conjurationGlorp))]);
+      expect(captured[0].toJson()['challengeId'], 'conjuration_glorp');
     });
   });
 
@@ -197,7 +198,7 @@ void main() {
   group('TerminalOpened', () {
     test('serializes challengeId and position', () {
       dispatch([TerminalOpened(
-        challengeId: 'evocation_countdown',
+        challengeId: PromptRef(PromptChallengeId.evocationCountdown),
         terminalX: 20,
         terminalY: 5,
       )]);
@@ -311,7 +312,7 @@ void main() {
     for (final result in CodeSubmitResult.values) {
       test('serializes result=${result.name}', () {
         dispatch([CodeSubmitted(
-          challengeId: 'test_challenge',
+          challengeId: CodeChallengeId.helloDart,
           result: result,
         )]);
         final json = captured[0].toJson();
@@ -427,7 +428,7 @@ void main() {
     test('serializes messageId and optional challengeId', () {
       dispatch([GroupMessageSent(
         messageId: 'msg_1',
-        challengeId: 'evocation_fizzbuzz',
+        challengeId: PromptRef(PromptChallengeId.evocationFizzbuzz),
       )]);
       final json = captured[0].toJson();
       expect(json['messageId'], 'msg_1');
@@ -451,7 +452,7 @@ void main() {
 
   group('HelpRequested', () {
     test('serializes challengeId', () {
-      dispatch([HelpRequested(challengeId: 'evocation_countdown')]);
+      dispatch([HelpRequested(challengeId: PromptRef(PromptChallengeId.evocationCountdown))]);
       expect(captured[0].toJson()['challengeId'], 'evocation_countdown');
     });
   });
@@ -550,7 +551,7 @@ void main() {
       expect(wordEvent.challengeId, PromptChallengeId.evocationFizzbuzz);
 
       final challengeEvent = captured[1] as ChallengeCompleted;
-      expect(challengeEvent.challengeId, 'evocation_fizzbuzz');
+      expect(challengeEvent.challengeId, PromptRef(PromptChallengeId.evocationFizzbuzz));
     });
 
     test('performCast pass emits events, fail emits nothing', () async {
@@ -631,7 +632,7 @@ void main() {
         expect(word.challengeId, id);
 
         final challenge = captured[1] as ChallengeCompleted;
-        expect(challenge.challengeId, id.wireName);
+        expect(challenge.challengeId, PromptRef(id));
       }
     });
 
@@ -796,12 +797,12 @@ void main() {
         PlayerMoved(destX: 12, destY: 8),
         PlayerEnteredProximity(playerId: 'user_2'),
         TerminalOpened(
-          challengeId: 'evocation_fizzbuzz',
+          challengeId: PromptRef(PromptChallengeId.evocationFizzbuzz),
           terminalX: 15,
           terminalY: 10,
         ),
         CodeSubmitted(
-          challengeId: 'evocation_fizzbuzz',
+          challengeId: CodeChallengeId.helloDart,
           result: CodeSubmitResult.pass,
         ),
         TerminalClosed(),

--- a/test/events/dispatch_test.dart
+++ b/test/events/dispatch_test.dart
@@ -105,10 +105,11 @@ void main() {
       expect(event.challengeId, PromptChallengeId.evocationFizzbuzz);
     });
 
-    test('ChallengeCompleted carries wire-format challengeId', () {
+    test('ChallengeCompleted carries typed challengeId', () {
       final event =
-          ChallengeCompleted(challengeId: 'evocation_fizzbuzz');
-      expect(event.challengeId, 'evocation_fizzbuzz');
+          ChallengeCompleted(challengeId: PromptRef(PromptChallengeId.evocationFizzbuzz));
+      expect(event.challengeId, PromptRef(PromptChallengeId.evocationFizzbuzz));
+      expect(event.challengeId.wireName, 'evocation_fizzbuzz');
     });
 
     test('timestamp defaults to now', () {

--- a/test/events/sinks_test.dart
+++ b/test/events/sinks_test.dart
@@ -38,7 +38,7 @@ void main() {
     });
 
     test('prints ChallengeCompleted with challengeId', () {
-      consoleSink(ChallengeCompleted(challengeId: 'divination_color'));
+      consoleSink(ChallengeCompleted(challengeId: PromptRef(PromptChallengeId.divinationColor)));
 
       expect(logs, hasLength(1));
       expect(logs[0], contains('ChallengeCompleted'));
@@ -103,7 +103,7 @@ void main() {
 
     test('ChallengeCompleted serializes correctly', () {
       final json = ChallengeCompleted(
-        challengeId: 'divination_color',
+        challengeId: PromptRef(PromptChallengeId.divinationColor),
         timestamp: DateTime(2026, 5, 8),
       ).toJson();
 

--- a/test/spellbook/cast_effects_test.dart
+++ b/test/spellbook/cast_effects_test.dart
@@ -46,7 +46,7 @@ void main() {
               PromptChallengeId.evocationFizzbuzz));
       expect(events[1], isA<ChallengeCompleted>()
           .having((e) => e.challengeId, 'challengeId',
-              'evocation_fizzbuzz'));
+              PromptRef(PromptChallengeId.evocationFizzbuzz)));
     });
 
     test('every PromptChallengeId produces exactly 2 events', () {


### PR DESCRIPTION
## Summary

Addresses Carnot's secondary concern from the PR #436 cage-match: event types exposed `String challengeId` even though the repo already has closed sets `CodeChallengeId` and `PromptChallengeId` with disjoint wire-name namespaces. The compiler should enforce union membership, not the runtime.

## Design

New sealed `ChallengeRef` in `lib/events/types.dart`:

```dart
sealed class ChallengeRef {
  String get wireName;
  static ChallengeRef? parse(String wire) { ... }
}
final class CodeRef extends ChallengeRef { final CodeChallengeId id; ... }
final class PromptRef extends ChallengeRef { final PromptChallengeId id; ... }
```

`==`/`hashCode` overrides so test `expect(event.challengeId, CodeRef(...))` works cleanly.

## Event field changes

| Event | Before | After |
|---|---|---|
| `ChallengeCompleted` | `String` | `ChallengeRef` |
| `TerminalOpened` | `String` | `ChallengeRef` |
| `HelpRequested` | `String` | `ChallengeRef` |
| `GroupMessageSent.challengeId?` | `String?` | `ChallengeRef?` |
| `CodeSubmitted` | `String` | `CodeChallengeId` (stricter — code-only event, not union) |

Also tightened `ChatService.requestHelp` signature: `String challengeId` → `CodeChallengeId challengeId` (help requests only fire from the code editor; main.dart caller already had the typed value).

## Wire format unchanged

`toJson()` still emits `'challengeId': challengeId.wireName` — a String. Existing Firestore data and JSONL logs round-trip without migration. The `expect(json['challengeId'], 'evocation_fizzbuzz')` style assertions still pass.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 1654/1654 pass
- [ ] Wire format spot-check: dispatch a `ChallengeCompleted` event, confirm `events.log` JSONL row has `"challengeId": "evocation_fizzbuzz"` (string, not object)

## Review tier

Type-system refactor across event boundary. Self-review tier — no concurrency, lifecycle, secrets, or wire-format-breaking changes. Sealed/sealed-class machinery means the analyzer catches missed sites at compile time, which it did during this PR (14 test errors surfaced after the type change; all resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)