### PR TITLE
feat(audio): disable DF audio on subscribe + Room seam for silence tests (#20)

### DIFF
--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -102,17 +102,17 @@ class LiveKitService {
     @visibleForTesting Future<String?> Function()? tokenRetriever,
     @visibleForTesting void Function(String identity)? silenceParticipantAudio,
     @visibleForTesting Iterable<String> Function()? remoteParticipantIdentities,
-  })  : _tokenRetriever = tokenRetriever,
-        // Seams for unit-testing the DF-silence logic without faking the
-        // LiveKit SDK. Default to the real server-side disable / the live
-        // `Room`'s participant set. The late-init dance is because the default
-        // closures capture `this`.
-        _silenceParticipantAudio = silenceParticipantAudio,
-        _remoteParticipantIdentities = remoteParticipantIdentities {
-    _silenceParticipantAudio ??=
-        (identity) => setParticipantAudioEnabled(identity, false);
-    _remoteParticipantIdentities ??=
-        () => _room?.remoteParticipants.values.map((p) => p.identity) ?? const [];
+  }) : _tokenRetriever = tokenRetriever {
+    // Seams for unit-testing the DF-silence logic without faking the LiveKit
+    // SDK. Default to the real server-side disable / the live `Room`'s
+    // participant set. Assigned in the constructor body (not the initializer
+    // list) because the default closures capture `this` — which lets the fields
+    // be `late final` rather than nullable, encoding "set once, never null".
+    _silenceParticipantAudio = silenceParticipantAudio ??
+        ((identity) => setParticipantAudioEnabled(identity, false));
+    _remoteParticipantIdentities = remoteParticipantIdentities ??
+        (() =>
+            _room?.remoteParticipants.values.map((p) => p.identity) ?? const []);
   }
 
   final String userId;
@@ -124,13 +124,13 @@ class LiveKitService {
   ///
   /// Injectable so tests can observe which identities get silenced without a
   /// live LiveKit `Room`. Defaults to [setParticipantAudioEnabled]`(id, false)`.
-  void Function(String identity)? _silenceParticipantAudio;
+  late final void Function(String identity) _silenceParticipantAudio;
 
   /// Source of the current remote participant identities.
   ///
   /// Injectable so [setDreamfinderSilenced]'s iteration is unit-testable
   /// without a live `Room`. Defaults to reading `_room.remoteParticipants`.
-  Iterable<String> Function()? _remoteParticipantIdentities;
+  late final Iterable<String> Function() _remoteParticipantIdentities;
 
   // LiveKit server URL
   static const _serverUrl = 'wss://livekit.imagineering.cc';
@@ -567,9 +567,9 @@ class LiveKitService {
   void setDreamfinderSilenced(bool silenced) {
     dreamfinderSilenced.value = silenced;
     if (!silenced) return;
-    for (final identity in _remoteParticipantIdentities!()) {
+    for (final identity in _remoteParticipantIdentities()) {
       if (isDreamfinderIdentity(identity)) {
-        _silenceParticipantAudio!(identity);
+        _silenceParticipantAudio(identity);
       }
     }
   }
@@ -603,7 +603,7 @@ class LiveKitService {
     required String identity,
   }) {
     if (isAudioTrack && isDreamfinderIdentity(identity)) {
-      _silenceParticipantAudio!(identity);
+      _silenceParticipantAudio(identity);
     }
   }
 

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -101,14 +101,18 @@ class LiveKitService {
     this.roomName = 'tech-world',
     @visibleForTesting Future<String?> Function()? tokenRetriever,
     @visibleForTesting void Function(String identity)? silenceParticipantAudio,
+    @visibleForTesting Iterable<String> Function()? remoteParticipantIdentities,
   })  : _tokenRetriever = tokenRetriever,
-        // Seam for unit-testing the silence-on-subscribe logic without faking
-        // the LiveKit SDK. Defaults to the real server-side audio disable
-        // (see [applyDreamfinderSilenceOnSubscribe]). The late-init dance is
-        // because the default closure captures `this`.
-        _silenceParticipantAudio = silenceParticipantAudio {
+        // Seams for unit-testing the DF-silence logic without faking the
+        // LiveKit SDK. Default to the real server-side disable / the live
+        // `Room`'s participant set. The late-init dance is because the default
+        // closures capture `this`.
+        _silenceParticipantAudio = silenceParticipantAudio,
+        _remoteParticipantIdentities = remoteParticipantIdentities {
     _silenceParticipantAudio ??=
         (identity) => setParticipantAudioEnabled(identity, false);
+    _remoteParticipantIdentities ??=
+        () => _room?.remoteParticipants.values.map((p) => p.identity) ?? const [];
   }
 
   final String userId;
@@ -121,6 +125,12 @@ class LiveKitService {
   /// Injectable so tests can observe which identities get silenced without a
   /// live LiveKit `Room`. Defaults to [setParticipantAudioEnabled]`(id, false)`.
   void Function(String identity)? _silenceParticipantAudio;
+
+  /// Source of the current remote participant identities.
+  ///
+  /// Injectable so [setDreamfinderSilenced]'s iteration is unit-testable
+  /// without a live `Room`. Defaults to reading `_room.remoteParticipants`.
+  Iterable<String> Function()? _remoteParticipantIdentities;
 
   // LiveKit server URL
   static const _serverUrl = 'wss://livekit.imagineering.cc';
@@ -542,48 +552,57 @@ class LiveKitService {
 
   /// Toggle whether we receive Dreamfinder's audio.
   ///
-  /// Iterates current remote participants and disables/enables audio on
-  /// any matching [isDreamfinderIdentity]. Late-joining DF tracks are
-  /// caught in the [TrackSubscribedEvent] handler.
+  /// Silencing mutes every current DF participant immediately (server-side
+  /// disable via [_silenceParticipantAudio]). UN-silencing does NOT force-enable
+  /// here: the per-frame proximity gate ([BubbleManager._updateDreamfinderAudio])
+  /// is the SOLE enabler, so DF only becomes audible again when you are actually
+  /// in range. Force-enabling on un-silence re-enabled DF for every matching
+  /// participant regardless of distance, leaving it audible from anywhere until
+  /// the next near→far transition (the #594 / PR #485 leak).
+  ///
+  /// Iterates participants via the [_remoteParticipantIdentities] seam (live
+  /// `Room` in production), so the disable-all / never-enable behaviour is
+  /// unit-testable without a live SDK. Late-joining DF tracks are caught in the
+  /// [TrackSubscribedEvent] handler.
   void setDreamfinderSilenced(bool silenced) {
     dreamfinderSilenced.value = silenced;
-    final room = _room;
-    if (room == null) return;
-    // Silencing mutes DF immediately. UN-silencing does NOT force-enable here:
-    // the per-frame proximity gate (BubbleManager._updateDreamfinderAudio) is
-    // the SOLE enabler, so DF only becomes audible again when you are actually
-    // in range. Force-enabling on un-silence re-enabled DF for every matching
-    // participant regardless of distance, leaving it audible from anywhere
-    // until the next near→far transition (the #594 / PR #485 leak).
     if (!silenced) return;
-    for (final participant in room.remoteParticipants.values) {
-      if (isDreamfinderIdentity(participant.identity)) {
-        setParticipantAudioEnabled(participant.identity, false);
+    for (final identity in _remoteParticipantIdentities!()) {
+      if (isDreamfinderIdentity(identity)) {
+        _silenceParticipantAudio!(identity);
       }
     }
   }
 
-  /// Silence a freshly-subscribed track if it belongs to a silenced
-  /// Dreamfinder.
+  /// Disable a freshly-subscribed Dreamfinder audio track.
   ///
-  /// Called from the [TrackSubscribedEvent] handler. A DF audio track that
-  /// arrives *after* the local player has toggled silence (DF joining late, or
-  /// republishing its track) would otherwise leak audio — [setDreamfinderSilenced]
-  /// only iterates the participants present at toggle time. Disabling on
-  /// subscribe closes that gap.
+  /// Called from the [TrackSubscribedEvent] handler. DF audio is proximity-
+  /// gated: the per-frame gate ([BubbleManager._updateDreamfinderAudio]) is the
+  /// SOLE enabler and only forwards DF audio when the local player is in range.
+  /// But that gate doesn't run until DF's `DreamfinderComponent` exists, which
+  /// is deferred to `gameReady` (it needs the path component). Between a DF
+  /// audio track subscribing and the gate's first tick, an *unsilenced* fresh
+  /// track would be audible from anywhere on the map — the deferred-component
+  /// window flagged in the PR #485 cage match.
+  ///
+  /// Fix: disable DF audio on subscribe **unconditionally** (not just when
+  /// silenced). The gate then enables it on the first near-frame. This is
+  /// consistent with the gate's own initial state — its `_audioEnabledParticipants`
+  /// set starts empty (it assumes the track begins disabled), so disabling on
+  /// subscribe simply makes the SFU match that assumption; the gate's
+  /// `shouldEnable = !hasAudio && near` transition still fires correctly when
+  /// the player walks into range. (Previously this only disabled when already
+  /// silenced, leaving the unsilenced-late-join window open.)
   ///
   /// Only fires for audio tracks ([isAudioTrack] true) from a Dreamfinder
-  /// [identity] while [dreamfinderSilenced] is set. Extracted from the inline
-  /// handler so the branch logic is unit-testable via the
-  /// `silenceParticipantAudio` seam without a live `Room`.
+  /// [identity]. Extracted from the inline handler so the branch logic is
+  /// unit-testable via the `silenceParticipantAudio` seam without a live `Room`.
   @visibleForTesting
-  void applyDreamfinderSilenceOnSubscribe({
+  void disableDreamfinderAudioOnSubscribe({
     required bool isAudioTrack,
     required String identity,
   }) {
-    if (isAudioTrack &&
-        dreamfinderSilenced.value &&
-        isDreamfinderIdentity(identity)) {
+    if (isAudioTrack && isDreamfinderIdentity(identity)) {
       _silenceParticipantAudio!(identity);
     }
   }
@@ -936,10 +955,11 @@ class LiveKitService {
           _trackSubscribedController
               .add((event.participant, event.track as VideoTrack));
         }
-        // Apply Dreamfinder silence to a freshly-subscribed DF audio track.
-        // Without this, toggling silence before DF joins (or while DF is
-        // republishing) would leave the new track audible.
-        applyDreamfinderSilenceOnSubscribe(
+        // Disable a freshly-subscribed DF audio track unconditionally; the
+        // per-frame proximity gate re-enables it when the local player is in
+        // range. Closes the deferred-component window where a fresh DF track
+        // would be audible from anywhere before the gate's first tick.
+        disableDreamfinderAudioOnSubscribe(
           isAudioTrack: event.track is AudioTrack,
           identity: event.participant.identity,
         );

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -100,12 +100,27 @@ class LiveKitService {
     required this.displayName,
     this.roomName = 'tech-world',
     @visibleForTesting Future<String?> Function()? tokenRetriever,
-  }) : _tokenRetriever = tokenRetriever;
+    @visibleForTesting void Function(String identity)? silenceParticipantAudio,
+  })  : _tokenRetriever = tokenRetriever,
+        // Seam for unit-testing the silence-on-subscribe logic without faking
+        // the LiveKit SDK. Defaults to the real server-side audio disable
+        // (see [applyDreamfinderSilenceOnSubscribe]). The late-init dance is
+        // because the default closure captures `this`.
+        _silenceParticipantAudio = silenceParticipantAudio {
+    _silenceParticipantAudio ??=
+        (identity) => setParticipantAudioEnabled(identity, false);
+  }
 
   final String userId;
   final String displayName;
   final String roomName;
   final Future<String?> Function()? _tokenRetriever;
+
+  /// Effect invoked to silence a participant's audio (server-side disable).
+  ///
+  /// Injectable so tests can observe which identities get silenced without a
+  /// live LiveKit `Room`. Defaults to [setParticipantAudioEnabled]`(id, false)`.
+  void Function(String identity)? _silenceParticipantAudio;
 
   // LiveKit server URL
   static const _serverUrl = 'wss://livekit.imagineering.cc';
@@ -548,6 +563,31 @@ class LiveKitService {
     }
   }
 
+  /// Silence a freshly-subscribed track if it belongs to a silenced
+  /// Dreamfinder.
+  ///
+  /// Called from the [TrackSubscribedEvent] handler. A DF audio track that
+  /// arrives *after* the local player has toggled silence (DF joining late, or
+  /// republishing its track) would otherwise leak audio — [setDreamfinderSilenced]
+  /// only iterates the participants present at toggle time. Disabling on
+  /// subscribe closes that gap.
+  ///
+  /// Only fires for audio tracks ([isAudioTrack] true) from a Dreamfinder
+  /// [identity] while [dreamfinderSilenced] is set. Extracted from the inline
+  /// handler so the branch logic is unit-testable via the
+  /// `silenceParticipantAudio` seam without a live `Room`.
+  @visibleForTesting
+  void applyDreamfinderSilenceOnSubscribe({
+    required bool isAudioTrack,
+    required String identity,
+  }) {
+    if (isAudioTrack &&
+        dreamfinderSilenced.value &&
+        isDreamfinderIdentity(identity)) {
+      _silenceParticipantAudio!(identity);
+    }
+  }
+
   /// Get a participant by their identity (userId)
   Participant? getParticipant(String identity) {
     if (_room == null) return null;
@@ -899,11 +939,10 @@ class LiveKitService {
         // Apply Dreamfinder silence to a freshly-subscribed DF audio track.
         // Without this, toggling silence before DF joins (or while DF is
         // republishing) would leave the new track audible.
-        if (event.track is AudioTrack &&
-            dreamfinderSilenced.value &&
-            isDreamfinderIdentity(event.participant.identity)) {
-          setParticipantAudioEnabled(event.participant.identity, false);
-        }
+        applyDreamfinderSilenceOnSubscribe(
+          isAudioTrack: event.track is AudioTrack,
+          identity: event.participant.identity,
+        );
       })
       ..on<TrackUnsubscribedEvent>((event) {
         _log.fine(

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -1186,4 +1186,9 @@ class FakeLiveKitService implements LiveKitService {
 
   @override
   void stopPositionHeartbeat() {}
+
+  // Catch-all so growth of the LiveKitService interface doesn't break this
+  // hand-rolled fake (mirrors the other fakes' noSuchMethod pattern).
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/test/livekit/livekit_service_df_silence_test.dart
+++ b/test/livekit/livekit_service_df_silence_test.dart
@@ -26,8 +26,8 @@ void main() {
       );
     });
 
-    tearDown(() {
-      service.dispose();
+    tearDown(() async {
+      await service.dispose();
     });
 
     // The disable-on-subscribe path is now UNCONDITIONAL for DF audio (the
@@ -109,8 +109,8 @@ void main() {
       );
     });
 
-    tearDown(() {
-      service.dispose();
+    tearDown(() async {
+      await service.dispose();
     });
 
     test('silence(true) disables every DF participant in the room', () {

--- a/test/livekit/livekit_service_df_silence_test.dart
+++ b/test/livekit/livekit_service_df_silence_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+
+/// Tests for the Dreamfinder silence-on-subscribe seam.
+///
+/// LiveKitService holds a concrete LiveKit `Room`, which makes the
+/// silence-on-track-subscribe logic awkward to drive end-to-end. The
+/// `silenceParticipantAudio` DI seam ([LiveKitService.new]'s
+/// `@visibleForTesting` callback) lets us observe whether the disable effect
+/// fires for a freshly-subscribed track without faking the whole SDK — we
+/// drive the decision through [LiveKitService.applyDreamfinderSilenceOnSubscribe]
+/// and assert on the recorded identities.
+void main() {
+  group('Dreamfinder silence on track-subscribe', () {
+    late List<String> silencedIdentities;
+    late LiveKitService service;
+
+    setUp(() {
+      silencedIdentities = [];
+      service = LiveKitService(
+        userId: 'user-1',
+        displayName: 'User 1',
+        silenceParticipantAudio: silencedIdentities.add,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('silenced + DF audio track subscribed -> disables that track', () {
+      service.dreamfinderSilenced.value = true;
+
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: true,
+        identity: 'agent-abc123',
+      );
+
+      expect(silencedIdentities, ['agent-abc123']);
+    });
+
+    test('silenced + bot-dreamfinder identity -> disables that track', () {
+      service.dreamfinderSilenced.value = true;
+
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: true,
+        identity: 'bot-dreamfinder',
+      );
+
+      expect(silencedIdentities, ['bot-dreamfinder']);
+    });
+
+    test('NOT silenced + DF audio track subscribed -> does NOT disable', () {
+      // dreamfinderSilenced defaults to false.
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: true,
+        identity: 'agent-abc123',
+      );
+
+      expect(silencedIdentities, isEmpty);
+    });
+
+    test('silenced + DF VIDEO track subscribed -> does NOT disable audio', () {
+      service.dreamfinderSilenced.value = true;
+
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: false,
+        identity: 'agent-abc123',
+      );
+
+      expect(silencedIdentities, isEmpty);
+    });
+
+    test('silenced + non-DF audio track subscribed -> does NOT disable', () {
+      service.dreamfinderSilenced.value = true;
+
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: true,
+        identity: 'bot-claude',
+      );
+
+      expect(silencedIdentities, isEmpty);
+    });
+
+    test('silenced + human peer audio track subscribed -> does NOT disable',
+        () {
+      service.dreamfinderSilenced.value = true;
+
+      service.applyDreamfinderSilenceOnSubscribe(
+        isAudioTrack: true,
+        identity: 'user-2',
+      );
+
+      expect(silencedIdentities, isEmpty);
+    });
+  });
+}

--- a/test/livekit/livekit_service_df_silence_test.dart
+++ b/test/livekit/livekit_service_df_silence_test.dart
@@ -1,17 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 
-/// Tests for the Dreamfinder silence-on-subscribe seam.
+/// Tests for the Dreamfinder audio silence/disable seams.
 ///
-/// LiveKitService holds a concrete LiveKit `Room`, which makes the
-/// silence-on-track-subscribe logic awkward to drive end-to-end. The
-/// `silenceParticipantAudio` DI seam ([LiveKitService.new]'s
-/// `@visibleForTesting` callback) lets us observe whether the disable effect
-/// fires for a freshly-subscribed track without faking the whole SDK — we
-/// drive the decision through [LiveKitService.applyDreamfinderSilenceOnSubscribe]
-/// and assert on the recorded identities.
+/// LiveKitService holds a concrete LiveKit `Room`, which makes both the
+/// silence-on-track-subscribe logic and `setDreamfinderSilenced`'s participant
+/// iteration awkward to drive end-to-end. Two `@visibleForTesting` seams on
+/// [LiveKitService.new] let us observe the effects without faking the SDK:
+///   - `silenceParticipantAudio` — records which identities get disabled.
+///   - `remoteParticipantIdentities` — supplies the "room roster" so
+///     [LiveKitService.setDreamfinderSilenced] can be exercised offline.
+///
+/// Mirrors the `@visibleForTesting` + fake DI pattern in room_session_test.dart.
 void main() {
-  group('Dreamfinder silence on track-subscribe', () {
+  group('Dreamfinder audio disable on track-subscribe', () {
     late List<String> silencedIdentities;
     late LiveKitService service;
 
@@ -28,10 +30,14 @@ void main() {
       service.dispose();
     });
 
-    test('silenced + DF audio track subscribed -> disables that track', () {
-      service.dreamfinderSilenced.value = true;
+    // The disable-on-subscribe path is now UNCONDITIONAL for DF audio (the
+    // proximity gate re-enables when near) — closing the deferred-component
+    // window where a fresh DF track was audible from anywhere before the gate's
+    // first tick. So it fires whether or not the silence toggle is set.
 
-      service.applyDreamfinderSilenceOnSubscribe(
+    test('DF audio track subscribed while NOT silenced -> disables it', () {
+      // dreamfinderSilenced defaults to false; we still disable on subscribe.
+      service.disableDreamfinderAudioOnSubscribe(
         isAudioTrack: true,
         identity: 'agent-abc123',
       );
@@ -39,10 +45,19 @@ void main() {
       expect(silencedIdentities, ['agent-abc123']);
     });
 
-    test('silenced + bot-dreamfinder identity -> disables that track', () {
+    test('DF audio track subscribed while silenced -> disables it', () {
       service.dreamfinderSilenced.value = true;
 
-      service.applyDreamfinderSilenceOnSubscribe(
+      service.disableDreamfinderAudioOnSubscribe(
+        isAudioTrack: true,
+        identity: 'agent-abc123',
+      );
+
+      expect(silencedIdentities, ['agent-abc123']);
+    });
+
+    test('bot-dreamfinder audio track subscribed -> disables it', () {
+      service.disableDreamfinderAudioOnSubscribe(
         isAudioTrack: true,
         identity: 'bot-dreamfinder',
       );
@@ -50,20 +65,8 @@ void main() {
       expect(silencedIdentities, ['bot-dreamfinder']);
     });
 
-    test('NOT silenced + DF audio track subscribed -> does NOT disable', () {
-      // dreamfinderSilenced defaults to false.
-      service.applyDreamfinderSilenceOnSubscribe(
-        isAudioTrack: true,
-        identity: 'agent-abc123',
-      );
-
-      expect(silencedIdentities, isEmpty);
-    });
-
-    test('silenced + DF VIDEO track subscribed -> does NOT disable audio', () {
-      service.dreamfinderSilenced.value = true;
-
-      service.applyDreamfinderSilenceOnSubscribe(
+    test('DF VIDEO track subscribed -> does NOT disable audio', () {
+      service.disableDreamfinderAudioOnSubscribe(
         isAudioTrack: false,
         identity: 'agent-abc123',
       );
@@ -71,10 +74,8 @@ void main() {
       expect(silencedIdentities, isEmpty);
     });
 
-    test('silenced + non-DF audio track subscribed -> does NOT disable', () {
-      service.dreamfinderSilenced.value = true;
-
-      service.applyDreamfinderSilenceOnSubscribe(
+    test('non-DF bot audio track subscribed -> does NOT disable', () {
+      service.disableDreamfinderAudioOnSubscribe(
         isAudioTrack: true,
         identity: 'bot-claude',
       );
@@ -82,16 +83,78 @@ void main() {
       expect(silencedIdentities, isEmpty);
     });
 
-    test('silenced + human peer audio track subscribed -> does NOT disable',
-        () {
-      service.dreamfinderSilenced.value = true;
-
-      service.applyDreamfinderSilenceOnSubscribe(
+    test('human peer audio track subscribed -> does NOT disable', () {
+      service.disableDreamfinderAudioOnSubscribe(
         isAudioTrack: true,
         identity: 'user-2',
       );
 
       expect(silencedIdentities, isEmpty);
+    });
+  });
+
+  group('setDreamfinderSilenced (Room-seam)', () {
+    late List<String> silencedIdentities;
+    late List<String> roster;
+    late LiveKitService service;
+
+    setUp(() {
+      silencedIdentities = [];
+      roster = [];
+      service = LiveKitService(
+        userId: 'user-1',
+        displayName: 'User 1',
+        silenceParticipantAudio: silencedIdentities.add,
+        remoteParticipantIdentities: () => roster,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('silence(true) disables every DF participant in the room', () {
+      roster = ['user-2', 'bot-claude', 'bot-dreamfinder', 'agent-xyz'];
+
+      service.setDreamfinderSilenced(true);
+
+      expect(service.dreamfinderSilenced.value, isTrue);
+      // Both DF identities (bot-dreamfinder + agent-*) disabled; nobody else.
+      expect(silencedIdentities, ['bot-dreamfinder', 'agent-xyz']);
+    });
+
+    test('silence(true) with no DF in room disables nobody', () {
+      roster = ['user-2', 'bot-claude'];
+
+      service.setDreamfinderSilenced(true);
+
+      expect(service.dreamfinderSilenced.value, isTrue);
+      expect(silencedIdentities, isEmpty);
+    });
+
+    test('silence(false) does NOT enable/touch any participant (#485 leak)', () {
+      roster = ['bot-dreamfinder', 'agent-xyz'];
+
+      service.setDreamfinderSilenced(false);
+
+      // The proximity gate is the sole enabler; un-silence must not force
+      // anything on (or off) here.
+      expect(service.dreamfinderSilenced.value, isFalse);
+      expect(silencedIdentities, isEmpty);
+    });
+
+    test('silence(true) then silence(false) leaves the gate as sole enabler',
+        () {
+      roster = ['bot-dreamfinder'];
+
+      service.setDreamfinderSilenced(true);
+      expect(silencedIdentities, ['bot-dreamfinder']);
+
+      service.setDreamfinderSilenced(false);
+      // No further disable AND no enable — the false branch is a pure no-op
+      // beyond flipping the notifier.
+      expect(silencedIdentities, ['bot-dreamfinder']);
+      expect(service.dreamfinderSilenced.value, isFalse);
     });
   });
 }

--- a/test/map_editor/map_sync_service_test.dart
+++ b/test/map_editor/map_sync_service_test.dart
@@ -724,4 +724,9 @@ class FakeLiveKitService implements LiveKitService {
   Future<void> dispose() async {
     _dataReceivedController.close();
   }
+
+  // Catch-all so growth of the LiveKitService interface doesn't break this
+  // hand-rolled fake (mirrors the other fakes' noSuchMethod pattern).
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }


### PR DESCRIPTION
Addresses both MEDIUM follow-ups deferred from the PR #485 cage match (Carnot), tracked as task #20.

## (1) Deferred-component window — disable DF audio on subscribe unconditionally

DF audio is proximity-gated: `BubbleManager._updateDreamfinderAudio` is the **sole enabler** and only forwards DF audio when the local player is in range. But that gate doesn't run until DF's `DreamfinderComponent` exists, which is deferred to `gameReady` (it needs the path component). Previously the `TrackSubscribedEvent` handler only disabled a fresh DF audio track when **already silenced** — so between a DF track subscribing and the gate's first tick, an *unsilenced* fresh track was **audible from anywhere on the map**.

**Fix:** disable DF audio on subscribe **unconditionally** (`applyDreamfinderSilenceOnSubscribe` → `disableDreamfinderAudioOnSubscribe`, dropped the `dreamfinderSilenced.value` condition). The gate re-enables on the first near-frame.

**Why this is safe (latch analysis):** the gate tracks state in `_audioEnabledParticipants`, which **starts empty** — it already assumes the track begins disabled. Disabling on subscribe just makes the SFU match that assumption, so the gate's `shouldEnable = !hasAudio && near` transition still fires correctly when the player walks into range. No latch conflict.

**agent-* timing:** `dreamfinderIdentity` is reconciled to the real `agent-*` identity at participant-join (`tech_world.dart:527/537`), and the audio track belongs to that same participant — so the gate keys off the matching identity. Disabling an `agent-*` track on subscribe just means it's muted until the gate's first near-tick, which is the intended proximity-gated behaviour.

## (2) Room seam for `setDreamfinderSilenced`

It read `_room` directly, so its participant iteration wasn't unit-testable. Added a `@visibleForTesting remoteParticipantIdentities` provider (defaults to reading `_room.remoteParticipants`) alongside the existing `silenceParticipantAudio` seam. `setDreamfinderSilenced` now iterates via the seam.

**Production behaviour unchanged:** the default provider returns `const []` when `_room` is null, so the old null-guard early-return is preserved as a harmless no-op.

## Tests — `test/livekit/livekit_service_df_silence_test.dart` (10 cases)

**Saw-it-fail-then-pass confirmed** for both behaviour changes (reverted impl to the old conditional → the unconditional-disable cases failed; restored → green).

Disable-on-subscribe:
- DF audio (not silenced) → disables ✅ · DF audio (silenced) → disables ✅ · `bot-dreamfinder` → disables ✅
- DF **video** → no-op ✅ · non-DF bot (`bot-claude`) → no-op ✅ · human peer → no-op ✅

`setDreamfinderSilenced`:
- `(true)` disables every DF identity in the roster (`bot-dreamfinder` + `agent-*`), nobody else ✅
- `(true)` with no DF in room → nobody disabled ✅
- `(false)` touches nobody — the #485 un-silence-no-force-enable leak, now pinned at the **service** level (was only pinned at the gate level + read-verified on the button) ✅
- `(true)`→`(false)` → no further disable, no enable ✅

Also adds a catch-all `noSuchMethod` to two hand-rolled `implements LiveKitService` fakes (`chat_service_test`, `map_sync_service_test`) that predate the `extends Mock` convention — adding any public interface member broke them.

## Verification
- `flutter analyze --fatal-infos` — clean over `lib/` + `test/` (only reported issues are inside the gitignored `build/macos/SourcePackages/` firebase bundled tests; CI never sees them).
- `flutter test` — all **1945** pass.

## Notes
- **Last gate (live):** the deferred-component-window fix is repro-blocked on a live DF session (harness #3) — Nick walking up to a freshly-joined DF and confirming audio fades in correctly. Logic + unit coverage are in; the experiential gate is not yet cleared.
- **Review tier: cage-match** — touches LiveKit track lifecycle + the DF-silence trust/state surface with prior leak history (#485/#594), and (1) is a genuine behaviour change.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)