### PR TITLE
fix(audio): recompute proximity every frame + hysteresis + DF proximity signal

### DIFF
--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -104,6 +104,9 @@ class BubbleManager {
   final Map<String, PositionComponent> _playerBubbles = {};
   final Map<String, Vector2> _bubbleDisplacements = {};
   final Set<String> _audioEnabledParticipants = {};
+  /// Last volume pushed to LiveKit per participant, so the per-frame fade only
+  /// writes when the value actually changes (distance is an int → rarely).
+  final Map<String, double> _audioVolumes = {};
   /// Last reported local-player proximity to Dreamfinder, so the df-proximity
   /// signal is published only on enter/exit transitions, not every frame.
   bool _wasNearDreamfinder = false;
@@ -298,16 +301,12 @@ class BubbleManager {
     }
 
     // Notify Dreamfinder when the local player enters/exits its range so the
-    // bot can gate whose speech it hears. DF is in [nearbyPlayerIds] exactly
-    // when within visual range (the same threshold that shows its bubble), so
-    // "DF can hear you" lines up with "DF's bubble is up for you". Published on
-    // transition only — the bot holds the state between signals.
-    final nearDf = dreamfinderComponent != null &&
-        nearbyPlayerIds.contains(dreamfinderIdentity);
-    if (nearDf != _wasNearDreamfinder) {
-      _wasNearDreamfinder = nearDf;
-      _liveKitService?.publishDfProximity(near: nearDf);
-    }
+    // bot can gate whose speech it hears. null distance == DF not present.
+    _updateDreamfinderProximity(
+      dreamfinderComponent == null
+          ? null
+          : chebyshevDistance(playerGrid, dreamfinderComponent!.miniGridPosition),
+    );
 
     // Remove bubbles for players no longer nearby.
     final toRemove = <String>[];
@@ -476,6 +475,13 @@ class BubbleManager {
     _mergedBubble?.removeFromParent();
     _mergedBubble = null;
     _audioEnabledParticipants.clear();
+    _audioVolumes.clear();
+    // Emit a final exit so Dreamfinder doesn't hold a stale near:true after we
+    // tear down while the player was in range (cage match PR #481 — Carnot).
+    // Best-effort; the bot also self-heals on our ParticipantDisconnected.
+    if (_wasNearDreamfinder) {
+      _liveKitService?.publishDfProximity(near: false);
+    }
     _wasNearDreamfinder = false;
     _liveKitService = null;
     _dreamfinderAvatarBridge?.dispose();
@@ -645,6 +651,12 @@ class BubbleManager {
   }
 
   void _updateParticipantAudio(String playerId, int distance) {
+    // No LiveKit service yet (pre-connect / post-teardown) → don't mutate the
+    // gate state. Latching a state change we couldn't actually send leaves the
+    // gate stuck once the service comes up (the next frame sees "no change").
+    final service = _liveKitService;
+    if (service == null) return;
+
     final hasAudio = _audioEnabledParticipants.contains(playerId);
 
     // Hysteresis: enable when within the (tighter) enable threshold, disable
@@ -656,7 +668,7 @@ class BubbleManager {
 
     if (shouldEnable) {
       _audioEnabledParticipants.add(playerId);
-      _liveKitService?.setParticipantAudioEnabled(playerId, true);
+      service.setParticipantAudioEnabled(playerId, true);
       if (avDiagnosticsEnabled) {
         dispatch([AvAudioGateChanged(
           participant: playerId,
@@ -666,7 +678,8 @@ class BubbleManager {
       }
     } else if (shouldDisable) {
       _audioEnabledParticipants.remove(playerId);
-      _liveKitService?.setParticipantAudioEnabled(playerId, false);
+      _audioVolumes.remove(playerId); // re-set volume on next enable
+      service.setParticipantAudioEnabled(playerId, false);
       if (avDiagnosticsEnabled) {
         dispatch([AvAudioGateChanged(
           participant: playerId,
@@ -679,21 +692,56 @@ class BubbleManager {
     // Distance fade: while the track is subscribed, ramp playback volume by
     // distance so voices fade with range instead of cutting. The hard
     // enable/disable above is the outer subscription boundary (and the
-    // bandwidth saver); this is the smooth gradient inside it. Web-only effect
-    // today — a no-op elsewhere (see LiveKitService.setParticipantAudioVolume).
+    // bandwidth saver); this is the per-square ramp inside it. Only push to
+    // LiveKit when the value actually changes — `distance` is an int, so for a
+    // stationary peer this is most frames, and the web path is a DOM write.
     if (_audioEnabledParticipants.contains(playerId)) {
-      _liveKitService?.setParticipantAudioVolume(
-          playerId, _volumeForDistance(distance));
+      final volume = _volumeForDistance(distance);
+      if (_audioVolumes[playerId] != volume) {
+        _audioVolumes[playerId] = volume;
+        service.setParticipantAudioVolume(playerId, volume);
+      }
     }
   }
 
-  /// Linear volume curve for the distance fade: full within
-  /// [_audioFullVolumeDistance], ramping to silence at [_audioDisableThreshold].
+  /// Volume curve for the distance fade: full within [_audioFullVolumeDistance],
+  /// then a linear step-down per grid square to silence at
+  /// [_audioDisableThreshold]. Stepwise (distance is an int), not continuous.
   double _volumeForDistance(int distance) {
     if (distance <= _audioFullVolumeDistance) return 1.0;
     final span = _audioDisableThreshold - _audioFullVolumeDistance;
     return ((_audioDisableThreshold - distance) / span).clamp(0.0, 1.0);
   }
+
+  /// Emit the `df-proximity` enter/exit signal to Dreamfinder. [dfDistance] is
+  /// null when DF isn't present (forces an exit).
+  ///
+  /// Hardened per the PR #481 cage match (Kelvin + Carnot):
+  /// - **Hysteresis** — enter within [_audioEnableThreshold]; once near, stay
+  ///   near until past [_audioDisableThreshold]. Stops a peer hovering at the
+  ///   boundary from spamming the reliable channel.
+  /// - **Null-service safety** — if the service isn't ready we do NOT latch
+  ///   [_wasNearDreamfinder]; the transition simply re-fires next frame once it
+  ///   is. Latching-without-sending was the "signal lost forever" bug.
+  void _updateDreamfinderProximity(int? dfDistance) {
+    final near = dfDistance != null &&
+        (_wasNearDreamfinder
+            ? dfDistance <= _audioDisableThreshold
+            : dfDistance <= _audioEnableThreshold);
+    if (near == _wasNearDreamfinder) return;
+    final service = _liveKitService;
+    if (service == null) return; // can't emit — don't latch; retry next frame
+    _wasNearDreamfinder = near;
+    service.publishDfProximity(near: near);
+  }
+
+  /// Test seam for the DF proximity emission logic — exercising it through the
+  /// real update loop would require a fully-constructed [DreamfinderComponent]
+  /// (sprite + path harness). Pass the Chebyshev distance to DF, or null for
+  /// "DF absent".
+  @visibleForTesting
+  void debugUpdateDreamfinderProximity(int? dfDistance) =>
+      _updateDreamfinderProximity(dfDistance);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Private — physics and rendering

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -104,7 +104,9 @@ class BubbleManager {
   final Map<String, PositionComponent> _playerBubbles = {};
   final Map<String, Vector2> _bubbleDisplacements = {};
   final Set<String> _audioEnabledParticipants = {};
-  Point<int>? _lastPlayerGridPosition;
+  /// Last reported local-player proximity to Dreamfinder, so the df-proximity
+  /// signal is published only on enter/exit transitions, not every frame.
+  bool _wasNearDreamfinder = false;
 
   // ── Rendering components ─────────────────────────────────────────────────
 
@@ -141,7 +143,14 @@ class BubbleManager {
 
   static const _localPlayerBubbleKey = '_local_player_';
   static const int _visualThreshold = 5; // grid squares — bubbles visible
-  static const int _audioThreshold = 2; // grid squares — audio enabled
+  // Audio gate with hysteresis so standing at the boundary doesn't flap the
+  // SFU forward on/off. Audio enables when a participant is within
+  // [_audioEnableThreshold] and only cuts once they drift past
+  // [_audioDisableThreshold]. The enable distance sits just inside the visual
+  // range (5) so you can hear almost anyone whose bubble you can see — closing
+  // the old see-but-can't-hear dead zone (audio was ≤2 while bubbles were ≤5).
+  static const int _audioEnableThreshold = 4; // grid squares — audio turns on
+  static const int _audioDisableThreshold = 5; // grid squares — audio cuts off
   static final _bubbleOffset =
       Vector2(16, -20); // center horizontally, above sprite
   static const double _mergeThreshold = 96.0; // 1.5× bubble diameter
@@ -189,12 +198,15 @@ class BubbleManager {
 
     final playerGrid = _localPlayer.miniGridPosition;
 
-    // Skip proximity re-evaluation if player hasn't moved to a new grid cell.
-    if (_lastPlayerGridPosition == playerGrid) {
-      _updateBubblePositions(dt);
-      return;
-    }
-    _lastPlayerGridPosition = playerGrid;
+    // Recompute proximity every frame. A previous optimisation skipped this
+    // whenever the LOCAL player hadn't changed grid cell — but remote players
+    // and Dreamfinder (which wanders autonomously) move too, and that changes
+    // distances. Skipping on local-stillness left the audio gate stale: a peer
+    // could walk back into range and stay inaudible until the local player
+    // happened to move (the "can't hear you until I move" bug). At meetup-scale
+    // participant counts the per-frame recompute is cheap — a handful of
+    // Chebyshev distances; bubble creation/removal is still transition-guarded,
+    // and the audio enable/disable is a no-op when the gate state is unchanged.
 
     // Check each other player for proximity.
     final nearbyPlayerIds = <String>{};
@@ -282,6 +294,18 @@ class BubbleManager {
       _setBubbleOpacity(
           _playerBubbles[_localPlayerBubbleKey]!, closestDistance);
       nearbyPlayerIds.add(_localPlayerBubbleKey);
+    }
+
+    // Notify Dreamfinder when the local player enters/exits its range so the
+    // bot can gate whose speech it hears. DF is in [nearbyPlayerIds] exactly
+    // when within visual range (the same threshold that shows its bubble), so
+    // "DF can hear you" lines up with "DF's bubble is up for you". Published on
+    // transition only — the bot holds the state between signals.
+    final nearDf = dreamfinderComponent != null &&
+        nearbyPlayerIds.contains(dreamfinderIdentity);
+    if (nearDf != _wasNearDreamfinder) {
+      _wasNearDreamfinder = nearDf;
+      _liveKitService?.publishDfProximity(near: nearDf);
     }
 
     // Remove bubbles for players no longer nearby.
@@ -451,7 +475,7 @@ class BubbleManager {
     _mergedBubble?.removeFromParent();
     _mergedBubble = null;
     _audioEnabledParticipants.clear();
-    _lastPlayerGridPosition = null;
+    _wasNearDreamfinder = false;
     _liveKitService = null;
     _dreamfinderAvatarBridge?.dispose();
     _dreamfinderAvatarBridge = null;
@@ -620,10 +644,16 @@ class BubbleManager {
   }
 
   void _updateParticipantAudio(String playerId, int distance) {
-    final shouldHaveAudio = distance <= _audioThreshold;
     final hasAudio = _audioEnabledParticipants.contains(playerId);
 
-    if (shouldHaveAudio && !hasAudio) {
+    // Hysteresis: enable when within the (tighter) enable threshold, disable
+    // only once past the (looser) disable threshold. Between the two, hold the
+    // current state so a participant hovering at the boundary doesn't toggle
+    // the SFU forward on and off every frame.
+    final shouldEnable = !hasAudio && distance <= _audioEnableThreshold;
+    final shouldDisable = hasAudio && distance > _audioDisableThreshold;
+
+    if (shouldEnable) {
       _audioEnabledParticipants.add(playerId);
       _liveKitService?.setParticipantAudioEnabled(playerId, true);
       if (avDiagnosticsEnabled) {
@@ -633,7 +663,7 @@ class BubbleManager {
           distance: distance,
         )]);
       }
-    } else if (!shouldHaveAudio && hasAudio) {
+    } else if (shouldDisable) {
       _audioEnabledParticipants.remove(playerId);
       _liveKitService?.setParticipantAudioEnabled(playerId, false);
       if (avDiagnosticsEnabled) {

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -456,6 +456,11 @@ class BubbleManager {
 
   /// Remove a single bubble by player ID.
   void removeBubble(String playerId) {
+    // A peer that vanishes (ungraceful disconnect) while inside audio range
+    // never crosses the disable threshold in the proximity loop, so drop their
+    // audio bookkeeping here to avoid leaking map entries until teardown.
+    _audioEnabledParticipants.remove(playerId);
+    _audioVolumes.remove(playerId);
     _replaceBubble(playerId, null, 'remove-bubble-api');
   }
 
@@ -698,8 +703,12 @@ class BubbleManager {
     if (_audioEnabledParticipants.contains(playerId)) {
       final volume = _volumeForDistance(distance);
       if (_audioVolumes[playerId] != volume) {
-        _audioVolumes[playerId] = volume;
-        service.setParticipantAudioVolume(playerId, volume);
+        // Cache only if the volume actually landed on a track. If the track
+        // hasn't subscribed yet the call no-ops; caching anyway would suppress
+        // the retry and leave the late track stuck at default volume.
+        if (service.setParticipantAudioVolume(playerId, volume)) {
+          _audioVolumes[playerId] = volume;
+        }
       }
     }
   }

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -151,6 +151,7 @@ class BubbleManager {
   // the old see-but-can't-hear dead zone (audio was ≤2 while bubbles were ≤5).
   static const int _audioEnableThreshold = 4; // grid squares — audio turns on
   static const int _audioDisableThreshold = 5; // grid squares — audio cuts off
+  static const int _audioFullVolumeDistance = 1; // ≤ this = full volume; fades out to _audioDisableThreshold
   static final _bubbleOffset =
       Vector2(16, -20); // center horizontally, above sprite
   static const double _mergeThreshold = 96.0; // 1.5× bubble diameter
@@ -674,6 +675,24 @@ class BubbleManager {
         )]);
       }
     }
+
+    // Distance fade: while the track is subscribed, ramp playback volume by
+    // distance so voices fade with range instead of cutting. The hard
+    // enable/disable above is the outer subscription boundary (and the
+    // bandwidth saver); this is the smooth gradient inside it. Web-only effect
+    // today — a no-op elsewhere (see LiveKitService.setParticipantAudioVolume).
+    if (_audioEnabledParticipants.contains(playerId)) {
+      _liveKitService?.setParticipantAudioVolume(
+          playerId, _volumeForDistance(distance));
+    }
+  }
+
+  /// Linear volume curve for the distance fade: full within
+  /// [_audioFullVolumeDistance], ramping to silence at [_audioDisableThreshold].
+  double _volumeForDistance(int distance) {
+    if (distance <= _audioFullVolumeDistance) return 1.0;
+    final span = _audioDisableThreshold - _audioFullVolumeDistance;
+    return ((_audioDisableThreshold - distance) / span).clamp(0.0, 1.0);
   }
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -495,14 +495,25 @@ class LiveKitService {
   /// subscription toggle (binary forward/don't-forward) — this is a local
   /// playback gain applied while the track is subscribed. Web-only effect today
   /// (see [setTrackVolume]); a safe no-op on other platforms.
-  void setParticipantAudioVolume(String identity, double volume) {
+  ///
+  /// Returns true iff at least one subscribed track was actually addressed.
+  /// Callers cache the applied volume — caching on a no-op (e.g. the audio
+  /// publication exists but [RemoteTrackPublication.track] hasn't subscribed
+  /// yet) would suppress the retry, leaving the track at default volume once it
+  /// finally subscribes.
+  bool setParticipantAudioVolume(String identity, double volume) {
     final participant = _room?.remoteParticipants[identity];
-    if (participant == null) return;
+    if (participant == null) return false;
 
+    var applied = false;
     for (final publication in participant.audioTrackPublications) {
       final track = publication.track;
-      if (track != null) setTrackVolume(track.getCid(), volume);
+      if (track != null) {
+        setTrackVolume(track.getCid(), volume);
+        applied = true;
+      }
     }
+    return applied;
   }
 
   /// Whether Dreamfinder's audio is currently silenced for the local player.

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -652,6 +652,20 @@ class LiveKitService {
     );
   }
 
+  /// Tell Dreamfinder whether the local player is within its range.
+  ///
+  /// Published on enter/exit transitions only (not every frame). Reliable,
+  /// because a missed enter would leave DF unable to hear a nearby player and a
+  /// missed exit would leave DF listening to someone who walked away. The bot
+  /// gates whose speech it responds to on this signal (near OR named).
+  Future<void> publishDfProximity({required bool near}) async {
+    await publishJson(
+      {'playerId': userId, 'near': near},
+      topic: LiveKitTopic.dfProximity.wire,
+      reliable: true,
+    );
+  }
+
   Timer? _heartbeatTimer;
 
   /// Last grid position sent via heartbeat, used to avoid duplicate sends.

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -19,6 +19,7 @@ import 'package:tech_world/flame/shared/player_path.dart';
 import 'package:tech_world/livekit/agent_hello.dart';
 import 'package:tech_world/livekit/livekit_topic.dart';
 import 'package:tech_world/livekit/platform_info.dart';
+import 'package:tech_world/livekit/set_track_volume.dart';
 
 /// Protocol version stamped on every outgoing LiveKit data-channel message.
 /// Bump when a wire-format change requires receivers to upgrade.
@@ -484,6 +485,23 @@ class LiveKitService {
       } else {
         publication.disable();
       }
+    }
+  }
+
+  /// Set the playback volume (0.0–1.0) for a remote participant's audio.
+  ///
+  /// Used by the proximity layer to fade voices by distance instead of hard
+  /// cutting. Distinct from [setParticipantAudioEnabled], which is a server-side
+  /// subscription toggle (binary forward/don't-forward) — this is a local
+  /// playback gain applied while the track is subscribed. Web-only effect today
+  /// (see [setTrackVolume]); a safe no-op on other platforms.
+  void setParticipantAudioVolume(String identity, double volume) {
+    final participant = _room?.remoteParticipants[identity];
+    if (participant == null) return;
+
+    for (final publication in participant.audioTrackPublications) {
+      final track = publication.track;
+      if (track != null) setTrackVolume(track.getCid(), volume);
     }
   }
 

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -496,11 +496,12 @@ class LiveKitService {
   /// playback gain applied while the track is subscribed. Web-only effect today
   /// (see [setTrackVolume]); a safe no-op on other platforms.
   ///
-  /// Returns true iff at least one subscribed track was actually addressed.
-  /// Callers cache the applied volume — caching on a no-op (e.g. the audio
-  /// publication exists but [RemoteTrackPublication.track] hasn't subscribed
-  /// yet) would suppress the retry, leaving the track at default volume once it
-  /// finally subscribes.
+  /// Returns true iff the volume actually landed on at least one track — i.e.
+  /// [setTrackVolume] reported it wrote the value, not merely that a
+  /// [RemoteTrackPublication.track] exists. The track can be subscribed a frame
+  /// or two before its web audio element is appended, so this distinction is
+  /// what lets the caller retry instead of caching a silent no-op (which would
+  /// strand the late track at default volume).
   bool setParticipantAudioVolume(String identity, double volume) {
     final participant = _room?.remoteParticipants[identity];
     if (participant == null) return false;
@@ -508,8 +509,7 @@ class LiveKitService {
     var applied = false;
     for (final publication in participant.audioTrackPublications) {
       final track = publication.track;
-      if (track != null) {
-        setTrackVolume(track.getCid(), volume);
+      if (track != null && setTrackVolume(track.getCid(), volume)) {
         applied = true;
       }
     }

--- a/lib/livekit/livekit_topic.dart
+++ b/lib/livekit/livekit_topic.dart
@@ -43,6 +43,12 @@ enum LiveKitTopic {
   oracleRequest('oracle-request'),
   oracleResponse('oracle-response'),
 
+  /// Local player's proximity to Dreamfinder, published on enter/exit of DF's
+  /// range. The client owns DF's on-screen position, so it is the authority on
+  /// proximity; the bot gates whose speech DF responds to on this signal (near
+  /// OR addressed-by-name). Payload `{near: bool}`, reliable.
+  dfProximity('df-proximity'),
+
   // ── Infrastructure ────────────────────────────────────────────────────────
   infraHealth('infra-health'),
   infraHeal('infra-heal'),

--- a/lib/livekit/set_track_volume.dart
+++ b/lib/livekit/set_track_volume.dart
@@ -1,0 +1,14 @@
+/// Sets the playback volume (0.0–1.0) of a subscribed remote audio track,
+/// keyed by the track's LiveKit CID, so the proximity layer can fade voices by
+/// distance instead of hard-cutting them.
+///
+/// Web sets the `volume` on the `HTMLAudioElement` that livekit_client
+/// auto-creates per remote track. Other platforms no-op for now — the
+/// proximity gate's enable/disable still applies, just without the fade.
+///
+/// Conditional export so neither `package:web` nor `dart:js_interop` leaks into
+/// native/VM builds (mirrors `platform_info.dart`).
+library;
+
+export 'set_track_volume_stub.dart'
+    if (dart.library.js_interop) 'set_track_volume_web.dart';

--- a/lib/livekit/set_track_volume_stub.dart
+++ b/lib/livekit/set_track_volume_stub.dart
@@ -1,0 +1,8 @@
+/// Non-web stub for [setTrackVolume].
+///
+/// There is no portable per-remote-track playback-volume API in
+/// livekit_client 2.7.0, and the web element trick doesn't apply off-web, so
+/// this is a deliberate no-op. The distance fade is therefore web-only today;
+/// the proximity enable/disable gate still works everywhere. A native fade
+/// (via `flutter_webrtc`'s `Helper.setVolume`) can be implemented here later.
+void setTrackVolume(String cid, double volume) {}

--- a/lib/livekit/set_track_volume_stub.dart
+++ b/lib/livekit/set_track_volume_stub.dart
@@ -5,4 +5,7 @@
 /// this is a deliberate no-op. The distance fade is therefore web-only today;
 /// the proximity enable/disable gate still works everywhere. A native fade
 /// (via `flutter_webrtc`'s `Helper.setVolume`) can be implemented here later.
-void setTrackVolume(String cid, double volume) {}
+///
+/// Returns true so callers treat the (intentional) no-op as "applied" and don't
+/// retry every frame forever — there is no element to appear on these platforms.
+bool setTrackVolume(String cid, double volume) => true;

--- a/lib/livekit/set_track_volume_web.dart
+++ b/lib/livekit/set_track_volume_web.dart
@@ -20,8 +20,13 @@ import 'package:web/web.dart' as web;
 /// livekit_client's audio-element id prefix (`_audio_html.dart`).
 const _audioElementPrefix = 'livekit_audio_';
 
-void setTrackVolume(String cid, double volume) {
+/// Returns true iff the audio element was found and its volume written. A track
+/// can be subscribed (`publication.track != null`) a frame or two before
+/// livekit_client appends its `HTMLAudioElement`, so a `false` here tells the
+/// caller "not applied — retry" rather than silently caching a no-op.
+bool setTrackVolume(String cid, double volume) {
   final element = web.document.getElementById('$_audioElementPrefix$cid');
-  if (element == null || !element.isA<web.HTMLAudioElement>()) return;
+  if (element == null || !element.isA<web.HTMLAudioElement>()) return false;
   (element as web.HTMLAudioElement).volume = volume.clamp(0.0, 1.0);
+  return true;
 }

--- a/lib/livekit/set_track_volume_web.dart
+++ b/lib/livekit/set_track_volume_web.dart
@@ -1,0 +1,27 @@
+/// Web implementation of [setTrackVolume].
+///
+/// livekit_client plays each subscribed remote audio track through an
+/// `HTMLAudioElement` it appends to a hidden container, with DOM id
+/// `livekit_audio_<cid>` (see livekit_client's `src/track/web/_audio_html.dart`,
+/// `audioPrefix = 'livekit_audio_'`). We look that element up by id and set its
+/// `volume` to fade the participant by distance.
+///
+/// This reaches into livekit_client's internal element-id scheme, which is the
+/// only handle the SDK gives us — it exposes no per-track volume API. If the
+/// prefix changes in a future SDK version the lookup simply misses and we
+/// no-op, so the worst case is "no fade" (audio still plays via the gate), not
+/// a crash. Typed `package:web` interop only — no dynamic dispatch (WASM-safe).
+library;
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+/// livekit_client's audio-element id prefix (`_audio_html.dart`).
+const _audioElementPrefix = 'livekit_audio_';
+
+void setTrackVolume(String cid, double volume) {
+  final element = web.document.getElementById('$_audioElementPrefix$cid');
+  if (element == null || !element.isA<web.HTMLAudioElement>()) return;
+  (element as web.HTMLAudioElement).volume = volume.clamp(0.0, 1.0);
+}

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -1159,6 +1159,9 @@ class FakeLiveKitService implements LiveKitService {
   Future<void> publishAvatar(Avatar avatar) async {}
 
   @override
+  Future<void> publishDfProximity({required bool near}) async {}
+
+  @override
   Future<DataChannelMessage?> sendPing({
     Duration timeout = const Duration(seconds: 5),
   }) async =>

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -1109,6 +1109,9 @@ class FakeLiveKitService implements LiveKitService {
   void setParticipantAudioEnabled(String identity, bool enabled) {}
 
   @override
+  void setParticipantAudioVolume(String identity, double volume) {}
+
+  @override
   final ValueNotifier<bool> dreamfinderSilenced = ValueNotifier<bool>(false);
 
   @override

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -1109,7 +1109,7 @@ class FakeLiveKitService implements LiveKitService {
   void setParticipantAudioEnabled(String identity, bool enabled) {}
 
   @override
-  void setParticipantAudioVolume(String identity, double volume) {}
+  bool setParticipantAudioVolume(String identity, double volume) => true;
 
   @override
   final ValueNotifier<bool> dreamfinderSilenced = ValueNotifier<bool>(false);

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -289,6 +289,31 @@ void main() {
         verify(() => mockLiveKit.setParticipantAudioEnabled('remote-1', false))
             .called(1);
       });
+
+      test('fades volume by distance while subscribed', () {
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+
+        // distance 3 → linear volume (5-3)/(5-1) = 0.5
+        final remote = PlayerComponent(
+          position: Vector2(256, 160), // 3 away
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioVolume('remote-1', 0.5))
+            .called(1);
+
+        // distance 1 → full volume.
+        remote.position = Vector2(192, 160); // 1 away
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioVolume('remote-1', 1.0))
+            .called(1);
+      });
     });
 
     group('clear', () {

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -316,6 +316,76 @@ void main() {
       });
     });
 
+    group('Dreamfinder proximity signal', () {
+      late BubbleManager manager;
+      late MockLiveKitService mockLiveKit;
+
+      setUp(() {
+        mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.publishDfProximity(near: any(named: 'near')))
+            .thenAnswer((_) async {});
+        manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2(160, 160),
+            id: 'local-user',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+        manager.setLiveKitService(mockLiveKit);
+      });
+
+      test('enters at the enable threshold, exits past the disable threshold',
+          () {
+        // d=4 ≤ enable(4) → enter.
+        manager.debugUpdateDreamfinderProximity(4);
+        verify(() => mockLiveKit.publishDfProximity(near: true)).called(1);
+
+        // d=5 — inside the hysteresis band (> enable 4, ≤ disable 5). No re-emit.
+        manager.debugUpdateDreamfinderProximity(5);
+        // d=6 > disable(5) → exit.
+        manager.debugUpdateDreamfinderProximity(6);
+        verify(() => mockLiveKit.publishDfProximity(near: false)).called(1);
+        // Exactly one enter + one exit across the whole sweep.
+        verifyNever(() => mockLiveKit.publishDfProximity(near: any(named: 'near')));
+      });
+
+      test('DF absent (null distance) forces an exit', () {
+        manager.debugUpdateDreamfinderProximity(2); // near
+        verify(() => mockLiveKit.publishDfProximity(near: true)).called(1);
+        manager.debugUpdateDreamfinderProximity(null); // DF gone → exit
+        verify(() => mockLiveKit.publishDfProximity(near: false)).called(1);
+      });
+
+      test('null service does NOT latch — re-fires once the service is set', () {
+        // Fresh manager with no service set yet (_liveKitService is null).
+        final noService = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2(160, 160),
+            id: 'local-user',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+        noService.debugUpdateDreamfinderProximity(2); // can't emit, must not latch
+        // Now the service is available; the SAME distance must still fire enter.
+        noService.setLiveKitService(mockLiveKit);
+        noService.debugUpdateDreamfinderProximity(2);
+        verify(() => mockLiveKit.publishDfProximity(near: true)).called(1);
+      });
+
+      test('clear() emits a final exit when the player was near DF', () {
+        manager.debugUpdateDreamfinderProximity(1); // near
+        verify(() => mockLiveKit.publishDfProximity(near: true)).called(1);
+        manager.clear();
+        verify(() => mockLiveKit.publishDfProximity(near: false)).called(1);
+      });
+    });
+
     group('clear', () {
       late BubbleManager manager;
       late List<Component> addedComponents;

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -206,6 +206,8 @@ void main() {
 
       setUp(() {
         mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
         localPlayer = PlayerComponent(
           position: Vector2(160, 160),
           id: 'local-user',
@@ -294,7 +296,7 @@ void main() {
         when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
             .thenReturn(null);
         when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
-            .thenReturn(null);
+            .thenReturn(true);
         when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
 
         // distance 3 → linear volume (5-3)/(5-1) = 0.5
@@ -314,6 +316,37 @@ void main() {
         verify(() => mockLiveKit.setParticipantAudioVolume('remote-1', 1.0))
             .called(1);
       });
+
+      test('does not cache volume until a track is actually addressed', () {
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+        // Track not subscribed yet → setParticipantAudioVolume returns false.
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(false);
+
+        final remote = PlayerComponent(
+          position: Vector2(256, 160), // 3 away → volume 0.5
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+
+        // Two frames at the same distance: because the volume never landed, it
+        // must be retried every frame (NOT cached after the first no-op).
+        manager.update(0.016);
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioVolume('remote-1', 0.5))
+            .called(2);
+
+        // Track subscribes → call now succeeds; next frame caches and stops.
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
+        manager.update(0.016);
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioVolume('remote-1', 0.5))
+            .called(1); // landed once, then cached
+      });
     });
 
     group('Dreamfinder proximity signal', () {
@@ -322,6 +355,8 @@ void main() {
 
       setUp(() {
         mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
         when(() => mockLiveKit.publishDfProximity(near: any(named: 'near')))
             .thenAnswer((_) async {});
         manager = BubbleManager(
@@ -585,6 +620,8 @@ void main() {
         addedComponents = [];
         remotePlayers = {};
         mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
         when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
             .thenReturn(null);
         localPlayer = PlayerComponent(
@@ -723,6 +760,8 @@ void main() {
         addedComponents = [];
         remotePlayers = {};
         mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
         when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
             .thenReturn(null);
         localPlayer = PlayerComponent(
@@ -972,6 +1011,8 @@ void main() {
 
         addedComponents = [];
         mockLiveKit = MockLiveKitService();
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
         when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
             .thenReturn(null);
         when(() => mockLiveKit.localParticipant).thenReturn(null);

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -241,14 +241,14 @@ void main() {
             .called(1);
       });
 
-      test('disables audio beyond threshold', () {
+      test('does not enable audio beyond the enable threshold', () {
         when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
             .thenReturn(null);
         when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
 
-        // Place player 4 squares away (beyond audio threshold)
+        // Place player 6 squares away — beyond the enable threshold (4).
         remotePlayers['remote-1'] = PlayerComponent(
-          position: Vector2(288, 160), // 4 away
+          position: Vector2(352, 160), // 6 away
           id: 'remote-1',
           displayName: 'Remote',
         );
@@ -257,6 +257,37 @@ void main() {
 
         verifyNever(() =>
             mockLiveKit.setParticipantAudioEnabled('remote-1', true));
+      });
+
+      test('hysteresis: stays enabled between thresholds, cuts past disable', () {
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+
+        final remote = PlayerComponent(
+          position: Vector2(256, 160), // 3 away — within enable threshold (4)
+          id: 'remote-1',
+          displayName: 'Remote',
+        );
+        remotePlayers['remote-1'] = remote;
+
+        // Enters enable range → audio turns on.
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioEnabled('remote-1', true))
+            .called(1);
+
+        // Drifts to 5 — inside the hysteresis band (> enable 4, ≤ disable 5).
+        // Audio must NOT cut: no further enable/disable calls.
+        remote.position = Vector2(320, 160); // 5 away
+        manager.update(0.016);
+        verifyNever(
+            () => mockLiveKit.setParticipantAudioEnabled('remote-1', false));
+
+        // Drifts past the disable threshold (6 > 5) → audio cuts.
+        remote.position = Vector2(352, 160); // 6 away
+        manager.update(0.016);
+        verify(() => mockLiveKit.setParticipantAudioEnabled('remote-1', false))
+            .called(1);
       });
     });
 

--- a/test/map_editor/map_sync_service_test.dart
+++ b/test/map_editor/map_sync_service_test.dart
@@ -620,6 +620,9 @@ class FakeLiveKitService implements LiveKitService {
   Future<void> publishAvatar(Avatar avatar) async {}
 
   @override
+  Future<void> publishDfProximity({required bool near}) async {}
+
+  @override
   Future<DataChannelMessage?> sendPing({
     Duration timeout = const Duration(seconds: 5),
   }) async =>

--- a/test/map_editor/map_sync_service_test.dart
+++ b/test/map_editor/map_sync_service_test.dart
@@ -690,7 +690,7 @@ class FakeLiveKitService implements LiveKitService {
   void setParticipantAudioEnabled(String identity, bool enabled) {}
 
   @override
-  void setParticipantAudioVolume(String identity, double volume) {}
+  bool setParticipantAudioVolume(String identity, double volume) => true;
 
   @override
   final ValueNotifier<bool> dreamfinderSilenced = ValueNotifier<bool>(false);

--- a/test/map_editor/map_sync_service_test.dart
+++ b/test/map_editor/map_sync_service_test.dart
@@ -690,6 +690,9 @@ class FakeLiveKitService implements LiveKitService {
   void setParticipantAudioEnabled(String identity, bool enabled) {}
 
   @override
+  void setParticipantAudioVolume(String identity, double volume) {}
+
+  @override
   final ValueNotifier<bool> dreamfinderSilenced = ValueNotifier<bool>(false);
 
   @override


### PR DESCRIPTION
## Why
Robin intermittently couldn't hear Nick until she moved/clicked. 

## Root cause
`BubbleManager`'s proximity loop — which drives per-peer audio enable/disable — was behind an early-return that only fired when the **local** player changed grid cell. Remote players (and Dreamfinder, which wanders autonomously) move too, so a peer could walk back into range and stay inaudible until the local player happened to move. Removed the guard → recompute every frame (cheap at meetup scale; bubble transitions stay guarded, audio toggles are no-ops when unchanged).

## Also in here
- **Audio hysteresis**: enable ≤4, disable >5 (was a hard cut at ≤2 while bubbles showed at ≤5 — a 3-square see-but-can't-hear dead zone + boundary flapping).
- **DF proximity signal**: client publishes `df-proximity {near}` on enter/exit of DF's range so the deployed bot can gate whose speech DF answers (near OR named). New `LiveKitTopic.dfProximity` + `LiveKitService.publishDfProximity`.
- Tests: stale-recompute + hysteresis regression test; LiveKitService fakes updated.

## Status
Held for review (per request) — green locally (`flutter analyze` + `flutter test` on touched files). Pairs with embodied-dreamfinder#58 (already deployed). A **distance fade** (Web Audio GainNode) is coming as a follow-up commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)