### PR TITLE
feat(events): add containsPii marker + registerRemoteSink gate

### DIFF
--- a/lib/events/dispatch.dart
+++ b/lib/events/dispatch.dart
@@ -15,6 +15,32 @@ void registerSink(Sink sink) => _syncSinks.add(sink);
 /// Register an asynchronous sink. Called once at app startup or in tests.
 void registerAsyncSink(AsyncSink sink) => _asyncSinks.add(sink);
 
+/// Register a sink that ships events off-device (Crashlytics, analytics,
+/// telemetry, network-attached log aggregator, etc.).
+///
+/// The wrapper short-circuits any [AppEvent] whose [AppEvent.containsPii]
+/// is `true` — the event never reaches [sink]. This makes the PII gate
+/// impossible to forget: the only way a remote sink sees a PII event is
+/// for someone to bypass this helper and call [registerSink] directly,
+/// which should fail code review.
+///
+/// Local-only sinks (JSONL on disk, debug console) bypass this filter
+/// via [registerSink] — they're already inside the trust boundary.
+void registerRemoteSink(Sink sink) {
+  registerSink((event) {
+    if (event.containsPii) return;
+    sink(event);
+  });
+}
+
+/// Async variant of [registerRemoteSink].
+void registerRemoteAsyncSink(AsyncSink sink) {
+  registerAsyncSink((event) async {
+    if (event.containsPii) return;
+    await sink(event);
+  });
+}
+
 /// Whether any sinks have been registered. Used to guard against
 /// duplicate registration on hot restart.
 bool get sinksRegistered => _syncSinks.isNotEmpty || _asyncSinks.isNotEmpty;

--- a/lib/events/types.dart
+++ b/lib/events/types.dart
@@ -68,6 +68,24 @@ sealed class AppEvent {
   /// Serialize to JSON for JSONL file sinks. Each subclass contributes
   /// its own fields; the `type` and `timestamp` are always present.
   Map<String, dynamic> toJson();
+
+  /// Whether this event carries personally-identifiable information
+  /// (user identifiers, display names, raw transcripts, free-form user
+  /// content, bot reply text, etc.).
+  ///
+  /// The default is `false` — events must explicitly opt in by
+  /// overriding `=> true;`. This is the type-system gate used by
+  /// [registerRemoteSink] (see `lib/events/dispatch.dart`) to drop
+  /// PII events before they reach any off-device sink (Crashlytics,
+  /// analytics, telemetry).
+  ///
+  /// Be conservative: when in doubt, return `true`. The cost of marking
+  /// a non-PII event as PII is a missing remote-sink line; the cost of
+  /// missing a PII event is a leak.
+  ///
+  /// Invariant: every PII override is pinned by a positive case in
+  /// `test/events/pii_marker_test.dart` (dual control).
+  bool get containsPii => false;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,7 +142,8 @@ enum CastFailureReason { noMatch, notLearned, wrongDoor }
 /// A voice-cast at a door failed.
 ///
 /// Note: [transcript] contains STT output of what the user spoke.
-/// Local-only — scrub before routing to any remote sink.
+/// Marked [containsPii] — `registerRemoteSink` will drop this event
+/// before it reaches any off-device sink.
 final class SpellCastFailed extends AppEvent {
   SpellCastFailed({
     required this.reason,
@@ -144,6 +163,10 @@ final class SpellCastFailed extends AppEvent {
         if (transcript != null) 'transcript': transcript,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: raw STT transcript of what the user spoke.
+  @override
+  bool get containsPii => true;
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +281,10 @@ final class RoomJoined extends AppEvent {
         'roomName': roomName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: room names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// Player left a room.
@@ -301,6 +328,10 @@ final class UserSignedIn extends AppEvent {
         'displayName': displayName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: user identifier + display name.
+  @override
+  bool get containsPii => true;
 }
 
 /// User signed out.
@@ -333,6 +364,10 @@ final class ProfileUpdated extends AppEvent {
         'displayName': displayName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: display name.
+  @override
+  bool get containsPii => true;
 }
 
 // ---------------------------------------------------------------------------
@@ -395,6 +430,10 @@ final class PlayerEnteredProximity extends AppEvent {
         'playerId': playerId,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: player identifier.
+  @override
+  bool get containsPii => true;
 }
 
 /// Another player left proximity range.
@@ -412,6 +451,10 @@ final class PlayerLeftProximity extends AppEvent {
         'playerId': playerId,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: player identifier.
+  @override
+  bool get containsPii => true;
 }
 
 /// A bot joined the room.
@@ -496,6 +539,10 @@ final class MapEditorEntered extends AppEvent {
         'mapName': mapName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: map names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// Player exited the map editor.
@@ -533,6 +580,10 @@ final class RoomCreated extends AppEvent {
         'roomName': roomName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: room names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// A room's map was saved to Firestore.
@@ -552,6 +603,10 @@ final class RoomMapSaved extends AppEvent {
         'roomName': roomName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: room names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// A room was deleted by its owner.
@@ -571,6 +626,10 @@ final class RoomDeleted extends AppEvent {
         'roomName': roomName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: room names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// Outcome of a code submission evaluation.
@@ -629,6 +688,10 @@ final class LiveKitConnected extends AppEvent {
         'roomName': roomName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: room names are user-typed free text.
+  @override
+  bool get containsPii => true;
 }
 
 /// LiveKit disconnected from a room.
@@ -675,6 +738,10 @@ final class BotSpoke extends AppEvent {
         'context': context.name,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: free-form bot reply text (may quote or reference user input).
+  @override
+  bool get containsPii => true;
 }
 
 /// Player requested a hint from Clawd.
@@ -753,12 +820,17 @@ final class GroupMessageSent extends AppEvent {
         if (challengeId != null) 'challengeId': challengeId!.wireName,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: references a user-authored chat message (and the sender).
+  @override
+  bool get containsPii => true;
 }
 
 /// Player sent a DM to another player.
 ///
 /// Note: [peerId] and [conversationId] are written to the local JSONL log.
-/// If this event is ever routed to a remote sink, scrub PII first.
+/// Marked [containsPii] — `registerRemoteSink` will drop this event
+/// before it reaches any off-device sink.
 final class DmSent extends AppEvent {
   DmSent({
     required this.peerId,
@@ -778,6 +850,10 @@ final class DmSent extends AppEvent {
         'conversationId': conversationId,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: peer identifier and conversation identifier.
+  @override
+  bool get containsPii => true;
 }
 
 /// Discriminator for [BotSpoke] origin.
@@ -836,4 +912,11 @@ final class AppLogRecord extends AppEvent {
         if (stackTrace != null) 'stackTrace': stackTrace,
         'timestamp': timestamp.toIso8601String(),
       };
+
+  /// PII: free-form log message may contain transcripts, oracle replies,
+  /// user names, or anything else a `_log.*` call passes in. Mark all log
+  /// records as PII conservatively — remote sinks must scrub or route
+  /// through Crashlytics' own redaction layer, not the JSONL pipeline.
+  @override
+  bool get containsPii => true;
 }

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -273,4 +273,67 @@ void main() {
       expect(received.single, same(keep));
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Async variant — same gate, same invariant. Carnot caught the
+  // coverage gap on PR #459: the sync helper had three tests, the
+  // async helper had zero. A future edit could invert the async
+  // `if (event.containsPii) return;` and the test file would still
+  // pass. Mirror the sync coverage here.
+  // ---------------------------------------------------------------------
+
+  group('registerRemoteAsyncSink', () {
+    tearDown(clearSinks);
+
+    test('drops PII events before they reach the wrapped async sink',
+        () async {
+      final received = <AppEvent>[];
+      registerRemoteAsyncSink((event) async => received.add(event));
+
+      dispatch([
+        DmSent(peerId: 'p', conversationId: 'c'),
+        BotSpoke(text: 'hi', context: BotSpokeContext.group),
+        SpellCastFailed(
+          reason: CastFailureReason.noMatch,
+          transcript: 'leaked',
+        ),
+      ]);
+      // Drain pending microtasks so the async sinks have run.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, isEmpty);
+    });
+
+    test('passes non-PII events through to the wrapped async sink',
+        () async {
+      final received = <AppEvent>[];
+      registerRemoteAsyncSink((event) async => received.add(event));
+
+      final ev1 = DoorUnlocked(doorX: 1, doorY: 2);
+      final ev2 = MediaEnabled();
+      dispatch([ev1, ev2]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(2));
+      expect(received[0], same(ev1));
+      expect(received[1], same(ev2));
+    });
+
+    test('mixed stream: only non-PII events reach the wrapped async sink',
+        () async {
+      final received = <AppEvent>[];
+      registerRemoteAsyncSink((event) async => received.add(event));
+
+      final keep = DoorUnlocked(doorX: 0, doorY: 0);
+      dispatch([
+        DmSent(peerId: 'p', conversationId: 'c'),
+        keep,
+        BotSpoke(text: 'x', context: BotSpokeContext.help),
+      ]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single, same(keep));
+    });
+  });
 }

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -1,0 +1,276 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/editor/challenge.dart';
+import 'package:tech_world/events/dispatch.dart';
+import 'package:tech_world/events/types.dart';
+import 'package:tech_world/prompt/prompt_challenge.dart';
+import 'package:tech_world/spellbook/word_of_power.dart';
+
+/// Verifies the `AppEvent.containsPii` type-system gate.
+///
+/// Why a test, not just a marker: the value of `containsPii` is the gate
+/// to remote sinks. Forgetting to override on a new PII-carrying event
+/// silently re-introduces the leak the gate exists to prevent. This test
+/// is the dual-control invariant — every PII event must announce itself
+/// here AND in the type definition.
+void main() {
+  group('AppEvent.containsPii', () {
+    // -------------------------------------------------------------------
+    // Positive cases — events that MUST be marked PII=true.
+    // Add a case here when you add a new PII-carrying event.
+    // -------------------------------------------------------------------
+
+    test('SpellCastFailed (raw STT transcript) is PII', () {
+      expect(
+        SpellCastFailed(
+          reason: CastFailureReason.noMatch,
+          transcript: 'ignis maxima',
+        ).containsPii,
+        isTrue,
+      );
+    });
+
+    test('BotSpoke (bot reply text) is PII', () {
+      expect(
+        BotSpoke(text: 'Try a for loop', context: BotSpokeContext.help)
+            .containsPii,
+        isTrue,
+      );
+    });
+
+    test('UserSignedIn (userId + displayName) is PII', () {
+      expect(
+        UserSignedIn(userId: 'u1', displayName: 'Alice').containsPii,
+        isTrue,
+      );
+    });
+
+    test('ProfileUpdated (displayName) is PII', () {
+      expect(ProfileUpdated(displayName: 'Alice').containsPii, isTrue);
+    });
+
+    test('DmSent (peerId + conversationId) is PII', () {
+      expect(
+        DmSent(peerId: 'peer1', conversationId: 'c1').containsPii,
+        isTrue,
+      );
+    });
+
+    test('GroupMessageSent (references user-typed content) is PII', () {
+      expect(GroupMessageSent(messageId: 'm1').containsPii, isTrue);
+    });
+
+    test('PlayerEnteredProximity (player identity) is PII', () {
+      expect(PlayerEnteredProximity(playerId: 'p1').containsPii, isTrue);
+    });
+
+    test('PlayerLeftProximity (player identity) is PII', () {
+      expect(PlayerLeftProximity(playerId: 'p1').containsPii, isTrue);
+    });
+
+    test('AppLogRecord (free-form message) is PII', () {
+      expect(
+        AppLogRecord(
+          loggerName: 'X',
+          severity: LogSeverity.info,
+          message: 'anything could be in here',
+        ).containsPii,
+        isTrue,
+      );
+    });
+
+    test('RoomJoined (user-named room) is PII', () {
+      expect(RoomJoined(roomId: 'r', roomName: 'Alice\'s room').containsPii,
+          isTrue);
+    });
+
+    test('RoomCreated (user-named room) is PII', () {
+      expect(RoomCreated(roomId: 'r', roomName: 'X').containsPii, isTrue);
+    });
+
+    test('RoomMapSaved (user-named room) is PII', () {
+      expect(RoomMapSaved(roomId: 'r', roomName: 'X').containsPii, isTrue);
+    });
+
+    test('RoomDeleted (user-named room) is PII', () {
+      expect(RoomDeleted(roomId: 'r', roomName: 'X').containsPii, isTrue);
+    });
+
+    test('LiveKitConnected (user-named room) is PII', () {
+      expect(LiveKitConnected(roomName: 'X').containsPii, isTrue);
+    });
+
+    test('MapEditorEntered (user-named map) is PII', () {
+      expect(
+        MapEditorEntered(mapId: 'm', mapName: 'X').containsPii,
+        isTrue,
+      );
+    });
+
+    // -------------------------------------------------------------------
+    // Negative cases — events that MUST be marked PII=false.
+    // No user identity, no user-typed content, no transcripts.
+    // -------------------------------------------------------------------
+
+    test('WordLearned is not PII', () {
+      expect(
+        WordLearned(
+          wordId: WordId.values.first,
+          challengeId: PromptChallengeId.values.first,
+        ).containsPii,
+        isFalse,
+      );
+    });
+
+    test('ChallengeCompleted is not PII', () {
+      expect(
+        ChallengeCompleted(
+          challengeId: CodeRef(CodeChallengeId.values.first),
+        ).containsPii,
+        isFalse,
+      );
+    });
+
+    test('DoorUnlocked is not PII', () {
+      expect(DoorUnlocked(doorX: 1, doorY: 2).containsPii, isFalse);
+    });
+
+    test('RemoteDoorUnlocked is not PII', () {
+      expect(RemoteDoorUnlocked(doorX: 1, doorY: 2).containsPii, isFalse);
+    });
+
+    test('PlayerMoved is not PII', () {
+      expect(PlayerMoved(destX: 1, destY: 2).containsPii, isFalse);
+    });
+
+    test('TerminalOpened is not PII', () {
+      expect(
+        TerminalOpened(
+          challengeId: CodeRef(CodeChallengeId.values.first),
+          terminalX: 0,
+          terminalY: 0,
+        ).containsPii,
+        isFalse,
+      );
+    });
+
+    test('TerminalClosed is not PII', () {
+      expect(TerminalClosed().containsPii, isFalse);
+    });
+
+    test('RoomLeft is not PII', () {
+      expect(RoomLeft().containsPii, isFalse);
+    });
+
+    test('UserSignedOut is not PII', () {
+      expect(UserSignedOut().containsPii, isFalse);
+    });
+
+    test('MapEdited is not PII', () {
+      expect(
+        MapEdited(action: MapEditAction.paintTile, x: 0, y: 0).containsPii,
+        isFalse,
+      );
+    });
+
+    test('BotJoined is not PII', () {
+      expect(BotJoined(identity: 'bot-claude').containsPii, isFalse);
+    });
+
+    test('BotLeft is not PII', () {
+      expect(BotLeft().containsPii, isFalse);
+    });
+
+    test('ScreenShareToggled is not PII', () {
+      expect(ScreenShareToggled(started: true).containsPii, isFalse);
+    });
+
+    test('AvatarSelected is not PII', () {
+      expect(AvatarSelected(avatarId: 'wizard').containsPii, isFalse);
+    });
+
+    test('MapEditorExited is not PII', () {
+      expect(MapEditorExited(applied: true).containsPii, isFalse);
+    });
+
+    test('CodeSubmitted is not PII', () {
+      expect(
+        CodeSubmitted(
+          challengeId: CodeChallengeId.values.first,
+          result: CodeSubmitResult.pass,
+        ).containsPii,
+        isFalse,
+      );
+    });
+
+    test('LiveKitDisconnected is not PII', () {
+      expect(LiveKitDisconnected().containsPii, isFalse);
+    });
+
+    test('HelpRequested is not PII', () {
+      expect(
+        HelpRequested(challengeId: CodeRef(CodeChallengeId.values.first))
+            .containsPii,
+        isFalse,
+      );
+    });
+
+    test('MediaEnabled is not PII', () {
+      expect(MediaEnabled().containsPii, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Remote-sink filter integration. `registerRemoteSink` is the single
+  // entry point for any sink that sends data off-device (Crashlytics,
+  // analytics, telemetry). It MUST drop PII events before the wrapped
+  // sink sees them — making the gate impossible to forget.
+  // ---------------------------------------------------------------------
+
+  group('registerRemoteSink', () {
+    tearDown(clearSinks);
+
+    test('drops PII events before they reach the wrapped sink', () {
+      final received = <AppEvent>[];
+      registerRemoteSink(received.add);
+
+      dispatch([
+        DmSent(peerId: 'p', conversationId: 'c'),
+        BotSpoke(text: 'hi', context: BotSpokeContext.group),
+        SpellCastFailed(
+          reason: CastFailureReason.noMatch,
+          transcript: 'leaked',
+        ),
+      ]);
+
+      expect(received, isEmpty);
+    });
+
+    test('passes non-PII events through to the wrapped sink', () {
+      final received = <AppEvent>[];
+      registerRemoteSink(received.add);
+
+      final ev1 = DoorUnlocked(doorX: 1, doorY: 2);
+      final ev2 = MediaEnabled();
+      dispatch([ev1, ev2]);
+
+      expect(received, hasLength(2));
+      expect(received[0], same(ev1));
+      expect(received[1], same(ev2));
+    });
+
+    test('mixed stream: only non-PII events reach the wrapped sink', () {
+      final received = <AppEvent>[];
+      registerRemoteSink(received.add);
+
+      final keep = DoorUnlocked(doorX: 0, doorY: 0);
+      dispatch([
+        DmSent(peerId: 'p', conversationId: 'c'),
+        keep,
+        BotSpoke(text: 'x', context: BotSpokeContext.help),
+      ]);
+
+      expect(received, hasLength(1));
+      expect(received.single, same(keep));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces comment-based PII gate (`/// Local-only — scrub before routing to any remote sink.`) with a type-system invariant. From CLAUDE.md TODO:

> Add `containsPii` marker to `AppEvent`. A `bool get containsPii => false;` overridden by `true` on `SpellCastFailed`, `BotSpoke`, `ProfileUpdated`, `DmSent` etc. makes the gate to remote sinks impossible to forget. Currently the gate is a code comment that future maintainers will ignore.

### Changes

- `AppEvent` gains `bool get containsPii => false;` default.
- 15 PII-carrying events override `=> true;` with a justification comment.
- New `registerRemoteSink(Sink)` / `registerRemoteAsyncSink(AsyncSink)` helpers in `dispatch.dart` wrap any off-device sink and drop PII events before they reach it. Local sinks (`registerSink`) bypass — they're inside the trust boundary.
- 37 new tests in `test/events/pii_marker_test.dart`:
  - Positive case per PII-marked event (`containsPii == true`)
  - Negative case per non-PII event (`containsPii == false`)
  - 3 integration tests on the remote-sink filter (drops PII, passes non-PII, mixed stream)

### PII=true events (15)

| Event | Why |
|---|---|
| `SpellCastFailed` | raw STT transcript |
| `BotSpoke` | free-form bot reply text |
| `UserSignedIn` | userId + displayName |
| `ProfileUpdated` | displayName |
| `DmSent` | peerId + conversationId |
| `GroupMessageSent` | references user-authored chat content |
| `PlayerEnteredProximity` / `PlayerLeftProximity` | player identity |
| `AppLogRecord` | free-form log message — per CLAUDE.md TODO may contain STT transcripts (`stt_service_web.dart`) or oracle replies (`oracle_service.dart`) |
| `RoomJoined` / `RoomCreated` / `RoomMapSaved` / `RoomDeleted` | user-typed room names |
| `LiveKitConnected` | user-typed room name |
| `MapEditorEntered` | user-typed map name |

Conservative classification — when in doubt, mark PII=true. Cost of a false positive is a missing telemetry line; cost of a false negative is a leak.

### Why this is boundary-class

This is the type-system gate for PII routing to off-device sinks (Crashlytics, telemetry). A future maintainer who registers a remote sink via `registerSink` directly bypasses the gate — that should fail code review. The contract is: **off-device sinks go through `registerRemoteSink`, full stop.**

### Verified

- Regression test verified by breaking: commented out the filter line in `registerRemoteSink`, 2 of the 3 integration tests fail with PII events leaking through. Restored.
- `flutter analyze --fatal-infos` clean
- `flutter test` — 1803 / 1803 pass (1766 previous + 37 new)

## Test plan

- [x] flutter analyze --fatal-infos clean
- [x] flutter test all green (1803 tests)
- [x] Filter break-and-restore verified
- [ ] CI green