### PR TITLE
feat(bubbles): visible speech animation for player bubbles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,9 +183,12 @@ Surfaced from PR cage-matches and session trawls — concrete items with a known
 - **Continue extracting `TechWorld`.** Shrunk from 1570 → ~1300 lines via the bridge + door-manager split, but terminal-interaction, speech-bubble lifecycle, and avatar-tracking still live there. Each is the same shape of extraction as `DoorManager` / `LiveKitGameBridge`.
 - **Add positive-case `predefinedAvatars` whitelist test.** Current coverage exhausts the negative cases (unknown / path-traversal / empty); a "valid sprite asset that's not in `predefinedAvatars`" test would tighten the gate against future avatar additions silently failing.
 
-### Feature work in flight
+### Operations & deploy hygiene (from Robin's Phase 5 audit, 2026-05-15)
 
-- **Avatar-only mode (ASD-accessibility toggle).** Fully scoped in `docs/avatar-only-mode-scoping.md` — S effort, ~30–50 LOC production + ~20 LOC tests. Implementation sketch present: `UserAccessibilityPreferences.avatarOnlyMode` Firestore field → `BubbleManager` constructor flag → two conditional returns in `_createBubbleForPlayer`/`_createLocalPlayerBubble`. Connected to the `RESEARCH.md` + `docs/asd-consultation-prep.md` thread.
+- **Android release signing.** `android/app/build.gradle.kts` uses `signingConfigs.getByName("debug")` for release builds — Play Store will reject this. Generate a production keystore, store via GitHub Actions secrets, wire to a `release` signing config. Not urgent until Play Store submission is on the table.
+- **`firebase_options.dart` committed to repo.** FlutterFire-generated; web API key is public-by-design (Firebase Auth domain allowlist is the real gate), but iOS/Android keys are also in repo history. Decision needed: leave as-is (treat all keys as public identifiers, lean on Firestore rules + Auth domain restrictions) or rotate iOS/Android, add to `.gitignore`, ship a `firebase_options.template.dart`. Mixed industry guidance — not a clear win either way.
+- **No staging environment.** LiveKit URL + Firebase project hardcoded; every merge to `main` deploys to production. Single-developer cadence makes this tolerable; add `--dart-define` env selection if a second risky-change contributor joins.
+- **Cross-repo topic drift test.** Bot mirrors a subset of `LiveKitTopic` via `tech_world_bot/src/livekit-topics.ts`, but nothing fails CI when a Flutter rename happens without a bot update. While auditing, found `bot-mood` (published by `dreamfinder-entry.ts`) has no Flutter subscriber — dead-channel drift. Either subscribe on the Flutter side or stop publishing.
 
 ## Grant Application
 

--- a/lib/flame/components/video_bubble_component.dart
+++ b/lib/flame/components/video_bubble_component.dart
@@ -118,8 +118,10 @@ class VideoBubbleComponent extends PositionComponent {
 
   // Voice ripple — number of wave lobes around the circle
   static const int _rippleLobes = 8;
-  // Max ripple displacement in pixels at full speaking volume
-  static const double _rippleAmplitude = 4.0;
+  // Max ripple displacement in pixels at full speaking volume.
+  // 10px on a 32px-radius bubble = ~30% edge wobble — clearly visible across
+  // a populated map without being gaudy.
+  static const double _rippleAmplitude = 10.0;
   // Smoothed audio level (lerped toward raw audioLevel each frame)
   double _smoothedAudioLevel = 0.0;
 
@@ -738,15 +740,16 @@ class VideoBubbleComponent extends PositionComponent {
       }
     }
 
-    if (_shader == null || !ui.ImageFilter.isShaderFilterSupported) {
-      final borderPaint = Paint()
-        ..color = _currentFrame != null ? _glowColor : Colors.white
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 2;
-      // Reuse the path built earlier, or build fresh if we took the no-video branch.
-      final path = _frameBubblePath ?? _buildBubblePath(center, radius);
-      canvas.drawPath(path, borderPaint);
-    }
+    // Always draw a thin border at the bubble edge. For player bubbles with
+    // glowIntensity = 0 this is the only edge affordance; for DF it sits on
+    // top of the radial gold halo as a crisp inner ring.
+    final borderPaint = Paint()
+      ..color = _currentFrame != null ? _glowColor : Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    // Reuse the path built earlier, or build fresh if we took the no-video branch.
+    final path = _frameBubblePath ?? _buildBubblePath(center, radius);
+    canvas.drawPath(path, borderPaint);
 
     if (_opacity < 1.0) {
       canvas.restore();


### PR DESCRIPTION
## Summary

Player bubbles had `glowIntensity = 0` (only DF sets it non-zero), so the existing shader-driven speech-pulse multiplied to zero — speech has been effectively invisible on player bubbles since the feature was first introduced. Two small visual changes inside `video_bubble_component.dart` fix it without depending on the still-disabled fragment shader:

- **Always draw a 2px stroke border** at the bubble edge in `_glowColor`. Previously gated on `_shader == null`, which kept the border hidden for every player bubble (`setShader` is always called for them). Border becomes the ambient edge affordance — cyan for local, green for remote, gold for DF (stacks on DF's existing radial halo as an inner ring).
- **Bump `_rippleAmplitude` 4.0 → 10.0.** The path-ripple becomes the visible speech indicator. Bubble edge wobbles by up to ~30% radius when speaking, no glow dependency.

The shader-imageFilter line at line ~656 stays commented out — its PR #276 disable predates this work and the actual transient cause of the black-frame investigation hasn't been root-caused (see TaskList item filed today).

## Background

Discovered while Nick noticed speech animation hadn't been visible since first introduction. Investigation:
- The shader-driven pulse requires `u_glow_intensity > 0` to be visible (`glow *= u_glow_intensity * pulse` in `video_bubble.frag`).
- Only DF sets glowIntensity > 0; every player bubble defaults to 0.
- Re-enabling the shader doesn't help — the multiplication still zeros out.
- Switching the speech indicator to the path-ripple side-steps the glow dependency entirely.

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test test/flame/` — 658 tests pass
- [x] Local Playwright run against `flutter build web --wasm` bundle — bubbles render with new border, no regression observed
- [ ] Visual confirm in production after merge — walk into proximity with a player bubble, observe the green/cyan border + edge wobble during speech

🤖 Generated with [Claude Code](https://claude.com/claude-code)