### PR TITLE
fix(audio): proximity-gate Dreamfinder audio symmetric with its video bubble (#594 dir A)

### DIFF
--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -266,6 +266,12 @@ class BubbleManager {
               dreamfinderIdentity, bubble, 'dreamfinder-entered-proximity');
         }
       }
+
+      // Proximity-gate DF audio symmetric with its video bubble — you hear
+      // Dreamfinder only when close enough for the bubble to work. Runs every
+      // frame (near OR far) so the gate is the single per-frame owner of DF
+      // audio state. See [_updateDreamfinderAudio].
+      _updateDreamfinderAudio(dfDistance);
     }
 
     // Check proximity to all bot characters.
@@ -751,6 +757,31 @@ class BubbleManager {
   @visibleForTesting
   void debugUpdateDreamfinderProximity(int? dfDistance) =>
       _updateDreamfinderProximity(dfDistance);
+
+  /// Proximity-gate Dreamfinder's audio symmetric with its video bubble: you
+  /// hear DF only when within audio range, via the same [_updateParticipantAudio]
+  /// gate (enable/disable + hysteresis + volume fade) used for remote players.
+  ///
+  /// The manual silence button ([LiveKitService.dreamfinderSilenced]) ALWAYS
+  /// wins: when silenced we feed the gate a beyond-range distance so DF stays
+  /// muted regardless of how close you stand. Because this runs every frame,
+  /// the gate is the single per-frame writer of DF audio state and
+  /// self-reconciles with the manual path (which also disables the track
+  /// directly) within one frame.
+  void _updateDreamfinderAudio(int dfDistance) {
+    final silenced = _liveKitService?.dreamfinderSilenced.value ?? false;
+    _updateParticipantAudio(
+      dreamfinderIdentity,
+      silenced ? _audioDisableThreshold + 1 : dfDistance,
+    );
+  }
+
+  /// Test seam for [_updateDreamfinderAudio] — see
+  /// [debugUpdateDreamfinderProximity] for why the real loop can't be driven
+  /// without a fully-constructed [DreamfinderComponent].
+  @visibleForTesting
+  void debugUpdateDreamfinderAudio(int dfDistance) =>
+      _updateDreamfinderAudio(dfDistance);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Private — physics and rendering

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -533,9 +533,16 @@ class LiveKitService {
     dreamfinderSilenced.value = silenced;
     final room = _room;
     if (room == null) return;
+    // Silencing mutes DF immediately. UN-silencing does NOT force-enable here:
+    // the per-frame proximity gate (BubbleManager._updateDreamfinderAudio) is
+    // the SOLE enabler, so DF only becomes audible again when you are actually
+    // in range. Force-enabling on un-silence re-enabled DF for every matching
+    // participant regardless of distance, leaving it audible from anywhere
+    // until the next near→far transition (the #594 / PR #485 leak).
+    if (!silenced) return;
     for (final participant in room.remoteParticipants.values) {
       if (isDreamfinderIdentity(participant.identity)) {
-        setParticipantAudioEnabled(participant.identity, !silenced);
+        setParticipantAudioEnabled(participant.identity, false);
       }
     }
   }

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flame/components.dart';
+import 'package:flutter/foundation.dart' show ValueNotifier;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -418,6 +419,75 @@ void main() {
         verify(() => mockLiveKit.publishDfProximity(near: true)).called(1);
         manager.clear();
         verify(() => mockLiveKit.publishDfProximity(near: false)).called(1);
+      });
+    });
+
+    group('Dreamfinder audio gate', () {
+      late BubbleManager manager;
+      late MockLiveKitService mockLiveKit;
+      late ValueNotifier<bool> silenced;
+
+      setUp(() {
+        mockLiveKit = MockLiveKitService();
+        silenced = ValueNotifier<bool>(false);
+        when(() => mockLiveKit.dreamfinderSilenced).thenReturn(silenced);
+        when(() => mockLiveKit.setParticipantAudioEnabled(any(), any()))
+            .thenReturn(null);
+        when(() => mockLiveKit.setParticipantAudioVolume(any(), any()))
+            .thenReturn(true);
+        when(() => mockLiveKit.getParticipant(any())).thenReturn(null);
+        manager = BubbleManager(
+          localPlayer: PlayerComponent(
+            position: Vector2(160, 160),
+            id: 'local-user',
+            displayName: 'Local',
+          ),
+          addComponent: (_) {},
+          remotePlayers: {},
+          bots: {},
+        );
+        manager.setLiveKitService(mockLiveKit);
+      });
+
+      tearDown(() => silenced.dispose());
+
+      test('enables DF audio when within the enable threshold', () {
+        manager.debugUpdateDreamfinderAudio(2); // ≤ enable (4)
+        verify(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true)).called(1);
+      });
+
+      test('does not enable DF audio beyond the enable threshold', () {
+        manager.debugUpdateDreamfinderAudio(6); // > disable (5)
+        verifyNever(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true));
+      });
+
+      test('cuts DF audio once past the disable threshold', () {
+        manager.debugUpdateDreamfinderAudio(2); // within → on
+        verify(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true)).called(1);
+        manager.debugUpdateDreamfinderAudio(6); // past disable → off
+        verify(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, false)).called(1);
+      });
+
+      test('manual silence vetoes proximity — DF stays muted even when close',
+          () {
+        silenced.value = true;
+        manager.debugUpdateDreamfinderAudio(1); // as close as possible
+        verifyNever(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true));
+      });
+
+      test('silencing while near forces DF audio off', () {
+        manager.debugUpdateDreamfinderAudio(1); // on
+        verify(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true)).called(1);
+        silenced.value = true;
+        manager.debugUpdateDreamfinderAudio(1); // near but silenced → off
+        verify(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, false)).called(1);
       });
     });
 

--- a/test/flame/bubble_manager_test.dart
+++ b/test/flame/bubble_manager_test.dart
@@ -489,6 +489,21 @@ void main() {
         verify(() => mockLiveKit.setParticipantAudioEnabled(
             manager.dreamfinderIdentity, false)).called(1);
       });
+
+      // Regression for the cage-match #594/#485 leak: the gate is the SOLE
+      // enabler. Even right after un-silencing, if you're out of range the gate
+      // must not enable DF — so an un-silence-while-far can never leave DF
+      // audible (the silence button no longer force-enables; see
+      // LiveKitService.setDreamfinderSilenced).
+      test('does not enable DF when far, even immediately after un-silencing',
+          () {
+        silenced.value = true;
+        manager.debugUpdateDreamfinderAudio(1); // silenced + near → stays off
+        silenced.value = false; // un-silence...
+        manager.debugUpdateDreamfinderAudio(6); // ...but now out of range
+        verifyNever(() => mockLiveKit.setParticipantAudioEnabled(
+            manager.dreamfinderIdentity, true));
+      });
     });
 
     group('clear', () {


### PR DESCRIPTION
You could hear Dreamfinder from **anywhere** in the room. The proximity audio gate (`_updateParticipantAudio` — enable/disable + hysteresis + volume fade) was called for every remote player but **never for DF** — the DF block only gated the *visual bubble* by distance, leaving audio ungated (only the manual silence button could stop it). That's direction A of #594.

## Fix
`_updateDreamfinderAudio(dfDistance)`, called every frame in the DF proximity block, runs DF through the same gate as remote players. **Manual silence always wins:** when `dreamfinderSilenced` is true we feed the gate a beyond-range distance so DF stays muted regardless of distance. Because the gate runs every frame it's the single per-frame writer of DF audio state and self-reconciles with the silence button's direct track-write within one frame.

**Truth table:** DF audio ON iff (within audio range AND not manually silenced).

Direction B (DF hears you only when close, via `publishDfProximity`) was already in place — this completes the symmetry.

## Tests (ATDD, RED→GREEN)
5 tests via a `debugUpdateDreamfinderAudio` seam (mirrors the existing `debugUpdateDreamfinderProximity`): enable within threshold, no-enable beyond, cut past disable, **silence vetoes proximity**, **silencing-while-near forces off**. Verified the silence tests fail when the veto is removed. Full suite 1891 green; analyze clean.

## Verification gate
The experiential proof is live — walk away from DF, hear the voice cut out. Needs a real DF session to confirm (repro-blocked locally; this is what harness #3 is for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)