### PR TITLE
ci(flutter): pin to 3.41.7, drop channel:stable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.41.7'
       - name: Install dependencies
         run: flutter pub get
       - name: Analyze code
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.41.7'
       - name: Install dependencies
         run: flutter pub get
       - run: flutter build web --wasm --pwa-strategy=none --dart-define="DREAMFINDER_API_KEY=$DREAMFINDER_API_KEY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.41.7'
       - name: Install dependencies
         run: flutter pub get
       - name: Analyze code


### PR DESCRIPTION
## Summary

- Pin both workflows (`test.yml`, `deploy.yml`) to `flutter-version: '3.41.7'` instead of `channel: stable`.
- Local `.fvm/` removed (already gitignored; no tracked-file change).

## Why

Flutter stable rolled to 3.44.0 between 2026-05-16 (last green CI on main, PR #472) and 2026-05-27 (PR #473 deploy attempt). 3.44 added `TextInputClient.onFocusReceived` as a required method, which `code_forge_web 2.9.0` (latest on pub.dev) doesn't implement. Both `dart2wasm` and `dart2js` fail to compile.

The site has been stuck on whatever shipped at #472 since then — no deploys reaching `world.imagineering.cc`.

## Root cause: fvm-vs-CI pinning drift

`.fvm/fvm_config.json` pinned 3.41.7 locally; CI used `channel: stable`. These disagreed silently. fvm protected local dev; CI rode stable and broke when 3.44 dropped.

Pinning CI to the same version fvm was using gives a single source of truth.

## Follow-up (not in this PR)

- File issue / PR against `code_forge_web` adding `onFocusReceived` (one-line stub: `void onFocusReceived() {}`).
- Once `code_forge_web` supports 3.44+, unpin and ride stable again.

## Test plan

- [x] YAML syntax valid (workflow re-validates on push)
- [ ] CI test job runs on this PR with 3.41.7
- [ ] After merge: CI on main rebuilds, deploy step completes, site updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)