### PR TITLE
feat(observability): AV pipeline diagnostics with rotating file sinks

### DIFF
--- a/lib/events/sinks/console_sink.dart
+++ b/lib/events/sinks/console_sink.dart
@@ -78,6 +78,27 @@ void consoleSink(AppEvent event) {
     DmSent(:final peerId) => 'DmSent: → $peerId',
     BotSpoke(:final text, :final context) =>
       'BotSpoke [${context.name}]: "${text.length > 60 ? '${text.substring(0, 60)}...' : text}"',
+    // AV pipeline diagnostics
+    AvPipelineSnapshot(:final participant, :final hasVideoTrack, :final captureMethod, :final bubbleType, :final audioEnabled, :final distance) =>
+      'AvSnapshot: $participant track=${hasVideoTrack ? 'VIDEO' : 'NONE'} capture=${captureMethod?.name ?? 'NONE'} bubble=${bubbleType?.name ?? 'NONE'} audio=${audioEnabled ? 'ON' : 'OFF'} dist=$distance',
+    AvTrackSubscribed(:final participant) =>
+      'AvTrackSubscribed: $participant',
+    AvTrackUnsubscribed(:final participant) =>
+      'AvTrackUnsubscribed: $participant',
+    AvCaptureInitialized(:final participant, :final method, :final retryCount) =>
+      'AvCaptureInit: $participant method=${method.name} retries=$retryCount',
+    AvCaptureInitFailed(:final participant, :final maxRetries) =>
+      'AvCaptureInitFailed: $participant after $maxRetries retries',
+    AvBubbleCreated(:final participant, :final bubbleType) =>
+      'AvBubbleCreated: $participant type=${bubbleType.name}',
+    AvBubbleRemoved(:final participant) =>
+      'AvBubbleRemoved: $participant',
+    AvAudioGateChanged(:final participant, :final enabled, :final distance) =>
+      'AvAudioGate: $participant ${enabled ? 'ENABLED' : 'DISABLED'} dist=$distance',
+    AvFrameDecodeError(:final participant, :final error) =>
+      'AvFrameDecodeError: $participant $error',
+    AvSpeakingChanged(:final participant, :final speaking) =>
+      'AvSpeaking: $participant ${speaking ? 'START' : 'STOP'}',
     // Log bridge
     AppLogRecord(:final loggerName, :final severity, :final message) =>
       '${severity.name.toUpperCase()} $loggerName: $message',

--- a/lib/events/sinks/file_sink.dart
+++ b/lib/events/sinks/file_sink.dart
@@ -1,42 +1,86 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:path_provider/path_provider.dart';
+import 'package:tech_world/events/sinks/rotating_file_sink.dart';
 import 'package:tech_world/events/types.dart';
 
-/// Creates an append-only JSONL file sink for native platforms
-/// (macOS, iOS, Android).
-///
-/// All events are written to a single `events.log` file in JSONL format
-/// (one JSON object per line). The file lives in the app's documents
-/// directory so it survives restarts and is accessible via Finder/Files.
-///
-/// **Not available on web** — use conditional import with
-/// `file_sink_stub.dart`:
-/// ```dart
-/// import 'sinks/file_sink.dart'
-///     if (dart.library.js_interop) 'sinks/file_sink_stub.dart';
-/// ```
-///
-/// Design notes:
-/// - Async writes (never blocks the UI thread)
-/// - JSONL format (greppable, parseable by jq / Loki / Datadog)
-/// - No rotation — app storage is OS-managed
-Future<void Function(AppEvent)> createFileSink() async {
+/// Directory shared by all JSONL sinks. Created once, reused by
+/// [createFileSink], [createAvPipelineSink], and [createErrorSink].
+Future<Directory> logDirectory() async {
   final appDir = await getApplicationDocumentsDirectory();
   final logDir = Directory('${appDir.path}/tech_world_logs');
   await logDir.create(recursive: true);
-  final logFile = File('${logDir.path}/events.log');
-
-  return (AppEvent event) {
-    final line = jsonEncode(event.toJson());
-    // Fire-and-forget — don't block dispatch on file I/O. Errors are
-    // swallowed because a failing sink must never crash the app.
-    logFile
-        .writeAsString('$line\n', mode: FileMode.append)
-        .then<void>((_) {}, onError: (Object e) {
-      debugPrint('[sink:file] Write failed: $e');
-    });
-  };
+  return logDir;
 }
+
+/// Creates the general-purpose JSONL event sink (all events).
+///
+/// **Not available on web** — use conditional import with
+/// `file_sink_stub.dart`.
+Future<void Function(AppEvent)> createFileSink() async {
+  final logDir = await logDirectory();
+  final sink = RotatingFileSink(logFile: File('${logDir.path}/events.log'));
+  return sink.call;
+}
+
+/// Creates the AV pipeline diagnostic sink (Av* events only).
+///
+/// Writes to `av-pipeline.jsonl`. The [enabledCheck] callback is evaluated
+/// on every event so the toggle can be flipped at runtime without restart.
+Future<void Function(AppEvent)> createAvPipelineSink({
+  required bool Function() enabledCheck,
+}) async {
+  final logDir = await logDirectory();
+  final sink = RotatingFileSink(
+    logFile: File('${logDir.path}/av-pipeline.jsonl'),
+    filter: _isAvEvent,
+    enabledCheck: enabledCheck,
+  );
+  return sink.call;
+}
+
+/// Creates the error sink (warning-or-above severity events).
+///
+/// Writes to `errors.jsonl`. AV errors also land here (duplicated with
+/// the AV pipeline sink) — that's intentional for the "something's broken,
+/// not sure what" reading mode.
+Future<void Function(AppEvent)> createErrorSink({
+  required bool Function() enabledCheck,
+}) async {
+  final logDir = await logDirectory();
+  final sink = RotatingFileSink(
+    logFile: File('${logDir.path}/errors.jsonl'),
+    filter: _isErrorEvent,
+    enabledCheck: enabledCheck,
+  );
+  return sink.call;
+}
+
+bool _isAvEvent(AppEvent event) => switch (event) {
+      AvPipelineSnapshot() => true,
+      AvTrackSubscribed() => true,
+      AvTrackUnsubscribed() => true,
+      AvCaptureInitialized() => true,
+      AvCaptureInitFailed() => true,
+      AvBubbleCreated() => true,
+      AvBubbleRemoved() => true,
+      AvAudioGateChanged() => true,
+      AvFrameDecodeError() => true,
+      AvSpeakingChanged() => true,
+      _ => false,
+    };
+
+bool _isErrorEvent(AppEvent event) => switch (event) {
+      // AV errors (always included in error log)
+      AvCaptureInitFailed() => true,
+      AvFrameDecodeError() => true,
+      // Log bridge records at warning or above
+      AppLogRecord(:final severity) => switch (severity) {
+          LogSeverity.warning => true,
+          LogSeverity.severe => true,
+          LogSeverity.info => false,
+        },
+      // LiveKit disconnect is operationally significant
+      LiveKitDisconnected() => true,
+      _ => false,
+    };

--- a/lib/events/sinks/file_sink.dart
+++ b/lib/events/sinks/file_sink.dart
@@ -71,9 +71,10 @@ bool _isAvEvent(AppEvent event) => switch (event) {
     };
 
 bool _isErrorEvent(AppEvent event) => switch (event) {
-      // AV errors (always included in error log)
+      // AV errors (always included in error log, regardless of AV toggle)
       AvCaptureInitFailed() => true,
       AvFrameDecodeError() => true,
+      AvTrackUnsubscribed() => true,
       // Log bridge records at warning or above
       AppLogRecord(:final severity) => switch (severity) {
           LogSeverity.warning => true,

--- a/lib/events/sinks/file_sink.dart
+++ b/lib/events/sinks/file_sink.dart
@@ -74,7 +74,6 @@ bool _isErrorEvent(AppEvent event) => switch (event) {
       // AV errors (always included in error log, regardless of AV toggle)
       AvCaptureInitFailed() => true,
       AvFrameDecodeError() => true,
-      AvTrackUnsubscribed() => true,
       // Log bridge records at warning or above
       AppLogRecord(:final severity) => switch (severity) {
           LogSeverity.warning => true,

--- a/lib/events/sinks/file_sink_stub.dart
+++ b/lib/events/sinks/file_sink_stub.dart
@@ -7,3 +7,17 @@ import 'package:tech_world/events/types.dart';
 Future<void Function(AppEvent)> createFileSink() async {
   return (_) {};
 }
+
+/// Web stub — AV pipeline sink is a no-op on web.
+Future<void Function(AppEvent)> createAvPipelineSink({
+  required bool Function() enabledCheck,
+}) async {
+  return (_) {};
+}
+
+/// Web stub — error sink is a no-op on web.
+Future<void Function(AppEvent)> createErrorSink({
+  required bool Function() enabledCheck,
+}) async {
+  return (_) {};
+}

--- a/lib/events/sinks/rotating_file_sink.dart
+++ b/lib/events/sinks/rotating_file_sink.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:tech_world/events/types.dart';
+
+/// A JSONL file sink with size-based rotation.
+///
+/// Writes events as one JSON object per line. When the file exceeds
+/// [maxBytes], rotates to `.1`, `.2`, … up to [maxRotations] (oldest
+/// deleted). The size check runs every [checkInterval] writes, not on
+/// every write — `stat()` is cheap but not free at event rates.
+///
+/// Used by [createFileSink], [createAvPipelineSink], and
+/// [createErrorSink] — all three share the same rotation mechanics.
+class RotatingFileSink {
+  RotatingFileSink({
+    required this.logFile,
+    this.maxBytes = 5 * 1024 * 1024, // 5 MB
+    this.maxRotations = 3,
+    this.checkInterval = 100,
+    this.filter,
+    this.enabledCheck,
+  });
+
+  final File logFile;
+  final int maxBytes;
+  final int maxRotations;
+  final int checkInterval;
+
+  /// Optional filter — when provided, only events where `filter(event)`
+  /// returns true are written. Null means all events pass.
+  final bool Function(AppEvent event)? filter;
+
+  /// Optional toggle — when provided, the sink no-ops if this returns
+  /// false. Checked on every call so it can be flipped at runtime.
+  final bool Function()? enabledCheck;
+
+  int _writeCount = 0;
+
+  /// The sink function to register with [registerSink].
+  void call(AppEvent event) {
+    if (enabledCheck != null && !enabledCheck!()) return;
+    if (filter != null && !filter!(event)) return;
+
+    _writeCount++;
+    if (_writeCount >= checkInterval) {
+      _writeCount = 0;
+      _rotateIfNeeded();
+    }
+
+    final line = jsonEncode(event.toJson());
+    logFile
+        .writeAsString('$line\n', mode: FileMode.append)
+        .then<void>((_) {}, onError: (Object e) {
+      debugPrint('[sink:${logFile.uri.pathSegments.last}] Write failed: $e');
+    });
+  }
+
+  void _rotateIfNeeded() {
+    try {
+      if (!logFile.existsSync()) return;
+      final size = logFile.lengthSync();
+      if (size < maxBytes) return;
+
+      // Shift existing rotations: .3 deleted, .2→.3, .1→.2, current→.1
+      for (var i = maxRotations; i >= 1; i--) {
+        final older = File('${logFile.path}.$i');
+        if (i == maxRotations) {
+          if (older.existsSync()) older.deleteSync();
+        } else {
+          final dest = File('${logFile.path}.${i + 1}');
+          if (older.existsSync()) older.renameSync(dest.path);
+        }
+      }
+      logFile.renameSync('${logFile.path}.1');
+    } catch (e) {
+      debugPrint('[sink:rotate] Rotation failed: $e');
+    }
+  }
+}

--- a/lib/events/types.dart
+++ b/lib/events/types.dart
@@ -933,6 +933,328 @@ final class DmSent extends AppEvent {
 enum BotSpokeContext { group, help }
 
 // ---------------------------------------------------------------------------
+// AV pipeline diagnostic events
+// ---------------------------------------------------------------------------
+
+/// How a video frame is being captured for a participant's bubble.
+enum AvCaptureMethod {
+  /// macOS FFI shared-memory capture via RTCVideoRenderer.
+  ffi,
+
+  /// Chrome MediaStreamTrackProcessor (fast, no DOM).
+  directTrack,
+
+  /// HTMLVideoElement fallback (all browsers).
+  videoElement,
+
+  /// Three.js iframe canvas capture (Dreamfinder avatar).
+  canvasCapture,
+}
+
+/// The type of proximity bubble rendered for a participant.
+enum AvBubbleType {
+  /// Video feed bubble (VideoBubbleComponent).
+  video,
+
+  /// Avatar-initial placeholder (PlayerBubbleComponent).
+  player,
+
+  /// Bot character bubble (BotBubbleComponent).
+  bot,
+}
+
+/// Periodic per-participant pipeline state snapshot.
+///
+/// Dispatched every ~5 seconds by [BubbleManager] for each remote participant
+/// (and the local player when they have a bubble). This is the single most
+/// important diagnostic event — it tells you exactly where each participant
+/// sits in the AV pipeline at a glance.
+final class AvPipelineSnapshot extends AppEvent {
+  AvPipelineSnapshot({
+    required this.participant,
+    required this.hasVideoTrack,
+    required this.captureMethod,
+    required this.captureRetryCount,
+    required this.framesCaptured,
+    required this.framesDropped,
+    required this.bubbleType,
+    required this.audioEnabled,
+    required this.distance,
+    required this.isLocal,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final bool hasVideoTrack;
+
+  /// Null when capture not yet initialized.
+  final AvCaptureMethod? captureMethod;
+  final int captureRetryCount;
+  final int framesCaptured;
+  final int framesDropped;
+
+  /// Null when no bubble exists for this participant.
+  final AvBubbleType? bubbleType;
+  final bool audioEnabled;
+
+  /// Chebyshev grid distance, or -1 if unknown.
+  final int distance;
+  final bool isLocal;
+
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_pipeline_snapshot',
+        'participant': participant,
+        'hasVideoTrack': hasVideoTrack,
+        if (captureMethod != null) 'captureMethod': captureMethod!.name,
+        'captureRetryCount': captureRetryCount,
+        'framesCaptured': framesCaptured,
+        'framesDropped': framesDropped,
+        if (bubbleType != null) 'bubbleType': bubbleType!.name,
+        'audioEnabled': audioEnabled,
+        'distance': distance,
+        'isLocal': isLocal,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// A video track was subscribed from LiveKit for a participant.
+final class AvTrackSubscribed extends AppEvent {
+  AvTrackSubscribed({required this.participant, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_track_subscribed',
+        'participant': participant,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// A video track was unsubscribed (lost) for a participant.
+final class AvTrackUnsubscribed extends AppEvent {
+  AvTrackUnsubscribed({required this.participant, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_track_unsubscribed',
+        'participant': participant,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// Video frame capture was successfully initialized for a participant.
+final class AvCaptureInitialized extends AppEvent {
+  AvCaptureInitialized({
+    required this.participant,
+    required this.method,
+    required this.retryCount,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final AvCaptureMethod method;
+  final int retryCount;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_capture_initialized',
+        'participant': participant,
+        'method': method.name,
+        'retryCount': retryCount,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// Video frame capture exhausted all retries for a participant.
+final class AvCaptureInitFailed extends AppEvent {
+  AvCaptureInitFailed({
+    required this.participant,
+    required this.maxRetries,
+    this.lastError,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final int maxRetries;
+  final String? lastError;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_capture_init_failed',
+        'participant': participant,
+        'maxRetries': maxRetries,
+        if (lastError != null) 'lastError': lastError,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// A proximity bubble was created for a participant.
+final class AvBubbleCreated extends AppEvent {
+  AvBubbleCreated({
+    required this.participant,
+    required this.bubbleType,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final AvBubbleType bubbleType;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_bubble_created',
+        'participant': participant,
+        'bubbleType': bubbleType.name,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// A proximity bubble was removed for a participant.
+final class AvBubbleRemoved extends AppEvent {
+  AvBubbleRemoved({required this.participant, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_bubble_removed',
+        'participant': participant,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// Audio gating changed for a participant (proximity crossed audio threshold).
+final class AvAudioGateChanged extends AppEvent {
+  AvAudioGateChanged({
+    required this.participant,
+    required this.enabled,
+    required this.distance,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final bool enabled;
+  final int distance;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_audio_gate_changed',
+        'participant': participant,
+        'enabled': enabled,
+        'distance': distance,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+/// A video frame failed to decode.
+final class AvFrameDecodeError extends AppEvent {
+  AvFrameDecodeError({
+    required this.participant,
+    required this.error,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final String error;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_frame_decode_error',
+        'participant': participant,
+        'error': error,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// No PII: participant identity is a LiveKit system identifier here,
+  /// and the error string is a platform exception message.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.none;
+}
+
+/// Speaker detection state changed for a participant.
+final class AvSpeakingChanged extends AppEvent {
+  AvSpeakingChanged({
+    required this.participant,
+    required this.speaking,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String participant;
+  final bool speaking;
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'av_speaking_changed',
+        'participant': participant,
+        'speaking': speaking,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// PII: participant identity.
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
+// ---------------------------------------------------------------------------
 // Log bridge events
 // ---------------------------------------------------------------------------
 

--- a/lib/events/types.dart
+++ b/lib/events/types.dart
@@ -1222,10 +1222,11 @@ final class AvFrameDecodeError extends AppEvent {
         'timestamp': timestamp.toIso8601String(),
       };
 
-  /// No PII: participant identity is a LiveKit system identifier here,
-  /// and the error string is a platform exception message.
+  /// PII: participant identity. Platform exception messages from WebRTC
+  /// can contain SDP fragments or stream IDs. Conservative per CLAUDE.md:
+  /// "when in doubt, mark pii."
   @override
-  PiiPolicy get piiPolicy => PiiPolicy.none;
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
 }
 
 /// Speaker detection state changed for a participant.

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -240,6 +240,7 @@ class BubbleManager {
               dreamfinderComponent!.position + _bubbleOffset;
           _playerBubbles[dreamfinderIdentity] = bubble;
           _addComponent(bubble);
+          _dispatchBubbleCreated(dreamfinderIdentity, bubble);
         }
       }
     }
@@ -260,6 +261,7 @@ class BubbleManager {
           bubble.position = botComp.position + _bubbleOffset;
           _playerBubbles[botId] = bubble;
           _addComponent(bubble);
+          _dispatchBubbleCreated(botId, bubble);
         }
       }
     }
@@ -896,6 +898,32 @@ class BubbleManager {
         bubble: bubble,
         participant: participant,
         distance: distance,
+        isLocal: false,
+      ));
+    }
+
+    // Dreamfinder snapshot.
+    if (dreamfinderComponent != null) {
+      final dfDistance = chebyshevDistance(
+          playerGrid, dreamfinderComponent!.miniGridPosition);
+      events.add(_snapshotForParticipant(
+        playerId: dreamfinderIdentity,
+        bubble: _playerBubbles[dreamfinderIdentity],
+        participant: _liveKitService?.getParticipant(dreamfinderIdentity),
+        distance: dfDistance,
+        isLocal: false,
+      ));
+    }
+
+    // Bot snapshots.
+    for (final entry in _bots.entries) {
+      final botDistance =
+          chebyshevDistance(playerGrid, entry.value.miniGridPosition);
+      events.add(_snapshotForParticipant(
+        playerId: entry.key,
+        bubble: _playerBubbles[entry.key],
+        participant: _liveKitService?.getParticipant(entry.key),
+        distance: botDistance,
         isLocal: false,
       ));
     }

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -19,6 +19,8 @@ import 'package:tech_world/flame/components/merged_video_bubble_component.dart';
 import 'package:tech_world/flame/components/player_bubble_component.dart';
 import 'package:tech_world/flame/components/player_component.dart';
 import 'package:tech_world/flame/components/video_bubble_component.dart';
+import 'package:tech_world/events/dispatch.dart';
+import 'package:tech_world/events/types.dart';
 import 'package:tech_world/livekit/dreamfinder_avatar_bridge.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
@@ -115,6 +117,16 @@ class BubbleManager {
   ui.FragmentProgram? _metaballShaderProgram;
   ui.FragmentProgram? _mergedVideoShaderProgram;
 
+  // ── AV diagnostics ─────────────────────────────────────────────────────────
+
+  /// When true, the 5-second snapshot timer runs and AV state-transition
+  /// events are dispatched. Toggled at runtime from main.dart via
+  /// [setAvDiagnosticsEnabled].
+  bool avDiagnosticsEnabled = false;
+
+  double _snapshotTimer = 0;
+  static const double _snapshotIntervalSeconds = 5.0;
+
   // ── Constants ─────────────────────────────────────────────────────────────
 
   static const _localPlayerBubbleKey = '_local_player_';
@@ -156,6 +168,15 @@ class BubbleManager {
 
   /// Main per-frame entry point. Called from TechWorld.update().
   void update(double dt) {
+    // ── Periodic AV snapshot ──────────────────────────────────────────────
+    if (avDiagnosticsEnabled) {
+      _snapshotTimer += dt;
+      if (_snapshotTimer >= _snapshotIntervalSeconds) {
+        _snapshotTimer = 0;
+        _dispatchPipelineSnapshots();
+      }
+    }
+
     final playerGrid = _localPlayer.miniGridPosition;
 
     // Skip proximity re-evaluation if player hasn't moved to a new grid cell.
@@ -186,6 +207,7 @@ class BubbleManager {
           bubble.position = playerComponent.position + _bubbleOffset;
           _playerBubbles[playerId] = bubble;
           _addComponent(bubble);
+          _dispatchBubbleCreated(playerId, bubble);
         }
 
         _setBubbleOpacity(_playerBubbles[playerId]!, distance);
@@ -265,6 +287,9 @@ class BubbleManager {
     }
     for (final playerId in toRemove) {
       _playerBubbles.remove(playerId);
+      if (avDiagnosticsEnabled) {
+        dispatch([AvBubbleRemoved(participant: playerId)]);
+      }
     }
 
     _updateBubblePositions(dt);
@@ -603,9 +628,23 @@ class BubbleManager {
     if (shouldHaveAudio && !hasAudio) {
       _audioEnabledParticipants.add(playerId);
       _liveKitService?.setParticipantAudioEnabled(playerId, true);
+      if (avDiagnosticsEnabled) {
+        dispatch([AvAudioGateChanged(
+          participant: playerId,
+          enabled: true,
+          distance: distance,
+        )]);
+      }
     } else if (!shouldHaveAudio && hasAudio) {
       _audioEnabledParticipants.remove(playerId);
       _liveKitService?.setParticipantAudioEnabled(playerId, false);
+      if (avDiagnosticsEnabled) {
+        dispatch([AvAudioGateChanged(
+          participant: playerId,
+          enabled: false,
+          distance: distance,
+        )]);
+      }
     }
   }
 
@@ -823,5 +862,99 @@ class BubbleManager {
     return largestGroup.length >= 2
         ? largestGroup.take(maxMergedBubbles).toList()
         : [];
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Private — AV diagnostics
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  void _dispatchBubbleCreated(String playerId, PositionComponent bubble) {
+    if (!avDiagnosticsEnabled) return;
+    final type = switch (bubble) {
+      VideoBubbleComponent() => AvBubbleType.video,
+      PlayerBubbleComponent() => AvBubbleType.player,
+      BotBubbleComponent() => AvBubbleType.bot,
+      _ => AvBubbleType.player,
+    };
+    dispatch([AvBubbleCreated(participant: playerId, bubbleType: type)]);
+  }
+
+  void _dispatchPipelineSnapshots() {
+    final playerGrid = _localPlayer.miniGridPosition;
+    final events = <AppEvent>[];
+
+    for (final entry in _remotePlayers.entries) {
+      final playerId = entry.key;
+      final playerComponent = entry.value;
+      final distance =
+          chebyshevDistance(playerGrid, playerComponent.miniGridPosition);
+      final bubble = _playerBubbles[playerId];
+      final participant = _liveKitService?.getParticipant(playerId);
+
+      events.add(_snapshotForParticipant(
+        playerId: playerId,
+        bubble: bubble,
+        participant: participant,
+        distance: distance,
+        isLocal: false,
+      ));
+    }
+
+    // Local player snapshot (publish state).
+    final localBubble = _playerBubbles[_localPlayerBubbleKey];
+    final localParticipant = _liveKitService?.localParticipant;
+    events.add(_snapshotForParticipant(
+      playerId: _localPlayerBubbleKey,
+      bubble: localBubble,
+      participant: localParticipant,
+      distance: 0,
+      isLocal: true,
+    ));
+
+    if (events.isNotEmpty) dispatch(events);
+  }
+
+  AvPipelineSnapshot _snapshotForParticipant({
+    required String playerId,
+    required PositionComponent? bubble,
+    required Participant? participant,
+    required int distance,
+    required bool isLocal,
+  }) {
+    final hasVideoTrack =
+        participant != null ? _hasVideoTrack(participant) : false;
+
+    AvCaptureMethod? captureMethod;
+    int captureRetryCount = 0;
+    int framesCaptured = 0;
+    int framesDropped = 0;
+
+    if (bubble is VideoBubbleComponent) {
+      captureMethod = bubble.diagnosticCaptureMethod;
+      captureRetryCount = bubble.diagnosticCaptureRetryCount;
+      framesCaptured = bubble.diagnosticFramesCaptured;
+      framesDropped = bubble.diagnosticFramesDropped;
+    }
+
+    final bubbleType = switch (bubble) {
+      VideoBubbleComponent() => AvBubbleType.video,
+      PlayerBubbleComponent() => AvBubbleType.player,
+      BotBubbleComponent() => AvBubbleType.bot,
+      null => null,
+      _ => AvBubbleType.player,
+    };
+
+    return AvPipelineSnapshot(
+      participant: playerId,
+      hasVideoTrack: hasVideoTrack,
+      captureMethod: captureMethod,
+      captureRetryCount: captureRetryCount,
+      framesCaptured: framesCaptured,
+      framesDropped: framesDropped,
+      bubbleType: bubbleType,
+      audioEnabled: _audioEnabledParticipants.contains(playerId),
+      distance: distance,
+      isLocal: isLocal,
+    );
   }
 }

--- a/lib/flame/components/video_bubble_component.dart
+++ b/lib/flame/components/video_bubble_component.dart
@@ -11,7 +11,7 @@ import 'package:flutter_webrtc/flutter_webrtc.dart' as webrtc;
 import 'package:livekit_client/livekit_client.dart';
 
 import '../../events/dispatch.dart';
-import '../../events/types.dart' show AvCaptureMethod, AvCaptureInitialized, AvCaptureInitFailed;
+import '../../events/types.dart' show AvCaptureMethod, AvCaptureInitialized, AvCaptureInitFailed, AvFrameDecodeError;
 import '../../native/frame_source.dart';
 import '../../native/video_frame_capture.dart' as ffi;
 import '../../native/direct_track_capture.dart' as direct_capture;
@@ -548,6 +548,10 @@ class VideoBubbleComponent extends PositionComponent {
       }
     } catch (e) {
       _framesDropped++;
+      dispatch([AvFrameDecodeError(
+        participant: participant.identity,
+        error: e.toString(),
+      )]);
     } finally {
       _nativeFrameInFlight = false;
     }

--- a/lib/flame/components/video_bubble_component.dart
+++ b/lib/flame/components/video_bubble_component.dart
@@ -10,6 +10,8 @@ import 'package:logging/logging.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as webrtc;
 import 'package:livekit_client/livekit_client.dart';
 
+import '../../events/dispatch.dart';
+import '../../events/types.dart' show AvCaptureMethod, AvCaptureInitialized, AvCaptureInitFailed;
 import '../../native/frame_source.dart';
 import '../../native/video_frame_capture.dart' as ffi;
 import '../../native/direct_track_capture.dart' as direct_capture;
@@ -140,6 +142,21 @@ class VideoBubbleComponent extends PositionComponent {
   double _timeSinceLastRetry = 0;
   static const double _retryIntervalSeconds = 0.5; // Retry every 500ms
 
+  // ── Diagnostic getters (read by BubbleManager for AvPipelineSnapshot) ──
+
+  /// Which capture path is active, or null if not yet initialized.
+  AvCaptureMethod? get diagnosticCaptureMethod {
+    if (externalVideoCapture != null) return AvCaptureMethod.canvasCapture;
+    if (_capture != null) return AvCaptureMethod.ffi;
+    if (_webCapture != null) return AvCaptureMethod.directTrack;
+    if (_remoteWebCapture != null) return AvCaptureMethod.videoElement;
+    return null;
+  }
+
+  int get diagnosticCaptureRetryCount => _captureRetryCount;
+  int get diagnosticFramesCaptured => _framesCaptured;
+  int get diagnosticFramesDropped => _framesDropped;
+
   // Opacity for distance-based fading
   double _opacity = 1.0;
 
@@ -214,6 +231,14 @@ class VideoBubbleComponent extends PositionComponent {
       if (_timeSinceLastRetry >= _retryIntervalSeconds) {
         _timeSinceLastRetry = 0;
         _initializeCapture();
+        // Dispatch failure event when retries are exhausted.
+        if (!_captureInitialized &&
+            _captureRetryCount >= _maxCaptureRetries) {
+          dispatch([AvCaptureInitFailed(
+            participant: participant.identity,
+            maxRetries: _maxCaptureRetries,
+          )]);
+        }
       }
     }
 
@@ -301,6 +326,11 @@ class VideoBubbleComponent extends PositionComponent {
     capture.startCapture();
     _captureInitialized = true;
     _captureInitializing = false;
+    dispatch([AvCaptureInitialized(
+      participant: participant.identity,
+      method: AvCaptureMethod.directTrack,
+      retryCount: _captureRetryCount,
+    )]);
   }
 
   /// Initialize capture for remote tracks using VideoElementCapture.
@@ -331,6 +361,11 @@ class VideoBubbleComponent extends PositionComponent {
         capture.startCapture();
         _captureInitialized = true;
         _captureInitializing = false;
+        dispatch([AvCaptureInitialized(
+          participant: participant.identity,
+          method: AvCaptureMethod.videoElement,
+          retryCount: _captureRetryCount,
+        )]);
         return;
       }
 
@@ -368,6 +403,11 @@ class VideoBubbleComponent extends PositionComponent {
 
     if (_capture != null) {
       _captureInitialized = true;
+      dispatch([AvCaptureInitialized(
+        participant: participant.identity,
+        method: AvCaptureMethod.ffi,
+        retryCount: _captureRetryCount,
+      )]);
     }
   }
 

--- a/lib/flame/livekit_game_bridge.dart
+++ b/lib/flame/livekit_game_bridge.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:logging/logging.dart';
 import 'package:tech_world/avatar/avatar.dart';
+import 'package:tech_world/events/dispatch.dart';
+import 'package:tech_world/events/types.dart';
 import 'package:tech_world/flame/bubble_manager.dart';
 import 'package:tech_world/flame/shared/player_path.dart';
 import 'package:tech_world/infra/infra_health_service.dart';
@@ -156,6 +158,10 @@ class LiveKitGameBridge {
     _speakingSub = _liveKitService.speakingChanged.listen((event) {
       final (participant, isSpeaking) = event;
       _bubbleManager.updateSpeakingState(participant.identity, isSpeaking);
+      dispatch([AvSpeakingChanged(
+        participant: participant.identity,
+        speaking: isSpeaking,
+      )]);
     });
 
     _trackSubscribedSub = _liveKitService.trackSubscribed.listen((event) {
@@ -163,6 +169,7 @@ class LiveKitGameBridge {
       if (track.kind == TrackType.VIDEO) {
         _log.fine('Video track subscribed for ${participant.identity}');
         _bubbleManager.refreshBubbleForPlayer(participant.identity);
+        dispatch([AvTrackSubscribed(participant: participant.identity)]);
       }
       _bubbleManager.notifyTrackReady(participant.identity);
     });
@@ -173,6 +180,7 @@ class LiveKitGameBridge {
       if (track.kind == TrackType.VIDEO) {
         _log.info('Video track unsubscribed for ${participant.identity}');
         _bubbleManager.downgradeVideoBubble(participant.identity);
+        dispatch([AvTrackUnsubscribed(participant: participant.identity)]);
       }
     });
 

--- a/lib/flame/livekit_game_bridge.dart
+++ b/lib/flame/livekit_game_bridge.dart
@@ -158,10 +158,12 @@ class LiveKitGameBridge {
     _speakingSub = _liveKitService.speakingChanged.listen((event) {
       final (participant, isSpeaking) = event;
       _bubbleManager.updateSpeakingState(participant.identity, isSpeaking);
-      dispatch([AvSpeakingChanged(
-        participant: participant.identity,
-        speaking: isSpeaking,
-      )]);
+      if (_bubbleManager.avDiagnosticsEnabled) {
+        dispatch([AvSpeakingChanged(
+          participant: participant.identity,
+          speaking: isSpeaking,
+        )]);
+      }
     });
 
     _trackSubscribedSub = _liveKitService.trackSubscribed.listen((event) {
@@ -169,7 +171,9 @@ class LiveKitGameBridge {
       if (track.kind == TrackType.VIDEO) {
         _log.fine('Video track subscribed for ${participant.identity}');
         _bubbleManager.refreshBubbleForPlayer(participant.identity);
-        dispatch([AvTrackSubscribed(participant: participant.identity)]);
+        if (_bubbleManager.avDiagnosticsEnabled) {
+          dispatch([AvTrackSubscribed(participant: participant.identity)]);
+        }
       }
       _bubbleManager.notifyTrackReady(participant.identity);
     });
@@ -180,7 +184,9 @@ class LiveKitGameBridge {
       if (track.kind == TrackType.VIDEO) {
         _log.info('Video track unsubscribed for ${participant.identity}');
         _bubbleManager.downgradeVideoBubble(participant.identity);
-        dispatch([AvTrackUnsubscribed(participant: participant.identity)]);
+        if (_bubbleManager.avDiagnosticsEnabled) {
+          dispatch([AvTrackUnsubscribed(participant: participant.identity)]);
+        }
       }
     });
 

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -380,6 +380,13 @@ class TechWorld extends World with TapCallbacks {
     _bubbleManager.reduceMotion = value;
   }
 
+  /// Toggle AV pipeline diagnostics (periodic snapshots, bubble lifecycle,
+  /// audio gate events). The sink-side toggle in main.dart controls file
+  /// writes; this controls event generation inside BubbleManager.
+  void setAvDiagnosticsEnabled(bool value) {
+    _bubbleManager.avDiagnosticsEnabled = value;
+  }
+
   /// Set the local player's avatar. Also broadcasts to other participants.
   void setLocalAvatar(Avatar avatar) {
     _localAvatar = avatar;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,13 +97,41 @@ void main() async {
   });
 }
 
+/// In-memory toggle states read synchronously by sinks. Loaded once at
+/// startup from [UserPreferences]; updated when the user flips a toggle.
+bool _avDiagnosticsEnabled = false;
+bool _errorLoggingEnabled = true;
+
+/// Whether AV diagnostics are currently enabled. Read by [BubbleManager]
+/// to start/stop the periodic snapshot timer.
+bool get avDiagnosticsEnabled => _avDiagnosticsEnabled;
+
+/// Toggle AV diagnostics at runtime. Persists to [UserPreferences] and
+/// updates the in-memory flag that sinks check synchronously.
+Future<void> setAvDiagnosticsEnabled(bool value) async {
+  _avDiagnosticsEnabled = value;
+  await UserPreferences.setAvDiagnosticsEnabled(value);
+}
+
+/// Toggle error logging at runtime.
+Future<void> setErrorLoggingEnabled(bool value) async {
+  _errorLoggingEnabled = value;
+  await UserPreferences.setErrorLoggingEnabled(value);
+}
+
 /// Register event sinks before the app starts. Console sink runs in
-/// debug mode only; file sink runs on native platforms (not web).
+/// debug mode only; file sink and diagnostic sinks run on native
+/// platforms (not web).
 ///
 /// Guarded against duplicate registration on hot restart — sinks are
 /// global mutable state that persists across restarts.
 Future<void> _registerEventSinks() async {
   if (sinksRegistered) return;
+
+  // Load toggle states from persisted preferences.
+  _avDiagnosticsEnabled = await UserPreferences.avDiagnosticsEnabled();
+  _errorLoggingEnabled = await UserPreferences.errorLoggingEnabled();
+
   if (kDebugMode) {
     registerSink(consoleSink);
   }
@@ -111,6 +139,16 @@ Future<void> _registerEventSinks() async {
     try {
       final fileSink = await createFileSink();
       registerSink(fileSink);
+
+      final avSink = await createAvPipelineSink(
+        enabledCheck: () => _avDiagnosticsEnabled,
+      );
+      registerSink(avSink);
+
+      final errSink = await createErrorSink(
+        enabledCheck: () => _errorLoggingEnabled,
+      );
+      registerSink(errSink);
     } catch (e) {
       // path_provider failure — continue without file logging.
       debugPrint('[events] File sink registration failed: $e');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -106,10 +106,13 @@ bool _errorLoggingEnabled = true;
 /// to start/stop the periodic snapshot timer.
 bool get avDiagnosticsEnabled => _avDiagnosticsEnabled;
 
-/// Toggle AV diagnostics at runtime. Persists to [UserPreferences] and
-/// updates the in-memory flag that sinks check synchronously.
+/// Toggle AV diagnostics at runtime. Persists to [UserPreferences],
+/// updates the in-memory flag that sinks check synchronously, and
+/// propagates to [BubbleManager] via [TechWorld] so the snapshot
+/// timer and BubbleManager-side event guards respond immediately.
 Future<void> setAvDiagnosticsEnabled(bool value) async {
   _avDiagnosticsEnabled = value;
+  Locator.maybeLocate<TechWorld>()?.setAvDiagnosticsEnabled(value);
   await UserPreferences.setAvDiagnosticsEnabled(value);
 }
 
@@ -475,6 +478,7 @@ class _MyAppState extends State<MyApp> {
             techWorld.setHideVideoBubbles(
                 await UserPreferences.hideVideoBubbles());
             techWorld.setReduceMotion(await UserPreferences.reduceMotion());
+            techWorld.setAvDiagnosticsEnabled(_avDiagnosticsEnabled);
             await techWorld.connectToLiveKit(userId, _currentDisplayName);
 
             // Wire C: camera + mic (depends on server connection).
@@ -730,6 +734,7 @@ class _MyAppState extends State<MyApp> {
           tw.setBotStatus(_session!.chatService.botStatus);
           tw.setHideVideoBubbles(await UserPreferences.hideVideoBubbles());
           tw.setReduceMotion(await UserPreferences.reduceMotion());
+          tw.setAvDiagnosticsEnabled(_avDiagnosticsEnabled);
           await tw.connectToLiveKit(userId, _currentDisplayName);
           await _session!.enableMedia();
           await _session!.chatService.loadHistory(room.id);

--- a/lib/preferences/user_preferences.dart
+++ b/lib/preferences/user_preferences.dart
@@ -87,4 +87,36 @@ abstract final class UserPreferences {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(proximityRadiusKey, clamped);
   }
+
+  // ── AV diagnostics ─────────────────────────────────────────────────────
+
+  /// Whether to write AV pipeline diagnostic events (periodic snapshots,
+  /// track lifecycle, capture init, bubble create/remove) to
+  /// `av-pipeline.jsonl`. Default off — toggle on when debugging
+  /// intermittent video/audio issues.
+  static const String avDiagnosticsEnabledKey = 'avDiagnosticsEnabled';
+
+  static Future<bool> avDiagnosticsEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(avDiagnosticsEnabledKey) ?? false;
+  }
+
+  static Future<void> setAvDiagnosticsEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(avDiagnosticsEnabledKey, value);
+  }
+
+  /// Whether to write error-level events (warning+) to `errors.jsonl`.
+  /// Default on — low volume, high signal, rarely a reason to disable.
+  static const String errorLoggingEnabledKey = 'errorLoggingEnabled';
+
+  static Future<bool> errorLoggingEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(errorLoggingEnabledKey) ?? true;
+  }
+
+  static Future<void> setErrorLoggingEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(errorLoggingEnabledKey, value);
+  }
 }

--- a/robin-docs/VIDEO_LOGGING.md
+++ b/robin-docs/VIDEO_LOGGING.md
@@ -1,0 +1,222 @@
+# Video & Audio Diagnostic Logging
+
+## 1. What is being logged
+
+Ten event types capture the full lifecycle of the audio-visual bubble pipeline:
+
+### Periodic snapshot (the most important one)
+
+**`AvPipelineSnapshot`** — emitted every 5 seconds for every participant (including yourself). One line per person tells you exactly where they sit in the pipeline:
+
+```json
+{"type":"av_pipeline_snapshot","participant":"alice","hasVideoTrack":true,"captureMethod":"directTrack","captureRetryCount":1,"framesCaptured":147,"framesDropped":2,"bubbleType":"video","audioEnabled":true,"distance":2,"isLocal":false,"timestamp":"2026-05-16T14:23:45.123"}
+```
+
+Fields:
+- `participant` — LiveKit identity string
+- `hasVideoTrack` — did LiveKit deliver a video track?
+- `captureMethod` — which capture path is active: `ffi` (macOS), `directTrack` (Chrome MediaStreamTrackProcessor), `videoElement` (fallback HTMLVideoElement), `canvasCapture` (Dreamfinder iframe), or null if not yet initialized
+- `captureRetryCount` — how many init attempts so far (max 10)
+- `framesCaptured` / `framesDropped` — lifetime frame counters
+- `bubbleType` — `video`, `player` (avatar initial), `bot`, or null (no bubble)
+- `audioEnabled` — is this participant's audio track subscribed?
+- `distance` — Chebyshev grid distance from you
+- `isLocal` — true for your own publish state
+
+### State transition events
+
+| Event | When | Key fields |
+|-------|------|-----------|
+| `AvTrackSubscribed` | LiveKit delivers a video track | `participant` |
+| `AvTrackUnsubscribed` | LiveKit drops a video track | `participant` |
+| `AvCaptureInitialized` | Frame capture starts working | `participant`, `method`, `retryCount` |
+| `AvCaptureInitFailed` | 10 retries exhausted, gave up | `participant`, `maxRetries`, `lastError` |
+| `AvBubbleCreated` | Proximity bubble appears | `participant`, `bubbleType` |
+| `AvBubbleRemoved` | Proximity bubble disappears | `participant` |
+| `AvAudioGateChanged` | Audio enabled/disabled by proximity | `participant`, `enabled`, `distance` |
+| `AvFrameDecodeError` | A video frame failed to decode | `participant`, `error` |
+| `AvSpeakingChanged` | Speaker detection fires | `participant`, `speaking` |
+
+## 2. Why it is being logged
+
+The AV bubble pipeline has ~7 stages per participant, and a silent failure at any stage produces the same symptom: "I can't see/hear them." Without diagnostics, you cannot distinguish between:
+
+- LiveKit never delivered the track (server/network issue)
+- The track arrived but capture init failed after 10 retries (platform issue)
+- Capture succeeded but frames are never produced (codec issue)
+- Frames are produced but proximity distance is wrong (position desync)
+- Proximity is correct but audio gating silently failed
+- A bubble was created but it's the wrong type (PlayerBubble instead of VideoBubble)
+
+The periodic snapshot solves this by showing the **full pipeline state** for every participant at a glance. When two people compare their snapshots, the asymmetry becomes immediately visible.
+
+## 3. Where it is being logged
+
+Three JSONL files on native platforms (macOS, iOS, Android). All in the app's documents directory:
+
+```
+~/Documents/tech_world_logs/
+  events.log           ← all events (existing, now with rotation)
+  av-pipeline.jsonl    ← AV diagnostic events only (new)
+  errors.jsonl         ← warning+ severity from all systems (new)
+```
+
+**Not available on web** — the web platform has no filesystem access. On web, AV events still flow through the console sink in debug mode (`debugPrint`).
+
+**AV errors appear in both files** — `av-pipeline.jsonl` and `errors.jsonl`. This is intentional. When debugging video issues, read `av-pipeline.jsonl` for the full timeline. When something's broken and you don't know what, scan `errors.jsonl` first.
+
+## 4. How to read the logs
+
+### Find the files
+
+On macOS, the documents directory is typically:
+```
+~/Library/Containers/cc.imagineering.techWorld/Data/Documents/tech_world_logs/
+```
+
+Or, if running from Xcode/flutter in debug mode:
+```
+~/Documents/tech_world_logs/
+```
+
+### Read with standard tools
+
+Each file is JSONL (one JSON object per line). Use `jq`, `grep`, or any text editor:
+
+```bash
+# Pretty-print the last 10 AV snapshots
+tail -10 av-pipeline.jsonl | jq .
+
+# Find all capture failures
+grep 'av_capture_init_failed' av-pipeline.jsonl | jq .
+
+# See all events for a specific participant
+grep '"alice"' av-pipeline.jsonl | jq .
+
+# Count frames captured per participant in the latest snapshots
+grep 'av_pipeline_snapshot' av-pipeline.jsonl | tail -20 | jq '{participant, framesCaptured, captureMethod}'
+
+# See all errors in the last hour
+cat errors.jsonl | jq 'select(.timestamp > "2026-05-16T13:00:00")'
+```
+
+### Compare two clients
+
+When the bug is asymmetric (works for Nick, not for Robin), have both clients enable AV diagnostics and then compare snapshots for the same participant at the same timestamp:
+
+```bash
+# Robin's view of alice
+grep '"alice"' robin-av-pipeline.jsonl | grep 'av_pipeline_snapshot' | tail -1 | jq .
+# → hasVideoTrack: false, captureMethod: null, bubbleType: "player"
+
+# Nick's view of alice
+grep '"alice"' nick-av-pipeline.jsonl | grep 'av_pipeline_snapshot' | tail -1 | jq .
+# → hasVideoTrack: true, captureMethod: "directTrack", framesCaptured: 892, bubbleType: "video"
+```
+
+The diff tells you exactly where Robin's pipeline stalled.
+
+## 5. What to look for when video or audio is not working
+
+### "I can't see someone"
+
+Read their latest `AvPipelineSnapshot` and check each field in order:
+
+| Field | Bad value | Diagnosis |
+|-------|-----------|-----------|
+| `hasVideoTrack` | `false` | LiveKit never delivered the track. Check their camera permissions, network, or LiveKit server logs. |
+| `captureMethod` | `null` | Track arrived but capture never initialized. Check `captureRetryCount` — if 10, look for `AvCaptureInitFailed` events. |
+| `framesCaptured` | `0` | Capture initialized but no frames produced. Platform bug — the capture path is running but the video source isn't producing frames (muted remote track, codec mismatch). |
+| `framesDropped` | High | Frames are arriving but being discarded (frame rate capping or decode failures). Check for `AvFrameDecodeError` events. |
+| `bubbleType` | `"player"` | Bubble exists but it's the avatar-initial fallback, not video. Either `hideVideoBubbles` is on, or the track wasn't available when the bubble was created. Wait for `AvTrackSubscribed` → the bubble should auto-upgrade. |
+| `bubbleType` | `null` | No bubble at all. Check `distance` — if > 5, you're too far. If ≤ 5, there's a bug in BubbleManager proximity logic. |
+
+### "I can't hear someone"
+
+| Field | Bad value | Diagnosis |
+|-------|-----------|-----------|
+| `audioEnabled` | `false` | You're more than 2 grid squares apart. Walk closer. |
+| `audioEnabled` | `true` but no sound | Audio track is subscribed but the participant may be muted, or their mic permissions are denied. Check LiveKit server-side participant state. |
+| `distance` | `-1` or unexpectedly large | Position desync — their position data isn't arriving. Check for `AvTrackSubscribed` (video works = data channel works) and look at heartbeat logs. |
+
+### "It works for Nick but not for me"
+
+Compare snapshots (see section 4). Common causes:
+- **Different browsers**: Chrome has `MediaStreamTrackProcessor`, Safari doesn't. Check `captureMethod` — if Nick gets `directTrack` and you get `videoElement`, the fallback path may have a bug.
+- **Different platforms**: macOS uses FFI (`ffi`), web uses JS interop. Completely different code paths.
+- **Race condition**: One client subscribed to tracks before the other published. Check `AvTrackSubscribed` timestamps — if they never appear, the track was published before the subscription was set up.
+
+### "It works sometimes but not always"
+
+Enable AV diagnostics and leave them running. After the next failure, check:
+1. `errors.jsonl` — any `AvCaptureInitFailed` or `AvFrameDecodeError`?
+2. `av-pipeline.jsonl` — find the transition from working to broken. Look for `AvTrackUnsubscribed` followed by no `AvTrackSubscribed` (track lost, never recovered).
+3. Check `captureRetryCount` in snapshots — if it's climbing toward 10, capture is struggling to initialize.
+
+## 6. How to toggle the logs on and off
+
+### Currently: code-level toggle
+
+AV diagnostics are **off by default** (low overhead, no disk writes). To enable:
+
+```dart
+// In main.dart (or from any code with access):
+import 'package:tech_world/main.dart' show setAvDiagnosticsEnabled;
+
+await setAvDiagnosticsEnabled(true);   // starts writing av-pipeline.jsonl
+await setAvDiagnosticsEnabled(false);  // stops immediately
+```
+
+Error logging is **on by default** (low volume, high signal):
+
+```dart
+await setErrorLoggingEnabled(false);   // stops writing errors.jsonl
+```
+
+The toggles are persisted in `SharedPreferences` and survive app restarts. The sinks check the toggle synchronously on every event, so flipping mid-session takes effect immediately — no restart needed.
+
+### SharedPreferences keys
+
+If you need to toggle from outside the app (e.g., via a debug tool):
+
+| Key | Type | Default | Effect |
+|-----|------|---------|--------|
+| `avDiagnosticsEnabled` | `bool` | `false` | Controls AV pipeline sink + 5-second snapshot timer |
+| `errorLoggingEnabled` | `bool` | `true` | Controls error sink |
+
+### Future: UI toggle
+
+A settings UI toggle is not yet built. When added, it should call `setAvDiagnosticsEnabled(bool)` from `main.dart`, which updates both the in-memory flag (instant effect) and SharedPreferences (survives restart).
+
+## 7. When the logs will be deleted
+
+### Automatic rotation
+
+All three log files use **size-based rotation**:
+
+- **Maximum file size**: 5 MB per file
+- **Rotation count**: 3 (keeps `.1`, `.2`, `.3` suffixes)
+- **Check frequency**: every 100 writes (not every write)
+
+When a file exceeds 5 MB:
+```
+av-pipeline.jsonl.3  ← deleted
+av-pipeline.jsonl.2  ← was .1
+av-pipeline.jsonl.1  ← was current
+av-pipeline.jsonl    ← new empty file
+```
+
+**Maximum disk usage**: 5 MB x 4 files x 3 sinks = 60 MB worst case. In practice, much less — `errors.jsonl` is tiny (low volume), and `av-pipeline.jsonl` only writes when diagnostics are enabled.
+
+### Manual cleanup
+
+Delete the files at any time — the sinks will recreate them on next write:
+
+```bash
+rm ~/Documents/tech_world_logs/av-pipeline.jsonl*
+rm ~/Documents/tech_world_logs/errors.jsonl*
+```
+
+### App uninstall
+
+On macOS sandboxed builds, the entire `tech_world_logs/` directory lives inside the app container and is removed when the app is uninstalled. On debug builds (unsandboxed), the logs persist in `~/Documents/tech_world_logs/` until manually deleted.

--- a/robin-docs/audio-visual-bubbles.md
+++ b/robin-docs/audio-visual-bubbles.md
@@ -1,0 +1,303 @@
+# Audio-Visual Bubble System
+
+When two players walk near each other, video/audio bubbles appear above their heads.
+This document maps every component involved.
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                              TechWorld (Flame World)                            │
+│                                                                                 │
+│  update(dt) ──► BubbleManager.update(dt)  ◄── called every frame               │
+│                                                                                 │
+│  connectToLiveKit() ──► creates LiveKitGameBridge (14 stream subscriptions)     │
+│                                                                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Full Pipeline
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  1. SESSION SETUP                                                            │
+│                                                                              │
+│  RoomSession.create()                                                        │
+│    ├── LiveKitService    (WebRTC room, streams, data channels)               │
+│    ├── ProximityService  (event dispatch only — NOT used for bubbles)        │
+│    └── ChatService                                                           │
+│                                                                              │
+│  RoomSession.connect()                                                       │
+│    └── LiveKitService.connect()                                              │
+│          └── Firebase httpsCallable('retrieveLiveKitToken')                  │
+│                └── Room(adaptiveStream: false)  ◄── CRITICAL: Flame needs    │
+│                                                     raw frames, not widget   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  2. LIVEKIT ──► FLAME BRIDGE                                                 │
+│                                                                              │
+│  LiveKitGameBridge (plain Dart, no Flame dependency)                         │
+│  Translates LiveKit events into game-world mutations via callbacks:          │
+│                                                                              │
+│  LiveKitService stream            Callback target                            │
+│  ─────────────────────────        ───────────────────────────────────        │
+│  speakingChanged ──────────────► BubbleManager.updateSpeakingState()         │
+│  trackSubscribed (VIDEO) ──────► BubbleManager.refreshBubbleForPlayer()      │
+│  trackUnsubscribed (VIDEO) ────► BubbleManager.downgradeVideoBubble()        │
+│  localTrackPublished (VIDEO) ──► BubbleManager.refreshLocalPlayerBubble()    │
+│  participantJoined ────────────► TechWorld._handleParticipantJoined()        │
+│  participantLeft ──────────────► TechWorld._handleParticipantLeft()           │
+│  positionReceived ─────────────► TechWorld._handlePositionReceived()         │
+│  heartbeatReceived ────────────► corrects stale positions                    │
+│  connectionLost ───────────────► TechWorld.disconnectFromLiveKit()           │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  3. PROXIMITY DETECTION (inside BubbleManager.update)                        │
+│                                                                              │
+│  Uses Chebyshev distance: max(|dx|, |dy|) in grid squares                   │
+│                                                                              │
+│       ┌──────────────────────────────────────────────┐                       │
+│       │                                              │                       │
+│       │          5 squares ─── VISUAL THRESHOLD      │                       │
+│       │       ┌──────────────────────────┐           │                       │
+│       │       │                          │           │                       │
+│       │       │    2 squares ─── AUDIO   │           │                       │
+│       │       │   ┌──────────────┐       │           │                       │
+│       │       │   │              │       │           │                       │
+│       │       │   │   Player A   │       │           │                       │
+│       │       │   │              │       │           │                       │
+│       │       │   └──────────────┘       │           │                       │
+│       │       │   audio enabled          │           │                       │
+│       │       │   full opacity           │           │                       │
+│       │       └──────────────────────────┘           │                       │
+│       │       bubbles visible, fading with distance  │                       │
+│       │                                              │                       │
+│       └──────────────────────────────────────────────┘                       │
+│       no bubbles, no audio                                                   │
+│                                                                              │
+│  NOTE: This is separate from ProximityService (threshold=3, events only).    │
+│  BubbleManager does its own inline Chebyshev check each frame.              │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  4. BUBBLE CREATION                                                          │
+│                                                                              │
+│  BubbleManager._createBubbleForPlayer(identity)                              │
+│                                                                              │
+│           ┌─────────────────────────┐                                        │
+│           │  Has video track?       │                                        │
+│           │  hideVideoBubbles=false? │                                        │
+│           └────────┬────────────────┘                                        │
+│              yes ╱    ╲ no                                                    │
+│                ╱        ╲                                                     │
+│    ┌──────────▼──┐   ┌───▼──────────────┐                                    │
+│    │ VideoBubble │   │ PlayerBubble      │                                    │
+│    │ Component   │   │ Component         │                                    │
+│    │             │   │ (initial letter,  │                                    │
+│    │ - shader    │   │  dark circle)     │                                    │
+│    │ - capture   │   └──────────────────-┘                                    │
+│    │ - glow      │                                                            │
+│    │ - ripple    │   ┌───────────────────┐                                    │
+│    └─────────────┘   │ BotBubble         │  (for bot characters)             │
+│                      │ Component         │                                    │
+│                      └───────────────────┘                                    │
+│                                                                              │
+│  Special case: Dreamfinder gets VideoBubbleComponent with gold glow +        │
+│  externalVideoCapture (CanvasCapture from Three.js iframe, not WebRTC).      │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  5. VIDEO FRAME CAPTURE (platform-specific)                                  │
+│                                                                              │
+│  Three parallel paths, all producing ui.Image at ~15fps:                     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐         │
+│  │ macOS (FFI)                                                     │         │
+│  │                                                                 │         │
+│  │ VideoFrameCapture ──► native ObjC RTCVideoRenderer              │         │
+│  │   ├── shared memory buffer (40-byte header + pixels)            │         │
+│  │   ├── getPixels() → zero-copy asTypedList                      │         │
+│  │   ├── BGRA → RGBA conversion                                   │         │
+│  │   └── ImageDescriptor.raw → codec → ui.Image                   │         │
+│  └─────────────────────────────────────────────────────────────────┘         │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐         │
+│  │ Web — Chrome (MediaStreamTrackProcessor)                        │         │
+│  │                                                                 │         │
+│  │ DirectTrackCapture                                              │         │
+│  │   ├── jsTrack → MediaStreamTrackProcessor → readable stream     │         │
+│  │   ├── reader.read() → VideoFrame                                │         │
+│  │   ├── draw to offscreen canvas → getImageData                   │         │
+│  │   └── decodeImageFromPixels → ui.Image                          │         │
+│  │                                                                 │         │
+│  │   ⚠ Never createImageFromImageBitmap (Skia #14637 = black)     │         │
+│  └─────────────────────────────────────────────────────────────────┘         │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐         │
+│  │ Web — Fallback (HTMLVideoElement)                               │         │
+│  │                                                                 │         │
+│  │ VideoElementCapture                                             │         │
+│  │   ├── hidden <video> at top:-9999px (NOT display:none)          │         │
+│  │   │   └── mobile browsers won't decode hidden elements          │         │
+│  │   ├── createImageBitmap(video) → draw to canvas → getImageData  │         │
+│  │   └── decodeImageFromPixels → ui.Image                          │         │
+│  └─────────────────────────────────────────────────────────────────┘         │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐         │
+│  │ Dreamfinder only (Three.js iframe)                              │         │
+│  │                                                                 │         │
+│  │ DreamfinderAvatarBridge                                         │         │
+│  │   ├── hidden iframe → /avatar (Three.js TalkingHead, 42MB GLB) │         │
+│  │   ├── postMessage 'renderer-ready' (up to 120s)                 │         │
+│  │   ├── CanvasCapture.create(iframe canvas, fps: 15)              │         │
+│  │   │                                                             │         │
+│  │   │  Data channel → iframe:                                     │         │
+│  │   │  dreamfinder-audio (PCM16→base64) → __onAudioChunk()       │         │
+│  │   │  dreamfinder-mood (JSON)           → __setMood()            │         │
+│  │   │                                                             │         │
+│  │   └── CanvasCapture exposes FrameSource → VideoBubbleComponent  │         │
+│  └─────────────────────────────────────────────────────────────────┘         │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  6. BUBBLE RENDERING                                                         │
+│                                                                              │
+│  VideoBubbleComponent.render(Canvas)                                         │
+│                                                                              │
+│         ┌─────────────────────────────────────┐                              │
+│         │           ╭─────────╮               │                              │
+│         │         ╱~ ~ ~ ~ ~ ~ ╲  ◄── radial glow (pulses when speaking)    │
+│         │        │  ┌────────┐  │                                            │
+│         │        │  │ video  │  │ ◄── circle-clipped drawImageRect           │
+│         │        │  │ frame  │  │                                            │
+│         │        │  └────────┘  │                                            │
+│         │         ╲  ╰─╮╭─╯   ╱  ◄── voice ripple (sinusoidal lobes)       │
+│         │           ╰──╯╰───╯     ◄── proportional to audioLevel            │
+│         │         ─── border ───  ◄── thin ring (glowColor or white)        │
+│         └─────────────────────────────────────┘                              │
+│                                                                              │
+│  Animation layers:                                                           │
+│    1. Breathing scale: 1.0 ± 2.5% × sin(t × 2.0)                           │
+│    2. Opacity layer (fades with proximity distance)                          │
+│    3. Shadow / glow halo                                                     │
+│    4. Glow pulse: radius + 8 × intensity × (1 + 0.15 × sin(t × 2.5))      │
+│    5. Video frame (circle-clipped)  — or dark bg + initial if no frame      │
+│    6. Voice ripple path (when audioLevel > 0.01)                             │
+│    7. Border ring                                                            │
+│    All animation skipped when reduceMotion = true.                           │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  7. BUBBLE PHYSICS & MERGING                                                 │
+│                                                                              │
+│  BubbleManager._updateBubblePositions(dt):                                   │
+│                                                                              │
+│  ┌─── Anchoring ──────────────────────────────────────────────────┐          │
+│  │  Each bubble anchored to character world pos + offset(16, -20) │          │
+│  └────────────────────────────────────────────────────────────────┘          │
+│                                                                              │
+│  ┌─── Repulsion (O(n²) pairwise) ────────────────────────────────┐          │
+│  │                                                                │          │
+│  │   ○ ◄──── 64px ────► ○     collision diameter                 │          │
+│  │    ╲                ╱                                          │          │
+│  │     ╲   overlap    ╱       force = overlap × 31.25            │          │
+│  │      ╲            ╱        damping = 0.85× per frame          │          │
+│  │       ╲──────────╱         max displacement = 24px (tether)   │          │
+│  │                            dt clamped to 50ms (stability)     │          │
+│  └────────────────────────────────────────────────────────────────┘          │
+│                                                                              │
+│  ┌─── Metaball Field (≥2 bubbles) ────────────────────────────────┐         │
+│  │                                                                 │         │
+│  │  BubbleFieldComponent (GLSL shader quad, BlendMode.plus)        │         │
+│  │  Uniforms: time, count, colour, radius, up to 8 positions      │         │
+│  │  Renders additive energy field below all bubbles                │         │
+│  └─────────────────────────────────────────────────────────────────┘         │
+│                                                                              │
+│  ┌─── Merge (≥2 video bubbles < 96px apart) ─────────────────────┐          │
+│  │                                                                │          │
+│  │  BFS finds connected groups → largest group (max 4)            │          │
+│  │                                                                │          │
+│  │  MergedVideoBubbleComponent (GLSL shader quad)                 │          │
+│  │    ├── up to 4 image samplers (reads currentFrame from each)   │          │
+│  │    ├── Voronoi metaball boundary between videos                │          │
+│  │    └── source bubbles: hiddenForMerge=true                     │          │
+│  │         (keep capturing frames, skip individual render)        │          │
+│  └────────────────────────────────────────────────────────────────┘          │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  8. SPEAKER DETECTION (two independent signal paths)                         │
+│                                                                              │
+│  Path A — Binary speaking state (event-driven):                              │
+│                                                                              │
+│    LiveKit ActiveSpeakersChangedEvent                                        │
+│      └── LiveKitService diffs _previousSpeakerIds vs new set                │
+│            └── emits (participant, true/false) on speakingChanged            │
+│                  └── LiveKitGameBridge                                       │
+│                        └── BubbleManager.updateSpeakingState()              │
+│                              └── VideoBubbleComponent.speakingLevel = 1│0   │
+│                                                                              │
+│  Path B — Continuous audio level (polled per frame):                         │
+│                                                                              │
+│    VideoBubbleComponent.update(dt)                                           │
+│      └── reads participant.audioLevel (0.0–1.0)                             │
+│            └── lerps into _smoothedAudioLevel                               │
+│                  └── drives voice ripple amplitude in render()              │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+
+## File Index
+
+| File | Role |
+|------|------|
+| `lib/rooms/room_session.dart` | Session factory — creates LiveKitService, connects |
+| `lib/livekit/livekit_service.dart` | WebRTC room wrapper, typed event streams |
+| `lib/flame/livekit_game_bridge.dart` | 14 subscriptions translating LiveKit → game world |
+| `lib/flame/bubble_manager.dart` | Core orchestrator — proximity, lifecycle, physics, merging |
+| `lib/flame/tech_world.dart` | Flame World, calls BubbleManager.update(dt) each frame |
+| `lib/flame/components/video_bubble_component.dart` | Per-player video bubble rendering + frame capture |
+| `lib/flame/components/player_bubble_component.dart` | Fallback bubble (no video, shows initial) |
+| `lib/flame/components/bot_bubble_component.dart` | Bot character bubbles |
+| `lib/flame/components/bubble_field_component.dart` | Metaball energy field (GLSL shader) |
+| `lib/flame/components/merged_video_bubble_component.dart` | Merged multi-video shader (up to 4) |
+| `lib/native/video_frame_ffi.dart` | macOS FFI capture (shared memory, BGRA→RGBA) |
+| `lib/native/video_frame_web_v2.dart` | Web capture (DirectTrackCapture + VideoElementCapture) |
+| `lib/native/canvas_capture_web.dart` | Dreamfinder Three.js canvas capture |
+| `lib/livekit/dreamfinder_avatar_bridge_web.dart` | Dreamfinder iframe + audio/mood forwarding |
+| `lib/proximity/proximity_service.dart` | Event-only proximity (separate from bubble system) |
+| `lib/flame/shared/speaker_role.dart` | Speech transcript attribution enum |
+| `lib/preferences/user_preferences.dart` | hideVideoBubbles / reduceMotion prefs |
+
+## Key Constraints
+
+1. **`adaptiveStream: false`** — Flame renders to canvas, not `VideoTrackRenderer` widget. Without this the SFU stops forwarding video.
+2. **Never `createImageFromImageBitmap`** — Skia bug #14637 renders black in CanvasKit WASM.
+3. **Hidden elements at `top: -9999px`**, not `display:none` — mobile browsers won't decode hidden video elements.
+4. **Two separate proximity systems** — `ProximityService` (threshold=3, events only) vs `BubbleManager` (visual=5, audio=2, owns bubbles). They don't talk to each other.
+5. **GLSL limits** — no array initializers or dynamic loop bounds (CanvasKit rejects them).
+6. **`hiddenForMerge`** — merged bubbles keep capturing but skip render; the merged component samples their `currentFrame` directly.

--- a/test/events/dispatch_test.dart
+++ b/test/events/dispatch_test.dart
@@ -169,6 +169,17 @@ void main() {
         DmSent() => 'dm',
         BotSpoke() => 'bot',
         AppLogRecord() => 'log',
+        // AV pipeline diagnostics
+        AvPipelineSnapshot() => 'av_snapshot',
+        AvTrackSubscribed() => 'av_track_sub',
+        AvTrackUnsubscribed() => 'av_track_unsub',
+        AvCaptureInitialized() => 'av_capture_init',
+        AvCaptureInitFailed() => 'av_capture_fail',
+        AvBubbleCreated() => 'av_bubble_create',
+        AvBubbleRemoved() => 'av_bubble_remove',
+        AvAudioGateChanged() => 'av_audio_gate',
+        AvFrameDecodeError() => 'av_frame_error',
+        AvSpeakingChanged() => 'av_speaking',
       };
       expect(label, 'door');
     });

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -58,7 +58,7 @@ void main() {
     // asserts on a known concrete type.
     void check(AppEvent event, PiiPolicy expected) {
       final declared = switch (event) {
-        // PII subtypes (15)
+        // PII subtypes (24)
         SpellCastFailed() => PiiPolicy.pii,
         RoomJoined() => PiiPolicy.pii,
         UserSignedIn() => PiiPolicy.pii,
@@ -74,7 +74,17 @@ void main() {
         GroupMessageSent() => PiiPolicy.pii,
         DmSent() => PiiPolicy.pii,
         AppLogRecord() => PiiPolicy.pii,
-        // Non-PII subtypes (19)
+        // AV pipeline PII (9 — participant identity)
+        AvPipelineSnapshot() => PiiPolicy.pii,
+        AvTrackSubscribed() => PiiPolicy.pii,
+        AvTrackUnsubscribed() => PiiPolicy.pii,
+        AvCaptureInitialized() => PiiPolicy.pii,
+        AvCaptureInitFailed() => PiiPolicy.pii,
+        AvBubbleCreated() => PiiPolicy.pii,
+        AvBubbleRemoved() => PiiPolicy.pii,
+        AvAudioGateChanged() => PiiPolicy.pii,
+        AvSpeakingChanged() => PiiPolicy.pii,
+        // Non-PII subtypes (20)
         WordLearned() => PiiPolicy.none,
         ChallengeCompleted() => PiiPolicy.none,
         DoorUnlocked() => PiiPolicy.none,
@@ -94,6 +104,7 @@ void main() {
         HelpRequested() => PiiPolicy.none,
         MediaEnabled() => PiiPolicy.none,
         RemoteDoorUnlocked() => PiiPolicy.none,
+        AvFrameDecodeError() => PiiPolicy.none,
       };
       // Cross-check: the caller's expectation, the exhaustive switch,
       // and the live override must all agree.
@@ -119,7 +130,7 @@ void main() {
       // here for the runtime classification to be pinned — see the
       // group comment above for what this list does and does not prove.
       final piiEvents = <AppEvent>[
-        // PII (15)
+        // PII (24)
         SpellCastFailed(
           reason: CastFailureReason.noMatch,
           transcript: 'ignis',
@@ -142,9 +153,41 @@ void main() {
           severity: LogSeverity.info,
           message: 'm',
         ),
+        // AV pipeline PII (9)
+        AvPipelineSnapshot(
+          participant: 'alice',
+          hasVideoTrack: true,
+          captureMethod: AvCaptureMethod.directTrack,
+          captureRetryCount: 0,
+          framesCaptured: 10,
+          framesDropped: 0,
+          bubbleType: AvBubbleType.video,
+          audioEnabled: true,
+          distance: 2,
+          isLocal: false,
+        ),
+        AvTrackSubscribed(participant: 'alice'),
+        AvTrackUnsubscribed(participant: 'alice'),
+        AvCaptureInitialized(
+          participant: 'alice',
+          method: AvCaptureMethod.directTrack,
+          retryCount: 1,
+        ),
+        AvCaptureInitFailed(participant: 'alice', maxRetries: 10),
+        AvBubbleCreated(
+          participant: 'alice',
+          bubbleType: AvBubbleType.video,
+        ),
+        AvBubbleRemoved(participant: 'alice'),
+        AvAudioGateChanged(
+          participant: 'alice',
+          enabled: true,
+          distance: 2,
+        ),
+        AvSpeakingChanged(participant: 'alice', speaking: true),
       ];
       final nonPiiEvents = <AppEvent>[
-        // Non-PII (19)
+        // Non-PII (20)
         WordLearned(
           wordId: WordId.values.first,
           challengeId: PromptChallengeId.values.first,
@@ -176,6 +219,7 @@ void main() {
         HelpRequested(challengeId: CodeRef(CodeChallengeId.values.first)),
         MediaEnabled(),
         RemoteDoorUnlocked(doorX: 0, doorY: 0),
+        AvFrameDecodeError(participant: 'alice', error: 'decode failed'),
       ];
 
       final events = [...piiEvents, ...nonPiiEvents];
@@ -196,9 +240,9 @@ void main() {
       // Cardinality cross-check: keeps this list and the switch above
       // honest against the same expected subtype count. Bump together
       // when adding a new subtype.
-      expect(events.length, 34);
-      expect(piiEvents.length, 15);
-      expect(nonPiiEvents.length, 19);
+      expect(events.length, 44);
+      expect(piiEvents.length, 24);
+      expect(nonPiiEvents.length, 20);
 
       for (final event in piiEvents) {
         check(event, PiiPolicy.pii);

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -84,7 +84,8 @@ void main() {
         AvBubbleRemoved() => PiiPolicy.pii,
         AvAudioGateChanged() => PiiPolicy.pii,
         AvSpeakingChanged() => PiiPolicy.pii,
-        // Non-PII subtypes (20)
+        AvFrameDecodeError() => PiiPolicy.pii,
+        // Non-PII subtypes (19)
         WordLearned() => PiiPolicy.none,
         ChallengeCompleted() => PiiPolicy.none,
         DoorUnlocked() => PiiPolicy.none,
@@ -104,7 +105,6 @@ void main() {
         HelpRequested() => PiiPolicy.none,
         MediaEnabled() => PiiPolicy.none,
         RemoteDoorUnlocked() => PiiPolicy.none,
-        AvFrameDecodeError() => PiiPolicy.none,
       };
       // Cross-check: the caller's expectation, the exhaustive switch,
       // and the live override must all agree.
@@ -185,9 +185,10 @@ void main() {
           distance: 2,
         ),
         AvSpeakingChanged(participant: 'alice', speaking: true),
+        AvFrameDecodeError(participant: 'alice', error: 'decode failed'),
       ];
       final nonPiiEvents = <AppEvent>[
-        // Non-PII (20)
+        // Non-PII (19)
         WordLearned(
           wordId: WordId.values.first,
           challengeId: PromptChallengeId.values.first,
@@ -219,7 +220,6 @@ void main() {
         HelpRequested(challengeId: CodeRef(CodeChallengeId.values.first)),
         MediaEnabled(),
         RemoteDoorUnlocked(doorX: 0, doorY: 0),
-        AvFrameDecodeError(participant: 'alice', error: 'decode failed'),
       ];
 
       final events = [...piiEvents, ...nonPiiEvents];
@@ -241,8 +241,8 @@ void main() {
       // honest against the same expected subtype count. Bump together
       // when adding a new subtype.
       expect(events.length, 44);
-      expect(piiEvents.length, 24);
-      expect(nonPiiEvents.length, 20);
+      expect(piiEvents.length, 25);
+      expect(nonPiiEvents.length, 19);
 
       for (final event in piiEvents) {
         check(event, PiiPolicy.pii);

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -58,7 +58,7 @@ void main() {
     // asserts on a known concrete type.
     void check(AppEvent event, PiiPolicy expected) {
       final declared = switch (event) {
-        // PII subtypes (24)
+        // PII subtypes (25)
         SpellCastFailed() => PiiPolicy.pii,
         RoomJoined() => PiiPolicy.pii,
         UserSignedIn() => PiiPolicy.pii,
@@ -74,7 +74,7 @@ void main() {
         GroupMessageSent() => PiiPolicy.pii,
         DmSent() => PiiPolicy.pii,
         AppLogRecord() => PiiPolicy.pii,
-        // AV pipeline PII (9 — participant identity)
+        // AV pipeline PII (10 — participant identity)
         AvPipelineSnapshot() => PiiPolicy.pii,
         AvTrackSubscribed() => PiiPolicy.pii,
         AvTrackUnsubscribed() => PiiPolicy.pii,
@@ -130,7 +130,7 @@ void main() {
       // here for the runtime classification to be pinned — see the
       // group comment above for what this list does and does not prove.
       final piiEvents = <AppEvent>[
-        // PII (24)
+        // PII (25)
         SpellCastFailed(
           reason: CastFailureReason.noMatch,
           transcript: 'ignis',
@@ -188,7 +188,7 @@ void main() {
         AvFrameDecodeError(participant: 'alice', error: 'decode failed'),
       ];
       final nonPiiEvents = <AppEvent>[
-        // Non-PII (19)
+        // Non-PII (19 — no participant identity)
         WordLearned(
           wordId: WordId.values.first,
           challengeId: PromptChallengeId.values.first,


### PR DESCRIPTION
## Summary

- **10 new AV diagnostic event types** for the full video/audio bubble pipeline lifecycle
- **RotatingFileSink** — 5MB max, 3 rotations, replaces no-rotation file sink
- **Two new log files** — `av-pipeline.jsonl` (toggle-gated) and `errors.jsonl` (always on)
- **Runtime toggles** — `avDiagnosticsEnabled` / `errorLoggingEnabled` via SharedPreferences

### Why

Intermittent video/audio failures where "it works for Nick but not Robin" are impossible to diagnose — the capture pipeline has ~7 silent failure points per participant. The periodic snapshot (every 5s) shows full pipeline state per participant: track subscription, capture method, frame counts, bubble type, audio gating, distance. Comparing two clients instantly reveals where the pipeline stalled.

### Key diagnostic event

```json
{"type":"av_pipeline_snapshot","participant":"alice","hasVideoTrack":true,
 "captureMethod":"directTrack","captureRetryCount":1,"framesCaptured":147,
 "framesDropped":2,"bubbleType":"video","audioEnabled":true,"distance":2}
```

### Cage-match reviewed

Adversarial review by MaxwellMergeSlam + KelvinBitBrawler caught:
1. **Critical toggle desync** — BubbleManager never heard about the toggle (fixed: wired through TechWorld)
2. Bridge events ungated (fixed: all AV events now respect toggle)
3. AvFrameDecodeError PII classification (fixed: conservative `.pii`)
4. Snapshot excluded bots/Dreamfinder (fixed: now included)
5. Bot/Dreamfinder bubble creation uninstrumented (fixed)
6. AvCaptureInitFailed missing from errors.jsonl (fixed)

### Full documentation

See `robin-docs/VIDEO_LOGGING.md` for the complete diagnostic guide: what/why/where/how to read/troubleshoot/toggle/retention.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 1824 tests pass
- [x] PII marker test updated (25 PII + 19 non-PII = 44 total)
- [x] Cage-match review — all 6 findings addressed
- [ ] Manual: enable AV diagnostics, join room with 2+ players, verify av-pipeline.jsonl populates
- [ ] Manual: verify rotation triggers after 5MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)