### PR TITLE
fix(auth,prompt): enable prompt Cast button on input + Google web sign-in via GIS renderButton

### DIFF
--- a/lib/auth/auth_gate.dart
+++ b/lib/auth/auth_gate.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:tech_world/auth/auth_service.dart';
+import 'package:tech_world/auth/google_sign_in_button.dart';
 import 'package:tech_world/utils/locator.dart';
 
 /// Helper class to show a snackbar using the passed context.
@@ -59,6 +60,10 @@ class _AuthGateState extends State<AuthGate> {
   Timer? _errorTimer;
   StreamSubscription<GoogleSignInAuthenticationEvent>? _googleAuthSubscription;
 
+  /// Web only: true once `GoogleSignIn.instance.initialize()` has completed,
+  /// so the GIS `renderButton()` has an initialized client to talk to.
+  bool _googleWebReady = false;
+
   AuthMode mode = AuthMode.login;
 
   bool isLoading = false;
@@ -76,6 +81,7 @@ class _AuthGateState extends State<AuthGate> {
   Future<void> _initGoogleSignInWeb() async {
     try {
       await locate<AuthService>().initializeGoogleSignIn();
+      if (mounted) setState(() => _googleWebReady = true);
 
       _googleAuthSubscription = GoogleSignIn.instance.authenticationEvents
           .listen((GoogleSignInAuthenticationEvent event) async {
@@ -297,27 +303,9 @@ class _AuthGateState extends State<AuthGate> {
                                 onPressed: _signInWithApple,
                               ),
                             ),
-                          // Show Google Sign In on all platforms
+                          // Show Google Sign In on all platforms.
                           if (_isApplePlatform) const SizedBox(height: 10),
-                          SizedBox(
-                            width: double.infinity,
-                            height: 50,
-                            child: ElevatedButton.icon(
-                              onPressed: isLoading ? null : _signInWithGoogle,
-                              icon: Image.network(
-                                'https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg',
-                                height: 24,
-                                width: 24,
-                                errorBuilder: (context, error, stackTrace) =>
-                                    const Icon(Icons.g_mobiledata),
-                              ),
-                              label: const Text('Sign in with Google'),
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.white,
-                                foregroundColor: Colors.black87,
-                              ),
-                            ),
-                          ),
+                          _buildGoogleSignIn(),
                         ],
                       ),
                     ),
@@ -440,31 +428,56 @@ class _AuthGateState extends State<AuthGate> {
     }
   }
 
-  Future<void> _signInWithGoogle() async {
+  /// Google sign-in entry point.
+  ///
+  /// Web: render the official Google Identity Services button — GIS only
+  /// starts the interactive flow from its own button, and the resulting
+  /// auth event is handled by the `authenticationEvents` listener wired in
+  /// [_initGoogleSignInWeb]. The button is shown only once
+  /// [GoogleSignIn.initialize] has completed ([_googleWebReady]); until then
+  /// a disabled placeholder holds the slot so layout doesn't jump.
+  ///
+  /// Native: a custom button wired to [_signInWithGoogle] →
+  /// `GoogleSignIn.instance.authenticate()`.
+  Widget _buildGoogleSignIn() {
     if (kIsWeb) {
-      // On web, attemptLightweightAuthentication triggers One Tap / FedCM.
-      // The result arrives via authenticationEvents (subscribed in initState).
-      // Returns null on web when the prompt is shown asynchronously.
-      try {
-        await locate<AuthService>().initializeGoogleSignIn();
-        final account =
-            GoogleSignIn.instance.attemptLightweightAuthentication();
-        if (account != null) {
-          final user = await account;
-          if (user != null) {
-            await locate<AuthService>()
-                .handleGoogleAuthEvent(user.authentication);
-            return;
-          }
-        }
-        // null means One Tap prompt shown — result via authenticationEvents
-      } catch (e) {
-        debugPrint('Google sign-in (web) trigger error: $e');
-        _setError('Google sign-in failed. Please try again.');
+      if (!_googleWebReady) {
+        return const SizedBox(
+          height: 50,
+          child: Center(child: CircularProgressIndicator.adaptive()),
+        );
       }
-      return;
+      // GIS renders its own fixed-size button; centre it to match the column.
+      return SizedBox(
+        height: 50,
+        child: Center(child: googleSignInButton()),
+      );
     }
 
+    return SizedBox(
+      width: double.infinity,
+      height: 50,
+      child: ElevatedButton.icon(
+        onPressed: isLoading ? null : _signInWithGoogle,
+        icon: Image.network(
+          'https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg',
+          height: 24,
+          width: 24,
+          errorBuilder: (context, error, stackTrace) =>
+              const Icon(Icons.g_mobiledata),
+        ),
+        label: const Text('Sign in with Google'),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black87,
+        ),
+      ),
+    );
+  }
+
+  /// Native-only Google sign-in. On web the GIS-rendered button drives the
+  /// flow instead (see [_buildGoogleSignIn]).
+  Future<void> _signInWithGoogle() async {
     setIsLoading();
     try {
       await locate<AuthService>().signInWithGoogle();

--- a/lib/auth/auth_gate.dart
+++ b/lib/auth/auth_gate.dart
@@ -38,6 +38,14 @@ class ScaffoldSnackbar {
 /// The mode of the current auth session, either [AuthMode.login] or [AuthMode.register].
 enum AuthMode { login, register }
 
+/// Lifecycle of web-only Google Identity Services initialization.
+///
+/// `initializing` → spinner, `ready` → render the GIS button, `failed` → a
+/// retry control. A one-way "ready" bool would strand the user on a permanent
+/// spinner if `initialize()` ever threw — the `failed` state makes that
+/// recoverable.
+enum _GoogleWebStatus { initializing, ready, failed }
+
 extension on AuthMode {
   String get label => this == AuthMode.login ? 'Sign in' : 'Register';
 }
@@ -60,9 +68,9 @@ class _AuthGateState extends State<AuthGate> {
   Timer? _errorTimer;
   StreamSubscription<GoogleSignInAuthenticationEvent>? _googleAuthSubscription;
 
-  /// Web only: true once `GoogleSignIn.instance.initialize()` has completed,
-  /// so the GIS `renderButton()` has an initialized client to talk to.
-  bool _googleWebReady = false;
+  /// Web only: where GIS initialization currently stands. Drives which
+  /// Google control [_buildGoogleSignIn] renders.
+  _GoogleWebStatus _googleWebStatus = _GoogleWebStatus.initializing;
 
   AuthMode mode = AuthMode.login;
 
@@ -79,9 +87,17 @@ class _AuthGateState extends State<AuthGate> {
   /// On web, initialize GoogleSignIn and listen for auth events from
   /// the GIS renderButton (since programmatic authenticate() is unsupported).
   Future<void> _initGoogleSignInWeb() async {
+    // Cancel any prior subscription so a retry after a partial init can't leak.
+    await _googleAuthSubscription?.cancel();
+    _googleAuthSubscription = null;
+    if (mounted) {
+      setState(() => _googleWebStatus = _GoogleWebStatus.initializing);
+    }
     try {
       await locate<AuthService>().initializeGoogleSignIn();
-      if (mounted) setState(() => _googleWebReady = true);
+      if (mounted) {
+        setState(() => _googleWebStatus = _GoogleWebStatus.ready);
+      }
 
       _googleAuthSubscription = GoogleSignIn.instance.authenticationEvents
           .listen((GoogleSignInAuthenticationEvent event) async {
@@ -100,6 +116,9 @@ class _AuthGateState extends State<AuthGate> {
       });
     } catch (e) {
       debugPrint('Google Sign-In init failed: $e');
+      if (mounted) {
+        setState(() => _googleWebStatus = _GoogleWebStatus.failed);
+      }
     }
   }
 
@@ -441,16 +460,23 @@ class _AuthGateState extends State<AuthGate> {
   /// `GoogleSignIn.instance.authenticate()`.
   Widget _buildGoogleSignIn() {
     if (kIsWeb) {
-      if (!_googleWebReady) {
-        return const SizedBox(
-          height: 50,
-          child: Center(child: CircularProgressIndicator.adaptive()),
-        );
-      }
-      // GIS renders its own fixed-size button; centre it to match the column.
       return SizedBox(
         height: 50,
-        child: Center(child: googleSignInButton()),
+        child: Center(
+          child: switch (_googleWebStatus) {
+            _GoogleWebStatus.initializing =>
+              const CircularProgressIndicator.adaptive(),
+            // GIS renders its own fixed-size button.
+            _GoogleWebStatus.ready => googleSignInButton(),
+            // Init failed — don't strand the user on a spinner. Offer a retry;
+            // email/password sign-in above remains fully usable meanwhile.
+            _GoogleWebStatus.failed => TextButton.icon(
+                onPressed: _initGoogleSignInWeb,
+                icon: const Icon(Icons.refresh, size: 18),
+                label: const Text('Google sign-in unavailable — retry'),
+              ),
+          },
+        ),
       );
     }
 

--- a/lib/auth/google_sign_in_button.dart
+++ b/lib/auth/google_sign_in_button.dart
@@ -1,0 +1,22 @@
+/// Platform-conditional Google sign-in button.
+///
+/// On **web**, Google Identity Services (GIS) only initiates the interactive
+/// sign-in flow from a Google-rendered button — a custom `ElevatedButton`
+/// calling `attemptLightweightAuthentication()` can at best surface One Tap,
+/// which is routinely suppressed (dismissal cooldown, third-party-cookie /
+/// FedCM restrictions). So on web we render the official GIS button via
+/// `google_sign_in_web`'s `renderButton()`; clicking it emits a
+/// `GoogleSignInAuthenticationEvent` on the `authenticationEvents` stream,
+/// which the auth gate already listens to and forwards to Firebase.
+///
+/// On **native** (iOS / macOS / Android) the GIS button doesn't exist; the
+/// stub renders nothing and the auth gate shows its own button wired to
+/// `GoogleSignIn.instance.authenticate()`.
+///
+/// The conditional export keeps the web-only `google_sign_in_web/web_only.dart`
+/// import out of native (and VM test) builds — same idiom as the other
+/// `dart.library.js_interop` seams in this repo.
+library;
+
+export 'google_sign_in_button_stub.dart'
+    if (dart.library.js_interop) 'google_sign_in_button_web.dart';

--- a/lib/auth/google_sign_in_button_stub.dart
+++ b/lib/auth/google_sign_in_button_stub.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+
+/// Native stub — there is no GIS-rendered button off the web, so render
+/// nothing. Native platforms use the auth gate's own button + the
+/// `GoogleSignIn.instance.authenticate()` flow instead.
+///
+/// Returns an empty box; callers only mount this when `kIsWeb` is true.
+Widget googleSignInButton() => const SizedBox.shrink();

--- a/lib/auth/google_sign_in_button_web.dart
+++ b/lib/auth/google_sign_in_button_web.dart
@@ -1,6 +1,23 @@
 import 'package:flutter/widgets.dart';
 import 'package:google_sign_in_web/web_only.dart' as web;
 
+/// A single, stable button configuration.
+///
+/// `renderButton()` (google_sign_in_web 1.1.3) builds its GIS `<div>` inside a
+/// `FutureBuilder` keyed on `configuration.hashCode`, and
+/// `GSIButtonConfiguration` uses *identity* hashCode. Allocating a fresh config
+/// on every `build()` would therefore hand the FutureBuilder a new key each
+/// time and remount the GIS button on every unrelated `AuthGate` rebuild
+/// (error banner animating, `isLoading` toggling, …). Hoisting one instance
+/// keeps the key — and the rendered button — stable.
+final _config = web.GSIButtonConfiguration(
+  theme: web.GSIButtonTheme.outline,
+  size: web.GSIButtonSize.large,
+  text: web.GSIButtonText.signinWith,
+  shape: web.GSIButtonShape.rectangular,
+  logoAlignment: web.GSIButtonLogoAlignment.left,
+);
+
 /// Renders the official Google Identity Services sign-in button.
 ///
 /// `GoogleSignIn.instance.initialize(...)` must have been called first (the
@@ -8,12 +25,4 @@ import 'package:google_sign_in_web/web_only.dart' as web;
 /// `authenticationEvents`). When the user clicks the button, GIS runs its
 /// popup / FedCM flow and emits a `GoogleSignInAuthenticationEvent` on
 /// `authenticationEvents`, which the auth gate forwards to Firebase.
-Widget googleSignInButton() => web.renderButton(
-      configuration: web.GSIButtonConfiguration(
-        theme: web.GSIButtonTheme.outline,
-        size: web.GSIButtonSize.large,
-        text: web.GSIButtonText.signinWith,
-        shape: web.GSIButtonShape.rectangular,
-        logoAlignment: web.GSIButtonLogoAlignment.left,
-      ),
-    );
+Widget googleSignInButton() => web.renderButton(configuration: _config);

--- a/lib/auth/google_sign_in_button_web.dart
+++ b/lib/auth/google_sign_in_button_web.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/widgets.dart';
+import 'package:google_sign_in_web/web_only.dart' as web;
+
+/// Renders the official Google Identity Services sign-in button.
+///
+/// `GoogleSignIn.instance.initialize(...)` must have been called first (the
+/// auth gate does this in `initState` before subscribing to
+/// `authenticationEvents`). When the user clicks the button, GIS runs its
+/// popup / FedCM flow and emits a `GoogleSignInAuthenticationEvent` on
+/// `authenticationEvents`, which the auth gate forwards to Firebase.
+Widget googleSignInButton() => web.renderButton(
+      configuration: web.GSIButtonConfiguration(
+        theme: web.GSIButtonTheme.outline,
+        size: web.GSIButtonSize.large,
+        text: web.GSIButtonText.signinWith,
+        shape: web.GSIButtonShape.rectangular,
+        logoAlignment: web.GSIButtonLogoAlignment.left,
+      ),
+    );

--- a/lib/prompt/prompt_challenge_panel.dart
+++ b/lib/prompt/prompt_challenge_panel.dart
@@ -245,6 +245,17 @@ class _PromptChallengePanelState extends State<PromptChallengePanel> {
   }
 
   Widget _buildCastButton() {
+    // Rebuild whenever either the spell slots change (regen / consume) or the
+    // prompt text changes — both feed `canCast`. Without listening to the
+    // controller the button would stay disabled forever, because nothing else
+    // rebuilds this subtree as the player types.
+    return ListenableBuilder(
+      listenable: Listenable.merge([widget.spellSlotService, _promptController]),
+      builder: (context, _) => _castButton(),
+    );
+  }
+
+  Widget _castButton() {
     final canCast = widget.spellSlotService.canCast &&
         _promptController.text.trim().isNotEmpty &&
         !_isCasting;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -627,7 +627,7 @@ packages:
     source: hosted
     version: "3.1.0"
   google_sign_in_web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_sign_in_web
       sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
@@ -891,10 +891,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1360,26 +1360,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   tiled:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,9 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   crypto: ^3.0.6
   google_sign_in: ^7.2.0
+  # Web-only: direct dependency so we can import web_only.dart's renderButton()
+  # (the GIS-rendered button is the only way to start interactive sign-in on web).
+  google_sign_in_web: ^1.1.3
   firebase_storage: ^13.0.5
   file_picker: ^8.0.0
   image_picker: ^1.1.2

--- a/test/prompt/prompt_challenge_panel_test.dart
+++ b/test/prompt/prompt_challenge_panel_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/prompt/cast_result.dart';
+import 'package:tech_world/prompt/predefined_prompt_challenges.dart';
+import 'package:tech_world/prompt/prompt_challenge_panel.dart';
+import 'package:tech_world/prompt/spell_slot_service.dart';
+
+void main() {
+  group('PromptChallengePanel cast button', () {
+    late SpellSlotService slots;
+
+    setUp(() {
+      slots = SpellSlotService(maxSlots: 3);
+    });
+
+    // Dispose inside each test body (not tearDown): draining slots starts a
+    // regen Timer.periodic, and flutter_test verifies no Timer is pending when
+    // the test body completes — which happens *before* tearDown runs.
+
+    Future<void> pumpPanel(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PromptChallengePanel(
+              challenge: fizzBuzzIncantation,
+              spellSlotService: slots,
+              onCast: (prompt) async =>
+                  ('a response', const CastResult(feedback: CastFeedback.resonates)),
+              onClose: () {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    /// Finds the "Cast Spell" ElevatedButton and reports whether it's enabled.
+    bool castButtonEnabled(WidgetTester tester) {
+      final button = tester.widget<ElevatedButton>(
+        find.ancestor(
+          of: find.text('Cast Spell'),
+          matching: find.byType(ElevatedButton),
+        ),
+      );
+      return button.onPressed != null;
+    }
+
+    testWidgets('is disabled when the prompt is empty', (tester) async {
+      await pumpPanel(tester);
+      expect(castButtonEnabled(tester), isFalse);
+      slots.dispose();
+    });
+
+    testWidgets('becomes enabled as soon as the player types a prompt',
+        (tester) async {
+      // Regression test: previously the button was gated on the prompt text
+      // but nothing rebuilt the widget on text change, so it stayed disabled
+      // forever — "you can't click submit".
+      await pumpPanel(tester);
+      expect(castButtonEnabled(tester), isFalse);
+
+      await tester.enterText(find.byType(TextField), 'Make it print FizzBuzz');
+      await tester.pump();
+
+      expect(castButtonEnabled(tester), isTrue,
+          reason: 'typing a prompt should enable the Cast Spell button');
+      slots.dispose();
+    });
+
+    testWidgets('is disabled when there are no spell slots, even with text',
+        (tester) async {
+      slots.consumeSlot(cost: 3); // drain all 3 slots
+      await pumpPanel(tester);
+
+      await tester.enterText(find.byType(TextField), 'Some incantation');
+      await tester.pump();
+
+      expect(castButtonEnabled(tester), isFalse,
+          reason: 'no slots means no cast regardless of prompt text');
+      slots.dispose(); // cancels the regen timer started by consumeSlot
+    });
+  });
+}

--- a/test/prompt/prompt_challenge_panel_test.dart
+++ b/test/prompt/prompt_challenge_panel_test.dart
@@ -68,15 +68,21 @@ void main() {
 
     testWidgets('is disabled when there are no spell slots, even with text',
         (tester) async {
-      slots.consumeSlot(cost: 3); // drain all 3 slots
-      await pumpPanel(tester);
+      slots.consumeSlot(cost: 3); // drain all 3 slots → starts a regen timer
+      // try/finally so a failed expectation still cancels the regen timer,
+      // otherwise a pending Timer would cascade into a noisier failure that
+      // masks the real assertion.
+      try {
+        await pumpPanel(tester);
 
-      await tester.enterText(find.byType(TextField), 'Some incantation');
-      await tester.pump();
+        await tester.enterText(find.byType(TextField), 'Some incantation');
+        await tester.pump();
 
-      expect(castButtonEnabled(tester), isFalse,
-          reason: 'no slots means no cast regardless of prompt text');
-      slots.dispose(); // cancels the regen timer started by consumeSlot
+        expect(castButtonEnabled(tester), isFalse,
+            reason: 'no slots means no cast regardless of prompt text');
+      } finally {
+        slots.dispose(); // cancels the regen timer started by consumeSlot
+      }
     });
   });
 }


### PR DESCRIPTION
Two user-facing bugs reported from a live session ("Google sign in still doesn't work, also the prompt challenges are broken, you can't click submit").

## Bug 1 — Prompt challenges: "can't click submit" ✅ verified
The **Cast Spell** button (`prompt_challenge_panel.dart`) gates `onPressed` on `_promptController.text.trim().isNotEmpty`, but **nothing rebuilt the subtree as the player typed** — the `TextField` had no `onChanged`→`setState`, and the button (unlike the spell-slot orbs) wasn't wrapped in a `ListenableBuilder`. So `canCast` was evaluated once at first build (empty text → disabled) and never re-evaluated. The button stayed greyed out forever.

**Fix:** wrap the button in `ListenableBuilder(Listenable.merge([spellSlotService, _promptController]))` so it re-evaluates on either a slot change or a keystroke.

**Test:** new ATDD widget test (`prompt_challenge_panel_test.dart`), proven RED→GREEN — covers empty prompt (disabled), typed prompt (enabled), and no-slots-with-text (disabled).

## Bug 2 — Google sign-in on web ⚠️ needs browser verification
The web path called `GoogleSignIn.instance.attemptLightweightAuthentication()` — the **silent** re-auth method that can only surface One Tap/FedCM (routinely suppressed by dismissal cooldown / third-party-cookie / FedCM restrictions). It is **not** a click-driven interactive sign-in. The code's own comments already said to use `renderButton`.

**Fix:** conditional-import helper (`google_sign_in_button.dart` + `_stub`/`_web`, matching the repo's `dart.library.js_interop` idiom) exposes `google_sign_in_web`'s `renderButton()` on web (SizedBox stub on native). The auth gate renders the official GIS button on web; clicking it emits an event on the `authenticationEvents` stream the gate **already** forwards to Firebase (`handleGoogleAuthEvent` → `_completeGoogleSignIn`, unchanged). Native keeps its custom button + `GoogleSignIn.authenticate()`. The GIS button renders only once `initialize()` completes (`_googleWebReady`).

The Firebase credential-exchange / token path is **unchanged** — only the client-side trigger UI changed.

## Verification
- ✅ `flutter test` — all 1877 pass
- ✅ `flutter analyze --fatal-infos lib/ test/` — clean
- ⚠️ **Web Google sign-in needs a real browser load to verify end-to-end** (full OAuth needs Google creds — last gate is a human signing in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)