### PR TITLE
feat(chat): @mentions that light up the world

### DIFF
--- a/lib/chat/chat_message.dart
+++ b/lib/chat/chat_message.dart
@@ -135,18 +135,32 @@ class ChatMessage {
   /// derived from this list, so a spoofed payload can name victims but cannot
   /// forge who sent the mention.
   ///
-  /// **Bounded at the trust boundary.** A hostile peer could otherwise put an
-  /// arbitrarily large list on the wire and drive unbounded pulse state /
-  /// beacons / arcs on every other client. The list is truncated to
-  /// [maxMentions] *distinct* UIDs (dedup-then-cap) so the resource cost of a
-  /// single chat message is bounded regardless of payload size — a real group
-  /// chat never names more than a handful of people at once.
+  /// **Bounded at the trust boundary, on both axes.** A hostile peer could
+  /// otherwise put a large list on the wire and drive unbounded pulse state /
+  /// beacons / arcs on every other client. Two independent caps:
+  /// - [maxMentions] distinct UIDs in the OUTPUT (dedup-then-cap), so all
+  ///   downstream world work is bounded; and
+  /// - [_maxMentionsScan] elements SCANNED from the input, so even a pathological
+  ///   payload (e.g. a million duplicate strings before 16 distinct ones) costs
+  ///   O(1) here rather than O(n). (The LiveKit data channel already size-bounds
+  ///   the payload, so this is belt-and-suspenders, but it makes the bound
+  ///   explicit instead of relying on the transport.)
+  ///
+  /// A real group chat never names more than a handful of people at once.
   static const int maxMentions = 16;
+
+  /// Hard cap on how many list elements [parseMentions] inspects, independent of
+  /// how many turn out to be distinct valid UIDs. Comfortably above
+  /// [maxMentions] so legitimate (deduped) payloads are never truncated, while a
+  /// hostile duplicate-stuffed list can't force an unbounded scan.
+  static const int _maxMentionsScan = 256;
 
   static List<String> parseMentions(Object? value) {
     if (value is! List) return const [];
     final seen = <String>{};
+    var scanned = 0;
     for (final element in value) {
+      if (scanned++ >= _maxMentionsScan) break;
       if (element is String) seen.add(element);
       if (seen.length >= maxMentions) break;
     }

--- a/lib/chat/chat_message.dart
+++ b/lib/chat/chat_message.dart
@@ -120,6 +120,25 @@ class ChatMessage {
     return (messageId: messageId, text: text, senderName: senderName);
   }
 
+  /// Defensively parse the `mentions` field from an untrusted wire payload.
+  ///
+  /// The structured `mentions` list — UIDs of named players — is the trust
+  /// anchor for the world-mention beacon (NOT the inline `@Name` text, which is
+  /// display-only and spoofable). It is parsed with the same discipline as
+  /// [_parseParticipants]: a non-`List` value (legacy / corrupt / hostile
+  /// payload) yields an empty list rather than throwing, and non-`String`
+  /// elements are skipped via [Iterable.whereType]. The whole field drops to
+  /// empty on malformed input — there is never a half-parsed mention list.
+  ///
+  /// Never throws — a single bad payload must not tear down the chat stream.
+  /// The *mentioner's* UID is always the transport-verified `senderId`, never
+  /// derived from this list, so a spoofed payload can name victims but cannot
+  /// forge who sent the mention.
+  static List<String> parseMentions(Object? value) {
+    if (value is! List) return const [];
+    return value.whereType<String>().toList();
+  }
+
   /// Defensively parse the `participants` field.
   ///
   /// A non-`List` value (legacy / corrupt doc) yields `null`; non-`String`

--- a/lib/chat/chat_message.dart
+++ b/lib/chat/chat_message.dart
@@ -134,9 +134,23 @@ class ChatMessage {
   /// The *mentioner's* UID is always the transport-verified `senderId`, never
   /// derived from this list, so a spoofed payload can name victims but cannot
   /// forge who sent the mention.
+  ///
+  /// **Bounded at the trust boundary.** A hostile peer could otherwise put an
+  /// arbitrarily large list on the wire and drive unbounded pulse state /
+  /// beacons / arcs on every other client. The list is truncated to
+  /// [maxMentions] *distinct* UIDs (dedup-then-cap) so the resource cost of a
+  /// single chat message is bounded regardless of payload size — a real group
+  /// chat never names more than a handful of people at once.
+  static const int maxMentions = 16;
+
   static List<String> parseMentions(Object? value) {
     if (value is! List) return const [];
-    return value.whereType<String>().toList();
+    final seen = <String>{};
+    for (final element in value) {
+      if (element is String) seen.add(element);
+      if (seen.length >= maxMentions) break;
+    }
+    return seen.toList();
   }
 
   /// Defensively parse the `participants` field.

--- a/lib/chat/chat_panel.dart
+++ b/lib/chat/chat_panel.dart
@@ -6,6 +6,8 @@ import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/chat/conversation_list_tile.dart';
 import 'package:tech_world/chat/dm_thread_view.dart';
+import 'package:tech_world/chat/mention_composer.dart';
+import 'package:tech_world/chat/mention_text.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/services/stt_service.dart';
 
@@ -18,12 +20,17 @@ class ChatPanel extends StatefulWidget {
     this.onCollapse,
     this.initialDmPeerId,
     this.onDmPeerConsumed,
+    this.onOpened,
     super.key,
   });
 
   final ChatService chatService;
   final LiveKitService liveKitService;
   final VoidCallback? onCollapse;
+
+  /// Called when the panel is shown — the user "seeing" chat. Used to
+  /// acknowledge any `@mention` of the local user (stops their public pulse).
+  final VoidCallback? onOpened;
 
   /// When set, the panel auto-opens a DM thread with this peer on first build.
   final String? initialDmPeerId;
@@ -52,6 +59,18 @@ class _ChatPanelState extends State<ChatPanel>
   /// composing a fresh message. Mirrors `DmThreadView._replyTarget`.
   ChatMessage? _replyTarget;
 
+  /// UIDs the user picked from the @-mention picker while composing, paired with
+  /// the display name inserted. Filtered at send time to those whose `@Name`
+  /// token still survives in the text (see [MentionComposer.survivingUids]).
+  final List<MentionCandidate> _pickedMentions = [];
+
+  /// Candidates currently shown in the @-mention picker, or empty when the
+  /// picker is closed (no active `@query`).
+  List<MentionCandidate> _mentionMatches = const [];
+
+  /// The active `@query`'s anchor index, so a pick knows what span to replace.
+  int? _mentionAtIndex;
+
   // Clawd's orange color
   static const clawdOrange = Color(0xFFD97757);
 
@@ -59,6 +78,13 @@ class _ChatPanelState extends State<ChatPanel>
   void initState() {
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
+
+    // The panel mounting means the user is now looking at chat — acknowledge
+    // any mention of them. Deferred to after the first frame so the ack fires
+    // outside build.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onOpened?.call();
+    });
 
     // If an initial DM peer was requested, switch to DMs tab.
     if (widget.initialDmPeerId != null) {
@@ -133,10 +159,24 @@ class _ChatPanelState extends State<ChatPanel>
     final text = _textController.text.trim();
     if (text.isEmpty) return;
 
+    // Keep only the picked mentions whose `@Name` token still survives in the
+    // text (the user may have deleted one after inserting it). The structured
+    // UID list is the trust anchor; the inline `@Name` text is display-only.
+    final mentions = MentionComposer.survivingUids(text, _pickedMentions);
+
     final replyTarget = _replyTarget;
-    widget.chatService.sendMessage(text, replyTo: replyTarget);
+    widget.chatService.sendMessage(
+      text,
+      replyTo: replyTarget,
+      mentions: mentions,
+    );
     _textController.clear();
-    setState(() => _replyTarget = null);
+    setState(() {
+      _replyTarget = null;
+      _pickedMentions.clear();
+      _mentionMatches = const [];
+      _mentionAtIndex = null;
+    });
     _focusNode.requestFocus();
 
     // Scroll to bottom after message is added
@@ -158,6 +198,67 @@ class _ChatPanelState extends State<ChatPanel>
 
   void _cancelReply() {
     setState(() => _replyTarget = null);
+  }
+
+  /// Everyone you can `@mention`: the remote participants plus yourself. The UID
+  /// (LiveKit identity) is the trust anchor; the display name is cosmetic.
+  List<MentionCandidate> _mentionCandidates() {
+    final candidates = <MentionCandidate>[
+      MentionCandidate(
+        uid: widget.liveKitService.userId,
+        displayName: widget.liveKitService.displayName,
+      ),
+    ];
+    for (final p in widget.liveKitService.remoteParticipants.values) {
+      final name = (p.name.isNotEmpty ? p.name : p.identity);
+      candidates.add(MentionCandidate(uid: p.identity, displayName: name));
+    }
+    return candidates;
+  }
+
+  /// React to composer edits: open/refresh the @-mention picker when the cursor
+  /// sits in an unfinished `@token`, otherwise close it.
+  void _onComposerChanged() {
+    final value = _textController.value;
+    final cursor = value.selection.baseOffset;
+    final active = MentionComposer.activeQuery(value.text, cursor);
+    if (active == null) {
+      if (_mentionMatches.isNotEmpty || _mentionAtIndex != null) {
+        setState(() {
+          _mentionMatches = const [];
+          _mentionAtIndex = null;
+        });
+      }
+      return;
+    }
+    final matches = MentionComposer.filter(_mentionCandidates(), active.query);
+    setState(() {
+      _mentionMatches = matches;
+      _mentionAtIndex = active.atIndex;
+    });
+  }
+
+  /// Insert the chosen mention, recording its UID for the structured wire list.
+  void _pickMention(MentionCandidate chosen) {
+    final atIndex = _mentionAtIndex;
+    if (atIndex == null) return;
+    final cursor = _textController.selection.baseOffset;
+    final ins = MentionComposer.insert(
+      text: _textController.text,
+      atIndex: atIndex,
+      cursor: cursor < 0 ? _textController.text.length : cursor,
+      chosen: chosen,
+    );
+    _textController.value = TextEditingValue(
+      text: ins.text,
+      selection: TextSelection.collapsed(offset: ins.cursor),
+    );
+    setState(() {
+      _pickedMentions.add(chosen);
+      _mentionMatches = const [];
+      _mentionAtIndex = null;
+    });
+    _focusNode.requestFocus();
   }
 
   @override
@@ -363,6 +464,14 @@ class _ChatPanelState extends State<ChatPanel>
             return Column(
               mainAxisSize: MainAxisSize.min,
               children: [
+                // @-mention picker — a filterable list of room participants
+                // shown while the cursor is inside an unfinished `@token`.
+                if (_mentionMatches.isNotEmpty)
+                  _MentionPicker(
+                    candidates: _mentionMatches,
+                    onPick: _pickMention,
+                    accentColor: clawdOrange,
+                  ),
                 // "Replying to X" banner while composing a reply.
                 if (replyTarget != null)
                   _ReplyComposingBanner(
@@ -426,6 +535,7 @@ class _ChatPanelState extends State<ChatPanel>
                               vertical: 12,
                             ),
                           ),
+                          onChanged: (_) => _onComposerChanged(),
                           onSubmitted:
                               isAbsent ? null : (_) => _sendMessage(),
                         ),
@@ -736,11 +846,20 @@ class _MessageBubble extends StatelessWidget {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (message.isReply) _QuotedMessage(message: message),
-                        Text(
-                          message.text,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 14,
+                        Text.rich(
+                          TextSpan(
+                            children: buildMentionSpans(
+                              message.text,
+                              baseStyle: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 14,
+                              ),
+                              mentionStyle: const TextStyle(
+                                color: clawdOrange,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
                           ),
                         ),
                       ],
@@ -889,6 +1008,77 @@ class _ReplyComposingBanner extends StatelessWidget {
             constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// A compact, filterable list of room participants shown above the composer
+/// while the user is typing an `@mention`. Tapping a row inserts `@Name` and
+/// records the participant's UID (see `_ChatPanelState._pickMention`).
+class _MentionPicker extends StatelessWidget {
+  const _MentionPicker({
+    required this.candidates,
+    required this.onPick,
+    required this.accentColor,
+  });
+
+  final List<MentionCandidate> candidates;
+  final ValueChanged<MentionCandidate> onPick;
+  final Color accentColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 180),
+      decoration: const BoxDecoration(
+        color: Color(0xFF252525),
+        border: Border(top: BorderSide(color: Color(0xFF3D3D3D))),
+      ),
+      child: ListView.builder(
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        itemCount: candidates.length,
+        itemBuilder: (context, i) {
+          final c = candidates[i];
+          final initial =
+              c.displayName.isNotEmpty ? c.displayName[0].toUpperCase() : '?';
+          return InkWell(
+            onTap: () => onPick(c),
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    radius: 12,
+                    backgroundColor: accentColor.withValues(alpha: 0.25),
+                    child: Text(
+                      initial,
+                      style: TextStyle(
+                        color: accentColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      c.displayName,
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Text('@',
+                      style: TextStyle(
+                          color: accentColor.withValues(alpha: 0.6),
+                          fontSize: 14)),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -342,6 +342,20 @@ class ChatService {
         replyToSenderName: reply.senderName,
       ));
       _messagesController.add(List.from(_messages));
+
+      // Structured @mention list — the trust anchor for the world beacon.
+      // Parsed defensively (malformed → empty, no throw). The mentioner is the
+      // TRANSPORT-verified sender, never the payload's self-reported senderId —
+      // a peer can name victims but cannot forge who sent the mention. Only
+      // dispatch when at least one valid UID survives parsing.
+      final mentionedUids = ChatMessage.parseMentions(json['mentions']);
+      if (mentionedUids.isNotEmpty) {
+        dispatch([PlayersMentioned(
+          mentionedUids: mentionedUids,
+          mentionerUid: message.senderId ?? 'unknown',
+          messageId: ownId ?? _nextMessageId(),
+        )]);
+      }
     }
 
     // Complete pending message if this is a response to one of ours
@@ -439,6 +453,7 @@ class ChatService {
     String text, {
     Map<String, dynamic>? metadata,
     ChatMessage? replyTo,
+    List<String> mentions = const [],
   }) async {
     if (text.trim().isEmpty) return null;
 
@@ -508,6 +523,10 @@ class ChatService {
       if (replyToMessageId != null) 'replyToMessageId': replyToMessageId,
       if (replyText != null) 'replyToText': replyText,
       if (replySenderName != null) 'replyToSenderName': replySenderName,
+      // The structured @mention UID list — the trust anchor for the world
+      // beacon. Inline `@Name` text in [text] is display-only. Omitted entirely
+      // when empty so a plain message carries no `mentions` key.
+      if (mentions.isNotEmpty) 'mentions': mentions,
       'timestamp': DateTime.now().toIso8601String(),
       if (safeMetadata != null) ...Map.fromEntries(safeMetadata),
     };

--- a/lib/chat/chat_service.dart
+++ b/lib/chat/chat_service.dart
@@ -546,6 +546,20 @@ class ChatService {
       payload: payload,
     ));
 
+    // Dispatch the mention locally too — LiveKit does NOT loop our own
+    // publishData back to us, so without this the SENDER never witnesses their
+    // own mention bloom/arc (breaking "witnessed by everyone"). Mirrors the
+    // optimistic local-add of the chat message above. The mentioner is our own
+    // authenticated identity. The receive path dispatches the same event for
+    // remote participants, so both routes funnel through one world consumer.
+    if (mentions.isNotEmpty) {
+      dispatch([PlayersMentioned(
+        mentionedUids: mentions,
+        mentionerUid: _liveKitService.userId,
+        messageId: messageId,
+      )]);
+    }
+
     _log.info('Sent message (id=$messageId, len=${text.length})');
     final challengeWire = metadata?['challengeId'] as String?;
     dispatch([GroupMessageSent(

--- a/lib/chat/dm_thread_view.dart
+++ b/lib/chat/dm_thread_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tech_world/chat/chat_message.dart';
+import 'package:tech_world/chat/mention_text.dart';
 import 'package:tech_world/chat/chat_service.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
@@ -396,11 +397,20 @@ class _DmBubble extends StatelessWidget {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (message.isReply) _QuotedMessage(message: message),
-                        Text(
-                          message.text,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 14,
+                        Text.rich(
+                          TextSpan(
+                            children: buildMentionSpans(
+                              message.text,
+                              baseStyle: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 14,
+                              ),
+                              mentionStyle: const TextStyle(
+                                color: _clawdOrange,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
                           ),
                         ),
                       ],

--- a/lib/chat/mention_composer.dart
+++ b/lib/chat/mention_composer.dart
@@ -1,0 +1,135 @@
+/// A participant that can be `@mention`ed: a stable UID plus a display name.
+class MentionCandidate {
+  const MentionCandidate({required this.uid, required this.displayName});
+
+  /// The participant's stable UID (LiveKit identity) — the trust anchor that
+  /// rides the wire as the structured `mentions` entry.
+  final String uid;
+
+  /// The cosmetic name shown in the picker and inserted as `@displayName`.
+  final String displayName;
+}
+
+/// The result of inserting a chosen mention into the composer text: the new
+/// text, the new cursor offset, and the UID to record so the structured
+/// `mentions` list can be built at send time.
+class MentionInsertion {
+  const MentionInsertion({
+    required this.text,
+    required this.cursor,
+    required this.uid,
+  });
+
+  final String text;
+  final int cursor;
+  final String uid;
+}
+
+/// Pure text logic for the `@mention` picker, factored out of the widget so it
+/// is unit-testable without a running Flutter tree.
+///
+/// The widget feeds it the current text + cursor; it reports the active `@`
+/// query (if the cursor sits in an unfinished `@token`), filters candidates,
+/// and computes the text/cursor edit when a candidate is chosen. The display
+/// name is inserted as `@Name `; the UID is reported separately so the caller
+/// can map inserted spans back to UIDs for the structured wire list.
+class MentionComposer {
+  /// The active `@query` if the cursor is inside an unfinished mention token,
+  /// else null. A mention token starts at an `@` that is at the start of the
+  /// text or preceded by whitespace, and runs up to the cursor with no
+  /// whitespace in between. Returns the lowercase query WITHOUT the `@`.
+  ///
+  /// Returns `('', start)` for a bare `@` (show all candidates).
+  static ({String query, int atIndex})? activeQuery(String text, int cursor) {
+    if (cursor < 0 || cursor > text.length) return null;
+    // Walk back from the cursor to find an `@` with no intervening whitespace.
+    var i = cursor - 1;
+    while (i >= 0) {
+      final ch = text[i];
+      if (ch == '@') {
+        // Valid only if at start or preceded by whitespace.
+        if (i == 0 || _isWhitespace(text[i - 1])) {
+          return (query: text.substring(i + 1, cursor), atIndex: i);
+        }
+        return null;
+      }
+      if (_isWhitespace(ch)) return null;
+      i--;
+    }
+    return null;
+  }
+
+  /// Candidates whose display name contains [query] (case-insensitive),
+  /// preserving the input order. A blank query returns all candidates.
+  static List<MentionCandidate> filter(
+    List<MentionCandidate> candidates,
+    String query,
+  ) {
+    if (query.isEmpty) return List.of(candidates);
+    final q = query.toLowerCase();
+    return candidates
+        .where((c) => c.displayName.toLowerCase().contains(q))
+        .toList();
+  }
+
+  /// Replace the active `@query` token (anchored at [atIndex], ending at
+  /// [cursor]) with `@displayName ` and report the [chosen]'s UID. The trailing
+  /// space lets the user keep typing after the mention.
+  static MentionInsertion insert({
+    required String text,
+    required int atIndex,
+    required int cursor,
+    required MentionCandidate chosen,
+  }) {
+    final before = text.substring(0, atIndex);
+    final after = text.substring(cursor);
+    final inserted = '@${chosen.displayName} ';
+    final newText = '$before$inserted$after';
+    return MentionInsertion(
+      text: newText,
+      cursor: before.length + inserted.length,
+      uid: chosen.uid,
+    );
+  }
+
+  /// Given the final message text and the set of (displayName → uid) pairs the
+  /// user picked while composing, return the UIDs whose `@displayName` token
+  /// still survives in the text. This keeps the structured `mentions` list
+  /// honest if the user deleted a mention after inserting it.
+  ///
+  /// Matching is on the literal `@displayName` token bounded by start/whitespace
+  /// and whitespace/end — the display name is cosmetic, but its presence is the
+  /// signal that the user still intends that mention.
+  static List<String> survivingUids(
+    String text,
+    List<MentionCandidate> picked,
+  ) {
+    final result = <String>[];
+    final seen = <String>{};
+    for (final cand in picked) {
+      if (seen.contains(cand.uid)) continue;
+      if (_containsMentionToken(text, cand.displayName)) {
+        result.add(cand.uid);
+        seen.add(cand.uid);
+      }
+    }
+    return result;
+  }
+
+  static bool _containsMentionToken(String text, String displayName) {
+    final token = '@$displayName';
+    var from = 0;
+    while (true) {
+      final idx = text.indexOf(token, from);
+      if (idx < 0) return false;
+      final atStart = idx == 0 || _isWhitespace(text[idx - 1]);
+      final endIdx = idx + token.length;
+      final atEnd = endIdx == text.length || _isWhitespace(text[endIdx]);
+      if (atStart && atEnd) return true;
+      from = idx + 1;
+    }
+  }
+
+  static bool _isWhitespace(String ch) =>
+      ch == ' ' || ch == '\n' || ch == '\t';
+}

--- a/lib/chat/mention_text.dart
+++ b/lib/chat/mention_text.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/widgets.dart';
+
+/// Builds a [TextSpan] tree that highlights `@Name` mention spans within a chat
+/// message body, used by both the group panel and the DM thread view so the two
+/// render mentions identically.
+///
+/// A mention span is an `@` that is at the start of the text or preceded by
+/// whitespace, followed by one or more non-whitespace characters. This is a
+/// DISPLAY-ONLY treatment — the inline `@Name` text is never a trust anchor for
+/// the world beacon (that is the structured `mentions` UID list). Highlighting
+/// here is purely cosmetic and is intentionally permissive: it styles whatever
+/// looks like a mention, even if the name doesn't resolve to a participant.
+List<InlineSpan> buildMentionSpans(
+  String text, {
+  required TextStyle baseStyle,
+  required TextStyle mentionStyle,
+}) {
+  final spans = <InlineSpan>[];
+  final pattern = RegExp(r'(^|\s)(@[^\s]+)');
+  var last = 0;
+
+  for (final m in pattern.allMatches(text)) {
+    // Leading whitespace (capture group 1) stays in the base run.
+    final leadStart = m.start;
+    final mentionStart = m.start + (m.group(1)?.length ?? 0);
+
+    if (leadStart > last) {
+      spans.add(TextSpan(text: text.substring(last, leadStart), style: baseStyle));
+    }
+    final lead = m.group(1) ?? '';
+    if (lead.isNotEmpty) {
+      spans.add(TextSpan(text: lead, style: baseStyle));
+    }
+    spans.add(TextSpan(text: m.group(2), style: mentionStyle));
+    last = mentionStart + (m.group(2)?.length ?? 0);
+  }
+
+  if (last < text.length) {
+    spans.add(TextSpan(text: text.substring(last), style: baseStyle));
+  }
+  return spans;
+}

--- a/lib/events/dispatch.dart
+++ b/lib/events/dispatch.dart
@@ -12,6 +12,13 @@ final List<AsyncSink> _asyncSinks = [];
 /// Register a synchronous sink. Called once at app startup or in tests.
 void registerSink(Sink sink) => _syncSinks.add(sink);
 
+/// Remove a previously-registered synchronous sink (by identity). No-op if the
+/// sink was never registered. Used for room-scoped sinks (e.g. the world's
+/// mention consumer) that must be torn down on room leave WITHOUT clearing the
+/// app-lifetime sinks (console / file). Pass the exact closure that was
+/// registered — capture it in a field so the same reference can be removed.
+void unregisterSink(Sink sink) => _syncSinks.remove(sink);
+
 /// Register an asynchronous sink. Called once at app startup or in tests.
 void registerAsyncSink(AsyncSink sink) => _asyncSinks.add(sink);
 

--- a/lib/events/sinks/console_sink.dart
+++ b/lib/events/sinks/console_sink.dart
@@ -76,6 +76,8 @@ void consoleSink(AppEvent event) {
     GroupMessageSent(:final messageId, :final challengeId) =>
       'GroupMessageSent: $messageId${challengeId != null ? ' (challenge: ${challengeId.wireName})' : ''}',
     DmSent(:final peerId) => 'DmSent: → $peerId',
+    PlayersMentioned(:final mentionedUids, :final mentionerUid) =>
+      'PlayersMentioned: $mentionerUid → ${mentionedUids.join(', ')}',
     BotSpoke(:final text, :final context) =>
       'BotSpoke [${context.name}]: "${text.length > 60 ? '${text.substring(0, 60)}...' : text}"',
     // AV pipeline diagnostics

--- a/lib/events/types.dart
+++ b/lib/events/types.dart
@@ -537,6 +537,51 @@ final class BotLeft extends AppEvent {
   PiiPolicy get piiPolicy => PiiPolicy.none;
 }
 
+/// One or more players were named with `@mention` in group chat.
+///
+/// Dispatched by [ChatService] after it has parsed the structured `mentions`
+/// UID list defensively from a chat payload. The world consumes this to bloom
+/// the named avatars and draw the light arc from the mentioner.
+///
+/// Trust boundary: [mentionerUid] is the LiveKit transport-verified sender of
+/// the chat message, NEVER the payload's self-reported `senderId`. The
+/// [mentionedUids] are the structured list (display-only `@Name` text is not a
+/// trust anchor). Marked [PiiPolicy.pii] — these are user identifiers, so the
+/// remote-sink gate drops the event (consistent with [DmSent] / chat events).
+final class PlayersMentioned extends AppEvent {
+  PlayersMentioned({
+    required this.mentionedUids,
+    required this.mentionerUid,
+    required this.messageId,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  /// UIDs of the named players (structured wire list, transport-independent).
+  final List<String> mentionedUids;
+
+  /// UID of the player who sent the mention — transport-verified `senderId`.
+  final String mentionerUid;
+
+  /// Stable ID of the originating chat message, so a `mention-ack` matches the
+  /// right mention and concurrent mentions don't cross-cancel.
+  final String messageId;
+
+  @override
+  final DateTime timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': 'players_mentioned',
+        'mentionedUids': mentionedUids,
+        'mentionerUid': mentionerUid,
+        'messageId': messageId,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  @override
+  PiiPolicy get piiPolicy => PiiPolicy.pii;
+}
+
 /// Player toggled screen sharing.
 final class ScreenShareToggled extends AppEvent {
   ScreenShareToggled({required this.started, DateTime? timestamp})

--- a/lib/flame/components/mention_arc_component.dart
+++ b/lib/flame/components/mention_arc_component.dart
@@ -1,0 +1,94 @@
+import 'dart:math' show pi, sin;
+import 'dart:ui' as ui;
+
+import 'package:flame/components.dart';
+import 'package:flutter/painting.dart';
+import 'package:tech_world/flame/components/mention_beacon_component.dart'
+    show kMentionColor;
+
+// ── Tunable feel ─────────────────────────────────────────────────────────────
+/// How long the light arc lingers before fully fading. Cosmetic.
+const Duration kMentionArcDuration = Duration(milliseconds: 1400);
+
+/// Peak stroke width (px) of the arc thread at its brightest.
+const double kMentionArcStrokeWidth = 3.0;
+
+/// How high (px) the arc bows above the straight line between the two avatars.
+const double kMentionArcBowHeight = 28.0;
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A brief light thread drawn from the mentioner's avatar to a named avatar
+/// when an `@mention` lands — the "the call travelled across the room" beat.
+///
+/// Lives in the World (not as a child of either avatar) because it spans two
+/// positions. It samples [from] / [to] each frame so it tracks if either avatar
+/// drifts, fades over [kMentionArcDuration], then removes itself. Purely
+/// cosmetic — it carries no state and no lifecycle authority; the bloom/pulse
+/// on the named avatar is owned by `MentionPulseController`.
+///
+/// If either endpoint isn't present locally (the avatar isn't in the room or
+/// hasn't spawned), the caller simply doesn't create the arc — degrade
+/// gracefully, still bloom the named one if it's present.
+class MentionArcComponent extends PositionComponent {
+  MentionArcComponent({
+    required this.from,
+    required this.to,
+  }) {
+    anchor = Anchor.topLeft;
+    position = Vector2.zero();
+  }
+
+  /// World-space position of the mentioner's avatar, sampled live each frame.
+  final Vector2 Function() from;
+
+  /// World-space position of the named avatar, sampled live each frame.
+  final Vector2 Function() to;
+
+  double _time = 0;
+
+  /// Drawn above most world entities so the thread reads on top.
+  @override
+  int get priority => 1 << 20;
+
+  static final Paint _paint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeCap = StrokeCap.round
+    ..maskFilter = const ui.MaskFilter.blur(ui.BlurStyle.normal, 2);
+
+  /// Progress 0→1 through the arc's lifetime.
+  double get _progress =>
+      (_time / (kMentionArcDuration.inMilliseconds / 1000.0)).clamp(0.0, 1.0);
+
+  @override
+  void update(double dt) {
+    _time += dt;
+    if (_progress >= 1.0) {
+      removeFromParent();
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    final p = _progress;
+    // Fade out over the lifetime; brightest at onset.
+    final alpha = (1.0 - p).clamp(0.0, 1.0);
+    if (alpha <= 0) return;
+
+    final a = from();
+    final b = to();
+    // A quadratic bow so the thread arcs up over the room rather than a flat
+    // line. Control point is the midpoint lifted by the bow height.
+    final mid = Offset((a.x + b.x) / 2, (a.y + b.y) / 2 - kMentionArcBowHeight);
+
+    final path = Path()
+      ..moveTo(a.x, a.y)
+      ..quadraticBezierTo(mid.dx, mid.dy, b.x, b.y);
+
+    // A faint travelling brightness pulse along the thread as it fades.
+    final shimmer = 0.6 + 0.4 * sin(_time * 2 * pi);
+    _paint
+      ..color = kMentionColor.withValues(alpha: alpha * shimmer)
+      ..strokeWidth = kMentionArcStrokeWidth * alpha;
+    canvas.drawPath(path, _paint);
+  }
+}

--- a/lib/flame/components/mention_beacon_component.dart
+++ b/lib/flame/components/mention_beacon_component.dart
@@ -1,0 +1,212 @@
+import 'dart:math' show cos, pi, sin;
+import 'dart:ui' as ui;
+
+import 'package:flame/components.dart';
+import 'package:flutter/painting.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+
+// ── Tunable feel ─────────────────────────────────────────────────────────────
+// All visual constants live here so Nick can tune the look LIVE after merge.
+// The STRUCTURE/WIRE/STATE below is correct; these numbers are the dials.
+
+/// How long the initial expanding bloom lasts before settling into the slow
+/// public pulse. Purely cosmetic onset.
+const Duration kMentionBloomDuration = Duration(milliseconds: 2500);
+
+/// Radius (px) the beacon ring reaches at the peak of the bloom.
+const double kMentionBloomMaxRadius = 46.0;
+
+/// Resting radius (px) the slow public pulse oscillates around once settled.
+const double kMentionPulseBaseRadius = 26.0;
+
+/// Peak extra radius (px) added at the top of each slow-pulse breath.
+const double kMentionPulseAmplitude = 5.0;
+
+/// Seconds per slow-pulse breath while a mention waits to be acknowledged.
+const double kMentionPulsePeriodSeconds = 1.6;
+
+/// Number of soft lobes around the ring (organic, non-circular edge).
+const int kMentionRippleLobes = 6;
+
+/// Edge wobble amplitude (px) of the lobes.
+const double kMentionRippleAmplitude = 2.5;
+
+/// The beacon's colour. A warm gold/amber so it reads as "someone called you",
+/// distinct from the green speaking-glow on video bubbles.
+const Color kMentionColor = Color(0xFFFFC247);
+
+/// Whether to draw the floating name label during the bloom.
+const bool kMentionShowNameLabel = true;
+
+/// Vertical offset (px, local space) of the name label above the avatar.
+const double kMentionLabelOffsetY = -54.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A world beacon that blooms on a player's AVATAR when they are `@mention`ed
+/// in chat — witnessed by everyone in the room.
+///
+/// **Why the avatar, not the video bubble:** video bubbles are proximity-gated
+/// and hideable, but a mention crosses the whole room to someone you may be
+/// nowhere near. The avatar ([PlayerComponent]) is always present at the
+/// player's world position, so the beacon is attached as a CHILD of it and
+/// auto-follows movement.
+///
+/// It is purely a *view* of [MentionPulseController]: it owns no lifecycle
+/// state. While the controller reports [MentionPulseController.isPulsing] for
+/// [mentionedUid] it renders — first an expanding bloom + name label, then a
+/// slow public pulse — and it removes itself when the pulse stops (ack or
+/// timeout). The ripple/glow technique is lifted from
+/// `video_bubble_component.dart` (the lobed [_buildRingPath] + the
+/// [MaskFilter.blur] glow pulse) so the two read as the same visual family.
+class MentionBeaconComponent extends PositionComponent {
+  MentionBeaconComponent({
+    required this.mentionedUid,
+    required this.controller,
+    required this.displayName,
+    required this.reduceMotion,
+    Vector2? localCenter,
+  }) : _localCenter = localCenter ?? Vector2(16, 32) {
+    // Cover the avatar; positioned by the parent's local coordinate space.
+    anchor = Anchor.topLeft;
+    position = Vector2.zero();
+  }
+
+  /// UID of the player this beacon belongs to — its key into [controller].
+  final String mentionedUid;
+
+  /// The shared pulse-state machine. Read-only here.
+  final MentionPulseController controller;
+
+  /// Cosmetic label shown during the bloom ("Alice").
+  final String displayName;
+
+  /// Honour the accessibility preference: when true, the bloom snaps to its
+  /// final ring and the slow pulse / ripple hold still (no animation).
+  final bool reduceMotion;
+
+  /// Where, in the parent avatar's local space, the beacon centres. Defaults to
+  /// the middle of the 32×64 sprite.
+  final Vector2 _localCenter;
+
+  double _time = 0;
+
+  static final Paint _glowPaint = Paint()
+    ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 8);
+  static final Paint _ringPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2.5;
+
+  ui.Paragraph? _labelParagraph;
+
+  @override
+  Future<void> onLoad() async {
+    if (kMentionShowNameLabel && displayName.isNotEmpty) {
+      _labelParagraph = _buildLabel(displayName);
+    }
+  }
+
+  /// Whether this beacon is still wanted — exposed so a test can assert the
+  /// view follows the controller's lifecycle.
+  bool get active => controller.isPulsing(mentionedUid);
+
+  @override
+  void update(double dt) {
+    _time += dt;
+    // Self-remove once the controller stops pulsing this player (ack/timeout).
+    if (!active) {
+      removeFromParent();
+    }
+  }
+
+  /// Progress through the bloom phase, 0→1, clamped. 1.0 means settled into the
+  /// slow public pulse. With reduce-motion the bloom is instantaneous.
+  double get _bloomProgress {
+    if (reduceMotion) return 1.0;
+    final t = _time / (kMentionBloomDuration.inMilliseconds / 1000.0);
+    return t.clamp(0.0, 1.0);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    final center = Offset(_localCenter.x, _localCenter.y);
+    final bloom = _bloomProgress;
+
+    final double radius;
+    final double alpha;
+    if (bloom < 1.0) {
+      // Bloom: a ring expanding outward, brightest at onset, easing to rest.
+      radius = kMentionPulseBaseRadius +
+          (kMentionBloomMaxRadius - kMentionPulseBaseRadius) * bloom;
+      alpha = 0.85 * (1.0 - bloom) + 0.5 * bloom;
+    } else {
+      // Settled: a slow public pulse around the resting radius.
+      final breath = reduceMotion
+          ? 0.0
+          : sin(_time * (2 * pi / kMentionPulsePeriodSeconds));
+      radius = kMentionPulseBaseRadius + kMentionPulseAmplitude * breath;
+      alpha = 0.45 + 0.15 * (reduceMotion ? 0.0 : breath);
+    }
+
+    // Soft radial glow under the ring.
+    _glowPaint.color = kMentionColor.withValues(alpha: 0.4 * alpha);
+    canvas.drawCircle(center, radius, _glowPaint);
+
+    // Lobed ring on top (the organic ripple edge from the video bubble).
+    _ringPaint.color = kMentionColor.withValues(alpha: alpha.clamp(0.0, 1.0));
+    canvas.drawPath(_buildRingPath(center, radius), _ringPaint);
+
+    // Name label during the bloom only.
+    if (bloom < 1.0) {
+      final label = _labelParagraph;
+      if (label != null) {
+        canvas.drawParagraph(
+          label,
+          Offset(center.dx - label.width / 2, center.dy + kMentionLabelOffsetY),
+        );
+      }
+    }
+  }
+
+  /// A circle with soft animated lobes — the same two-wave technique as
+  /// `VideoBubbleComponent._buildBubblePath`, so the beacon edge ripples like
+  /// the speaking bubble rather than being a hard circle.
+  Path _buildRingPath(Offset center, double radius) {
+    if (reduceMotion) {
+      return Path()..addOval(Rect.fromCircle(center: center, radius: radius));
+    }
+    final path = Path();
+    const segments = 64;
+    for (int i = 0; i <= segments; i++) {
+      final angle = (i / segments) * 2.0 * pi;
+      final wave1 =
+          sin(angle * kMentionRippleLobes + _time * 5.0) * kMentionRippleAmplitude;
+      final wave2 =
+          sin(angle * (kMentionRippleLobes + 3) - _time * 3.0) *
+              kMentionRippleAmplitude *
+              0.4;
+      final r = radius + wave1 + wave2;
+      final x = center.dx + cos(angle) * r;
+      final y = center.dy + sin(angle) * r;
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    path.close();
+    return path;
+  }
+
+  ui.Paragraph _buildLabel(String name) {
+    final builder = ui.ParagraphBuilder(ui.ParagraphStyle(
+      textAlign: TextAlign.center,
+      fontSize: 11,
+      fontWeight: FontWeight.bold,
+    ))
+      ..pushStyle(ui.TextStyle(color: kMentionColor))
+      ..addText(name);
+    return builder.build()
+      ..layout(const ui.ParagraphConstraints(width: 120));
+  }
+}

--- a/lib/flame/livekit_game_bridge.dart
+++ b/lib/flame/livekit_game_bridge.dart
@@ -2,15 +2,19 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:livekit_client/livekit_client.dart';
+// Hide LiveKit's own ChatMessage so the project's ChatMessage (used for the
+// defensive `parseMentions` / `asStringOrNull` wire helpers) resolves cleanly.
+import 'package:livekit_client/livekit_client.dart' hide ChatMessage;
 import 'package:logging/logging.dart';
 import 'package:tech_world/avatar/avatar.dart';
+import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/events/dispatch.dart';
 import 'package:tech_world/events/types.dart';
 import 'package:tech_world/flame/bubble_manager.dart';
 import 'package:tech_world/flame/shared/player_path.dart';
 import 'package:tech_world/infra/infra_health_service.dart';
 import 'package:tech_world/livekit/data_topic.dart';
+import 'package:tech_world/livekit/livekit_topic.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/utils/locator.dart';
 
@@ -46,6 +50,11 @@ class LiveKitGameBridge {
     // Data channel
     required void Function(DataChannelMessage) onSpeechTranscript,
     required void Function(DataChannelMessage) onDoorUnlock,
+    // Mentions
+    required void Function(
+            List<String> mentionedUids, String mentionerUid, String messageId)
+        onPlayersMentioned,
+    required void Function(String ackerUid, String messageId) onMentionAck,
     // Map
     required void Function() onMapInfoRequested,
     required void Function(String mapId) onMapSwitchReceived,
@@ -63,6 +72,8 @@ class LiveKitGameBridge {
         _onAvatarUpdate = onAvatarUpdate,
         _onSpeechTranscript = onSpeechTranscript,
         _onDoorUnlock = onDoorUnlock,
+        _onPlayersMentioned = onPlayersMentioned,
+        _onMentionAck = onMentionAck,
         _onMapInfoRequested = onMapInfoRequested,
         _onMapSwitchReceived = onMapSwitchReceived,
         _onConnectionLost = onConnectionLost;
@@ -81,6 +92,10 @@ class LiveKitGameBridge {
   final void Function(AvatarUpdate) _onAvatarUpdate;
   final void Function(DataChannelMessage) _onSpeechTranscript;
   final void Function(DataChannelMessage) _onDoorUnlock;
+  final void Function(
+          List<String> mentionedUids, String mentionerUid, String messageId)
+      _onPlayersMentioned;
+  final void Function(String ackerUid, String messageId) _onMentionAck;
   final void Function() _onMapInfoRequested;
   final void Function(String) _onMapSwitchReceived;
   final void Function() _onConnectionLost;
@@ -100,6 +115,8 @@ class LiveKitGameBridge {
   StreamSubscription<String>? _mapSwitchSub;
   StreamSubscription<DataChannelMessage>? _speechTranscriptSub;
   StreamSubscription<DataChannelMessage>? _doorUnlockSub;
+  StreamSubscription<DataChannelMessage>? _mentionSub;
+  StreamSubscription<DataChannelMessage>? _mentionAckSub;
 
   InfraHealthService? _infraHealthService;
 
@@ -207,6 +224,35 @@ class LiveKitGameBridge {
         .where((msg) => msg.topic == DataTopic.doorUnlock.wireName)
         .listen(_onDoorUnlock);
 
+    // ── @mentions ────────────────────────────────────────────────────────
+    // Extract the structured mention list from group chat messages and route
+    // it to the world. The mentioner is the TRANSPORT-verified sender, never
+    // the payload's self-reported senderId (a peer can name victims but cannot
+    // forge who sent the mention). Malformed lists drop to empty (no callback).
+    _mentionSub = _liveKitService.dataReceived
+        .where((msg) => msg.topic == LiveKitTopic.chat.wire)
+        .listen((msg) {
+      final json = msg.json;
+      if (json == null) return;
+      final mentioned = ChatMessage.parseMentions(json['mentions']);
+      if (mentioned.isEmpty) return;
+      final messageId =
+          ChatMessage.asStringOrNull(json['id']) ?? 'mention-${msg.senderId}';
+      _onPlayersMentioned(mentioned, msg.senderId ?? 'unknown', messageId);
+    });
+
+    // A mention-ack: the acker UID is the TRANSPORT sender — a peer can only
+    // ack its own mention, never silence someone else's pulse.
+    _mentionAckSub = _liveKitService.dataReceived
+        .where((msg) => msg.topic == LiveKitTopic.mentionAck.wire)
+        .listen((msg) {
+      final json = msg.json;
+      if (json == null) return;
+      final messageId = ChatMessage.asStringOrNull(json['messageId']);
+      if (messageId == null) return;
+      _onMentionAck(msg.senderId ?? 'unknown', messageId);
+    });
+
     // ── Infrastructure health ────────────────────────────────────────────
     _infraHealthService = InfraHealthService(
       liveKitService: _liveKitService,
@@ -266,6 +312,10 @@ class LiveKitGameBridge {
     _speechTranscriptSub = null;
     _doorUnlockSub?.cancel();
     _doorUnlockSub = null;
+    _mentionSub?.cancel();
+    _mentionSub = null;
+    _mentionAckSub?.cancel();
+    _mentionAckSub = null;
 
     _infraHealthService?.dispose();
     Locator.remove<InfraHealthService>();

--- a/lib/flame/livekit_game_bridge.dart
+++ b/lib/flame/livekit_game_bridge.dart
@@ -50,10 +50,9 @@ class LiveKitGameBridge {
     // Data channel
     required void Function(DataChannelMessage) onSpeechTranscript,
     required void Function(DataChannelMessage) onDoorUnlock,
-    // Mentions
-    required void Function(
-            List<String> mentionedUids, String mentionerUid, String messageId)
-        onPlayersMentioned,
+    // Mentions — only the ack travels here; the mention itself reaches the
+    // world via the dispatched [PlayersMentioned] event (so the SENDER, whose
+    // own publishData LiveKit does not loop back, still witnesses it).
     required void Function(String ackerUid, String messageId) onMentionAck,
     // Map
     required void Function() onMapInfoRequested,
@@ -72,7 +71,6 @@ class LiveKitGameBridge {
         _onAvatarUpdate = onAvatarUpdate,
         _onSpeechTranscript = onSpeechTranscript,
         _onDoorUnlock = onDoorUnlock,
-        _onPlayersMentioned = onPlayersMentioned,
         _onMentionAck = onMentionAck,
         _onMapInfoRequested = onMapInfoRequested,
         _onMapSwitchReceived = onMapSwitchReceived,
@@ -92,9 +90,6 @@ class LiveKitGameBridge {
   final void Function(AvatarUpdate) _onAvatarUpdate;
   final void Function(DataChannelMessage) _onSpeechTranscript;
   final void Function(DataChannelMessage) _onDoorUnlock;
-  final void Function(
-          List<String> mentionedUids, String mentionerUid, String messageId)
-      _onPlayersMentioned;
   final void Function(String ackerUid, String messageId) _onMentionAck;
   final void Function() _onMapInfoRequested;
   final void Function(String) _onMapSwitchReceived;
@@ -115,7 +110,6 @@ class LiveKitGameBridge {
   StreamSubscription<String>? _mapSwitchSub;
   StreamSubscription<DataChannelMessage>? _speechTranscriptSub;
   StreamSubscription<DataChannelMessage>? _doorUnlockSub;
-  StreamSubscription<DataChannelMessage>? _mentionSub;
   StreamSubscription<DataChannelMessage>? _mentionAckSub;
 
   InfraHealthService? _infraHealthService;
@@ -224,24 +218,12 @@ class LiveKitGameBridge {
         .where((msg) => msg.topic == DataTopic.doorUnlock.wireName)
         .listen(_onDoorUnlock);
 
-    // ── @mentions ────────────────────────────────────────────────────────
-    // Extract the structured mention list from group chat messages and route
-    // it to the world. The mentioner is the TRANSPORT-verified sender, never
-    // the payload's self-reported senderId (a peer can name victims but cannot
-    // forge who sent the mention). Malformed lists drop to empty (no callback).
-    _mentionSub = _liveKitService.dataReceived
-        .where((msg) => msg.topic == LiveKitTopic.chat.wire)
-        .listen((msg) {
-      final json = msg.json;
-      if (json == null) return;
-      final mentioned = ChatMessage.parseMentions(json['mentions']);
-      if (mentioned.isEmpty) return;
-      final messageId =
-          ChatMessage.asStringOrNull(json['id']) ?? 'mention-${msg.senderId}';
-      _onPlayersMentioned(mentioned, msg.senderId ?? 'unknown', messageId);
-    });
-
-    // A mention-ack: the acker UID is the TRANSPORT sender — a peer can only
+    // ── @mention ack ─────────────────────────────────────────────────────
+    // The mention itself reaches the world via the dispatched
+    // [PlayersMentioned] event (fired by ChatService on BOTH send and receive),
+    // so the sender witnesses their own mention even though LiveKit doesn't
+    // loop their publishData back. Only the ack is a pure wire signal handled
+    // here. The acker UID is the TRANSPORT sender — a peer can only
     // ack its own mention, never silence someone else's pulse.
     _mentionAckSub = _liveKitService.dataReceived
         .where((msg) => msg.topic == LiveKitTopic.mentionAck.wire)
@@ -312,8 +294,6 @@ class LiveKitGameBridge {
     _speechTranscriptSub = null;
     _doorUnlockSub?.cancel();
     _doorUnlockSub = null;
-    _mentionSub?.cancel();
-    _mentionSub = null;
     _mentionAckSub?.cancel();
     _mentionAckSub = null;
 

--- a/lib/flame/mention/mention_pulse_controller.dart
+++ b/lib/flame/mention/mention_pulse_controller.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/foundation.dart';
+
+/// Owns the multiplayer state lifecycle of an `@mention` world-pulse,
+/// independent of any rendering.
+///
+/// Every client runs one of these. When a mention arrives (parsed from a chat
+/// payload by `ChatService` and delivered via the `PlayersMentioned` event),
+/// `onMention` starts a pulse on the named avatar — visible to everyone. The
+/// pulse is bounded by THREE independent stop conditions, so it can never get
+/// stuck on:
+///
+///  1. **Ack** — the named player's OWN client broadcasts a `mention-ack` when
+///     it opens the chat panel; all clients call [onAck] and stop that pulse.
+///  2. **Auto-timeout** — [pulseTimeout] after the (most recent) mention, the
+///     pulse stops everywhere even if no ack ever arrives. Driven by [tick],
+///     which the owning Flame component calls each frame against an injected
+///     clock (so tests use a fake clock, not wall time).
+///  3. A re-mention of the same player **refreshes** both the timeout deadline
+///     and the active `messageId`.
+///
+/// The active `messageId` is the match key: an ack only cancels when it carries
+/// the messageId of the *currently-live* mention. This stops a stale ack (for
+/// an already-superseded mention) from silencing a fresh pulse, and stops
+/// concurrent mentions of the same player from cross-cancelling.
+///
+/// A [ChangeNotifier] so the rendering layer (and tests) can observe start /
+/// ack / timeout transitions; it notifies only on an actual state change.
+class MentionPulseController extends ChangeNotifier {
+  MentionPulseController({DateTime Function()? clock})
+      : _clock = clock ?? DateTime.now;
+
+  final DateTime Function() _clock;
+
+  /// How long a pulse persists with no acknowledgement before auto-stopping.
+  /// Bounded so an un-answered mention is a slow public pulse, never permanent.
+  static const Duration pulseTimeout = Duration(seconds: 45);
+
+  /// Active pulses keyed by the mentioned player's UID. Only the most recent
+  /// mention per player is tracked (a re-mention overwrites).
+  final Map<String, _ActivePulse> _active = {};
+
+  /// Whether [uid]'s avatar is currently pulsing.
+  bool isPulsing(String uid) => _active.containsKey(uid);
+
+  /// The UID of whoever raised the *current* live mention of [uid], for drawing
+  /// the light arc from mentioner → named. Null if [uid] isn't pulsing.
+  String? mentionerOf(String uid) => _active[uid]?.mentionerUid;
+
+  /// The messageId of the *current* live mention of [uid] — the value to put in
+  /// an ack so it matches. Null if [uid] isn't pulsing.
+  String? activeMessageId(String uid) => _active[uid]?.messageId;
+
+  /// UIDs of all players currently pulsing — a snapshot for the renderer.
+  Iterable<String> get pulsingUids => _active.keys;
+
+  /// Start (or refresh) a pulse on [mentionedUid]. Records [mentionerUid] for
+  /// the arc and [messageId] as the ack-match key, and resets the timeout
+  /// deadline to [pulseTimeout] from now.
+  void onMention({
+    required String mentionedUid,
+    required String mentionerUid,
+    required String messageId,
+  }) {
+    _active[mentionedUid] = _ActivePulse(
+      mentionerUid: mentionerUid,
+      messageId: messageId,
+      deadline: _clock().add(pulseTimeout),
+    );
+    notifyListeners();
+  }
+
+  /// Stop [mentionedUid]'s pulse IFF [messageId] matches the currently-live
+  /// mention. A mismatched or stale messageId, or an ack for a non-pulsing
+  /// player, is a no-op (no notification).
+  void onAck({required String mentionedUid, required String messageId}) {
+    final pulse = _active[mentionedUid];
+    if (pulse == null || pulse.messageId != messageId) return;
+    _active.remove(mentionedUid);
+    notifyListeners();
+  }
+
+  /// Drive auto-timeout. Called each frame by the owning component (or directly
+  /// in tests after advancing the fake clock). Removes every pulse whose
+  /// deadline has passed and notifies once if anything expired.
+  void tick() {
+    final now = _clock();
+    final expired = _active.entries
+        .where((e) => !now.isBefore(e.value.deadline))
+        .map((e) => e.key)
+        .toList();
+    if (expired.isEmpty) return;
+    for (final uid in expired) {
+      _active.remove(uid);
+    }
+    notifyListeners();
+  }
+
+  /// Drop all pulses without notifying — for teardown on room leave.
+  void clear() => _active.clear();
+}
+
+/// One live mention pulse: who raised it, which message it belongs to (the
+/// ack-match key), and when it auto-expires.
+class _ActivePulse {
+  _ActivePulse({
+    required this.mentionerUid,
+    required this.messageId,
+    required this.deadline,
+  });
+
+  final String mentionerUid;
+  final String messageId;
+  final DateTime deadline;
+}

--- a/lib/flame/mention/mention_world_controller.dart
+++ b/lib/flame/mention/mention_world_controller.dart
@@ -1,0 +1,130 @@
+import 'package:flame/components.dart';
+import 'package:tech_world/flame/components/mention_arc_component.dart';
+import 'package:tech_world/flame/components/mention_beacon_component.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+
+/// Bridges the `@mention` *state machine* ([MentionPulseController]) to the
+/// *world view* (beacons on avatars + the travelling light arc) and to the
+/// *ack wire* (broadcasting when the local user sees a mention of themselves).
+///
+/// This is the seam TechWorld delegates to. It owns no rendering and no wire
+/// transport directly — both are injected as callbacks so it is testable
+/// without a running game or LiveKit:
+///
+///  - [avatarLookup] resolves a UID to its on-screen avatar (or null if that
+///    player isn't present locally — the graceful-degradation case);
+///  - [addToWorld] adds the spanning arc to the World;
+///  - [publishAck] broadcasts a `mention-ack` over LiveKit;
+///  - [localUid] identifies which mentions are "of me".
+///
+/// **Trust:** the controller never derives identity from a payload. When a
+/// mention arrives, the mentioner UID is the transport-verified chat sender
+/// (supplied by the bridge). When an ack arrives, the acker UID is the
+/// transport-verified ack sender — so a peer can only ack its OWN mention.
+class MentionWorldController {
+  MentionWorldController({
+    required this.pulseController,
+    required this.localUid,
+    required this.avatarLookup,
+    required this.addToWorld,
+    required this.publishAck,
+    required this.reduceMotion,
+    String Function(String uid)? displayNameLookup,
+  }) : displayNameLookup = displayNameLookup ?? ((_) => '');
+
+  /// The shared pulse-state machine (one per client).
+  final MentionPulseController pulseController;
+
+  /// UID of the local user — used to detect mentions "of me" and to scope the
+  /// ack broadcast.
+  final String localUid;
+
+  /// Resolve a player UID to its avatar component, or null if not present
+  /// locally (not in room / not yet spawned). Both remote and local.
+  final PositionComponent? Function(String uid) avatarLookup;
+
+  /// Add a (world-spanning) component such as the arc to the World.
+  final void Function(Component) addToWorld;
+
+  /// Broadcast a `mention-ack` for the local user's [uid] against [messageId].
+  final void Function(String uid, String messageId) publishAck;
+
+  /// Accessibility: hold beacon/arc animation still when true.
+  final bool reduceMotion;
+
+  /// Resolve a UID to a display name for the beacon's cosmetic label. Defaults
+  /// to empty (no label). Avoids reaching into the avatar via dynamic dispatch
+  /// (which breaks under WASM).
+  final String Function(String uid) displayNameLookup;
+
+  /// Handle an incoming mention (already parsed + trust-checked upstream).
+  ///
+  /// Starts/refreshes the pulse for every named player, attaches a beacon to
+  /// each present avatar, and — when both endpoints are present — spawns the
+  /// light arc from the mentioner to the (first) named player. Absent endpoints
+  /// degrade gracefully: the pulse state is still recorded, but no local view
+  /// is created for an avatar that isn't here.
+  void onPlayersMentioned({
+    required List<String> mentionedUids,
+    required String mentionerUid,
+    required String messageId,
+  }) {
+    final mentionerAvatar = avatarLookup(mentionerUid);
+
+    for (final uid in mentionedUids) {
+      pulseController.onMention(
+        mentionedUid: uid,
+        mentionerUid: mentionerUid,
+        messageId: messageId,
+      );
+
+      final avatar = avatarLookup(uid);
+      if (avatar == null) continue; // not present locally — pulse only.
+
+      // Avoid stacking duplicate beacons if a re-mention lands while one lives;
+      // the existing beacon already follows the (refreshed) controller state.
+      final hasBeacon =
+          avatar.children.whereType<MentionBeaconComponent>().isNotEmpty;
+      if (!hasBeacon) {
+        avatar.add(MentionBeaconComponent(
+          mentionedUid: uid,
+          controller: pulseController,
+          displayName: displayNameLookup(uid),
+          reduceMotion: reduceMotion,
+        ));
+      }
+
+      // Arc from mentioner → this named avatar, if the mentioner is present.
+      if (mentionerAvatar != null && !identical(mentionerAvatar, avatar)) {
+        addToWorld(MentionArcComponent(
+          from: () => mentionerAvatar.position.clone(),
+          to: () => avatar.position.clone(),
+        ));
+      }
+    }
+  }
+
+  /// The local user opened the chat panel — acknowledge every live mention that
+  /// names them. Broadcasts one `mention-ack` per such pulse (carrying its
+  /// messageId) so all clients stop the local user's avatar pulse. Mentions of
+  /// OTHER players are untouched — opening my chat only acks mentions of me.
+  void onLocalChatOpened() {
+    final messageId = pulseController.activeMessageId(localUid);
+    if (messageId == null) return;
+    publishAck(localUid, messageId);
+    // Optimistically stop our own pulse locally too (don't wait for the echo).
+    pulseController.onAck(mentionedUid: localUid, messageId: messageId);
+  }
+
+  /// Handle an incoming `mention-ack` from the wire. [ackerUid] is the
+  /// TRANSPORT-verified sender of the ack — a peer can only ack its own pulse.
+  void onMentionAck({required String ackerUid, required String messageId}) {
+    pulseController.onAck(mentionedUid: ackerUid, messageId: messageId);
+  }
+
+  /// Drive auto-timeout — call each frame from TechWorld.update.
+  void tick() => pulseController.tick();
+
+  /// Drop all pulses on room leave.
+  void clear() => pulseController.clear();
+}

--- a/lib/flame/mention/mention_world_controller.dart
+++ b/lib/flame/mention/mention_world_controller.dart
@@ -30,7 +30,9 @@ class MentionWorldController {
     required this.publishAck,
     required this.reduceMotion,
     String Function(String uid)? displayNameLookup,
-  }) : displayNameLookup = displayNameLookup ?? ((_) => '');
+    bool Function()? isLocalChatOpen,
+  })  : displayNameLookup = displayNameLookup ?? ((_) => ''),
+        isLocalChatOpen = isLocalChatOpen ?? (() => false);
 
   /// The shared pulse-state machine (one per client).
   final MentionPulseController pulseController;
@@ -46,8 +48,12 @@ class MentionWorldController {
   /// Add a (world-spanning) component such as the arc to the World.
   final void Function(Component) addToWorld;
 
-  /// Broadcast a `mention-ack` for the local user's [uid] against [messageId].
-  final void Function(String uid, String messageId) publishAck;
+  /// Broadcast a `mention-ack` against [messageId]. The acked player is always
+  /// the local user (the only mention you can acknowledge is one of yourself),
+  /// and the ack's identity is the transport sender on the wire — so this
+  /// deliberately carries ONLY the messageId, never a payload UID, to remove
+  /// any invitation to trust a payload-sourced identity.
+  final void Function(String messageId) publishAck;
 
   /// Accessibility: hold beacon/arc animation still when true.
   final bool reduceMotion;
@@ -56,6 +62,12 @@ class MentionWorldController {
   /// to empty (no label). Avoids reaching into the avatar via dynamic dispatch
   /// (which breaks under WASM).
   final String Function(String uid) displayNameLookup;
+
+  /// Whether the local user's chat panel is currently visible. When a mention
+  /// of the local user arrives while chat is ALREADY open, they've effectively
+  /// already "seen" it, so we ack immediately rather than waiting for the next
+  /// panel-open (or the 45s timeout). Defaults to always-closed.
+  final bool Function() isLocalChatOpen;
 
   /// Handle an incoming mention (already parsed + trust-checked upstream).
   ///
@@ -71,7 +83,12 @@ class MentionWorldController {
   }) {
     final mentionerAvatar = avatarLookup(mentionerUid);
 
+    // Dedupe so a payload naming the same UID twice can't create duplicate
+    // arcs/work. The structured list is the trust anchor but it's still
+    // untrusted shape — bound it to distinct players.
+    final seenUids = <String>{};
     for (final uid in mentionedUids) {
+      if (!seenUids.add(uid)) continue;
       pulseController.onMention(
         mentionedUid: uid,
         mentionerUid: mentionerUid,
@@ -102,6 +119,32 @@ class MentionWorldController {
         ));
       }
     }
+
+    // If this mention names the local user and their chat is ALREADY open,
+    // they've seen it — ack immediately so the pulse doesn't ride the 45s
+    // timeout despite the user being right there in chat.
+    if (seenUids.contains(localUid) && isLocalChatOpen()) {
+      onLocalChatOpened();
+    }
+  }
+
+  /// Attach a beacon to a freshly-spawned avatar if a pulse for [uid] is
+  /// already active — covers the race where a mention arrives BEFORE the named
+  /// player's `PlayerComponent` is created (the controller recorded the pulse
+  /// state, but had no avatar to attach to at the time). Idempotent: no-op if
+  /// not pulsing or a beacon already exists. Called by TechWorld on player
+  /// component creation.
+  void reconcileBeaconFor(String uid, PositionComponent avatar) {
+    if (!pulseController.isPulsing(uid)) return;
+    final hasBeacon =
+        avatar.children.whereType<MentionBeaconComponent>().isNotEmpty;
+    if (hasBeacon) return;
+    avatar.add(MentionBeaconComponent(
+      mentionedUid: uid,
+      controller: pulseController,
+      displayName: displayNameLookup(uid),
+      reduceMotion: reduceMotion,
+    ));
   }
 
   /// The local user opened the chat panel — acknowledge every live mention that
@@ -111,7 +154,7 @@ class MentionWorldController {
   void onLocalChatOpened() {
     final messageId = pulseController.activeMessageId(localUid);
     if (messageId == null) return;
-    publishAck(localUid, messageId);
+    publishAck(messageId);
     // Optimistically stop our own pulse locally too (don't wait for the echo).
     pulseController.onAck(mentionedUid: localUid, messageId: messageId);
   }

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -19,6 +19,7 @@ import 'package:tech_world/flame/components/barriers_component.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/livekit_game_bridge.dart';
 import 'package:tech_world/flame/components/countdown_clock_component.dart';
+import 'package:tech_world/flame/components/mention_arc_component.dart';
 import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
 import 'package:tech_world/flame/mention/mention_world_controller.dart';
 import 'package:tech_world/livekit/livekit_topic.dart';
@@ -106,10 +107,19 @@ class TechWorld extends World with TapCallbacks {
   /// LiveKit connect (when [userId] is known), cleared on disconnect.
   MentionWorldController? _mentionController;
 
+  /// The [PlayersMentioned] dispatch sink, held so it can be removed (by
+  /// identity) on disconnect without clearing app-lifetime sinks.
+  Sink? _mentionSink;
+
   /// The chat-panel-opened hook the UI calls so the local user can acknowledge
   /// a mention of themselves. Routed through [_mentionController]; a no-op until
   /// a room is connected.
   void onChatPanelOpened() => _mentionController?.onLocalChatOpened();
+
+  /// Whether the local user's chat panel is currently visible. Set by the UI
+  /// (main.dart) so a mention arriving while chat is already open auto-acks.
+  /// Defaults to closed.
+  bool Function() isLocalChatOpen = () => false;
   DreamfinderComponent? _dreamfinderComponent;
   late final BubbleManager _bubbleManager;
   late final DoorManager _doorManager;
@@ -487,6 +497,9 @@ class TechWorld extends World with TapCallbacks {
         );
         _otherPlayerComponentsMap[path.playerId] = playerComponent;
         add(playerComponent);
+        // A mention may have arrived before this avatar spawned — attach its
+        // beacon now if a pulse is already active for this player.
+        _mentionController?.reconcileBeaconFor(path.playerId, playerComponent);
       }
       _otherPlayerComponentsMap[path.playerId]
           ?.move(path.directions, path.largeGridPoints);
@@ -515,6 +528,8 @@ class TechWorld extends World with TapCallbacks {
         );
         _otherPlayerComponentsMap[heartbeat.playerId] = playerComponent;
         add(playerComponent);
+        _mentionController?.reconcileBeaconFor(
+            heartbeat.playerId, playerComponent);
       } else {
         _otherPlayerComponentsMap[heartbeat.playerId]?.position =
             targetPosition;
@@ -634,6 +649,9 @@ class TechWorld extends World with TapCallbacks {
       );
       _otherPlayerComponentsMap[participant.identity] = playerComponent;
       add(playerComponent);
+      // Attach a mention beacon if this player was named before they spawned.
+      _mentionController?.reconcileBeaconFor(
+          participant.identity, playerComponent);
 
       // Dreamfinder notices the new human player arriving.
       _dreamfinderComponent?.noticePlayer(playerComponent.position);
@@ -766,7 +784,7 @@ class TechWorld extends World with TapCallbacks {
       avatarLookup: _avatarForUid,
       addToWorld: add,
       displayNameLookup: _displayNameForUid,
-      publishAck: (uid, messageId) {
+      publishAck: (messageId) {
         _liveKitService?.publishJson(
           {
             'type': LiveKitTopic.mentionAck.wire,
@@ -777,7 +795,24 @@ class TechWorld extends World with TapCallbacks {
         );
       },
       reduceMotion: _bubbleManager.reduceMotion,
+      isLocalChatOpen: () => isLocalChatOpen(),
     );
+
+    // Consume PlayersMentioned from the dispatch bus — fired by ChatService on
+    // BOTH send (so the mentioner sees their own bloom; LiveKit doesn't loop a
+    // participant's own publishData back) AND receive (remote mentions). One
+    // world entry point for both directions. Registered here, removed on
+    // disconnect via [unregisterSink] so app-lifetime sinks are untouched.
+    _mentionSink = (AppEvent event) {
+      if (event is PlayersMentioned) {
+        _mentionController?.onPlayersMentioned(
+          mentionedUids: event.mentionedUids,
+          mentionerUid: event.mentionerUid,
+          messageId: event.messageId,
+        );
+      }
+    };
+    registerSink(_mentionSink!);
 
     _liveKitBridge = LiveKitGameBridge(
       liveKitService: _liveKitService!,
@@ -792,13 +827,6 @@ class TechWorld extends World with TapCallbacks {
       onAvatarUpdate: _handleAvatarUpdate,
       onSpeechTranscript: _handleSpeechTranscript,
       onDoorUnlock: _doorManager.handleRemoteDoorUnlock,
-      onPlayersMentioned: (mentionedUids, mentionerUid, messageId) {
-        _mentionController?.onPlayersMentioned(
-          mentionedUids: mentionedUids,
-          mentionerUid: mentionerUid,
-          messageId: messageId,
-        );
-      },
       onMentionAck: (ackerUid, messageId) {
         _mentionController?.onMentionAck(
           ackerUid: ackerUid,
@@ -1434,10 +1462,18 @@ class TechWorld extends World with TapCallbacks {
     _clockComponent?.removeFromParent();
     _clockComponent = null;
 
-    // Drop any active mention pulses; beacons self-remove when no longer
-    // pulsing, and arcs self-remove on their own fade timer.
+    // Stop consuming mention events, drop active pulses (beacons self-remove
+    // when no longer pulsing), and sweep any in-flight arcs so none linger
+    // past room-leave on their own fade timer.
+    if (_mentionSink != null) {
+      unregisterSink(_mentionSink!);
+      _mentionSink = null;
+    }
     _mentionController?.clear();
     _mentionController = null;
+    for (final arc in children.whereType<MentionArcComponent>().toList()) {
+      arc.removeFromParent();
+    }
 
     for (final component in _otherPlayerComponentsMap.values) {
       component.removeFromParent();

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -19,6 +19,9 @@ import 'package:tech_world/flame/components/barriers_component.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/livekit_game_bridge.dart';
 import 'package:tech_world/flame/components/countdown_clock_component.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+import 'package:tech_world/flame/mention/mention_world_controller.dart';
+import 'package:tech_world/livekit/livekit_topic.dart';
 import 'package:tech_world/flame/components/door_component.dart';
 import 'package:tech_world/flame/door_manager.dart';
 import 'package:tech_world/flame/maps/barrier_occlusion.dart';
@@ -98,6 +101,15 @@ class TechWorld extends World with TapCallbacks {
 
   final Map<String, PlayerComponent> _otherPlayerComponentsMap = {};
   final Map<String, BotCharacterComponent> _botCharacterComponents = {};
+
+  /// Owns the `@mention` pulse lifecycle + world beacons/arcs. Constructed on
+  /// LiveKit connect (when [userId] is known), cleared on disconnect.
+  MentionWorldController? _mentionController;
+
+  /// The chat-panel-opened hook the UI calls so the local user can acknowledge
+  /// a mention of themselves. Routed through [_mentionController]; a no-op until
+  /// a room is connected.
+  void onChatPanelOpened() => _mentionController?.onLocalChatOpened();
   DreamfinderComponent? _dreamfinderComponent;
   late final BubbleManager _bubbleManager;
   late final DoorManager _doorManager;
@@ -425,6 +437,8 @@ class TechWorld extends World with TapCallbacks {
       _doorManager.recomputeNearbyLockedDoor();
     }
     _bubbleManager.update(dt);
+    // Drive @mention pulse auto-timeout (bounded; stops un-acked pulses).
+    _mentionController?.tick();
   }
 
   /// Listen for gameReady and process pending Dreamfinder participant.
@@ -650,6 +664,20 @@ class TechWorld extends World with TapCallbacks {
     _bubbleManager.removeBubble(participant.identity);
   }
 
+  /// Resolve a player UID to its on-screen avatar — local or remote — or null
+  /// if that player isn't present locally (the graceful-degradation case for
+  /// the mention beacon/arc). Used by [MentionWorldController].
+  PositionComponent? _avatarForUid(String uid) {
+    if (uid == _userPlayerComponent.id) return _userPlayerComponent;
+    return _otherPlayerComponentsMap[uid];
+  }
+
+  /// Display name for a player UID, for the mention beacon's cosmetic label.
+  String _displayNameForUid(String uid) {
+    if (uid == _userPlayerComponent.id) return _userPlayerComponent.displayName;
+    return _otherPlayerComponentsMap[uid]?.displayName ?? '';
+  }
+
   /// Handle an avatar update from a remote player.
   void _handleAvatarUpdate(AvatarUpdate update) {
     final playerComponent = _otherPlayerComponentsMap[update.playerId];
@@ -732,6 +760,25 @@ class TechWorld extends World with TapCallbacks {
     _log.info('Using LiveKitService from Locator');
     _bubbleManager.setLiveKitService(_liveKitService!);
 
+    _mentionController = MentionWorldController(
+      pulseController: MentionPulseController(),
+      localUid: userId,
+      avatarLookup: _avatarForUid,
+      addToWorld: add,
+      displayNameLookup: _displayNameForUid,
+      publishAck: (uid, messageId) {
+        _liveKitService?.publishJson(
+          {
+            'type': LiveKitTopic.mentionAck.wire,
+            'messageId': messageId,
+            'timestamp': DateTime.now().toIso8601String(),
+          },
+          topic: LiveKitTopic.mentionAck.wire,
+        );
+      },
+      reduceMotion: _bubbleManager.reduceMotion,
+    );
+
     _liveKitBridge = LiveKitGameBridge(
       liveKitService: _liveKitService!,
       userId: userId,
@@ -745,6 +792,19 @@ class TechWorld extends World with TapCallbacks {
       onAvatarUpdate: _handleAvatarUpdate,
       onSpeechTranscript: _handleSpeechTranscript,
       onDoorUnlock: _doorManager.handleRemoteDoorUnlock,
+      onPlayersMentioned: (mentionedUids, mentionerUid, messageId) {
+        _mentionController?.onPlayersMentioned(
+          mentionedUids: mentionedUids,
+          mentionerUid: mentionerUid,
+          messageId: messageId,
+        );
+      },
+      onMentionAck: (ackerUid, messageId) {
+        _mentionController?.onMentionAck(
+          ackerUid: ackerUid,
+          messageId: messageId,
+        );
+      },
       onMapInfoRequested: () =>
           _liveKitService?.publishMapInfo(currentMap.value),
       onMapSwitchReceived: (mapId) {
@@ -1373,6 +1433,11 @@ class TechWorld extends World with TapCallbacks {
     // Remove the in-world clock — its TimerService is torn down on leave.
     _clockComponent?.removeFromParent();
     _clockComponent = null;
+
+    // Drop any active mention pulses; beacons self-remove when no longer
+    // pulsing, and arcs self-remove on their own fade timer.
+    _mentionController?.clear();
+    _mentionController = null;
 
     for (final component in _otherPlayerComponentsMap.values) {
       component.removeFromParent();

--- a/lib/livekit/livekit_topic.dart
+++ b/lib/livekit/livekit_topic.dart
@@ -39,6 +39,15 @@ enum LiveKitTopic {
   helpRequest('help-request'),
   helpResponse('help-response'),
 
+  /// Acknowledgement that a mentioned player has *seen* a mention — broadcast
+  /// by the named player's OWN client when it opens the chat panel. All clients
+  /// stop that avatar's mention pulse on receiving it. Payload carries the
+  /// stable `messageId` of the originating mention so a concurrent mention of
+  /// the same player isn't cross-cancelled. The acked player's UID is the
+  /// transport-verified `senderId`, never the payload — a peer can only ack
+  /// its own mentions. Reliable. See `lib/flame/components/mention_beacon_component.dart`.
+  mentionAck('mention-ack'),
+
   // ── Bot / Oracle ──────────────────────────────────────────────────────────
   oracleRequest('oracle-request'),
   oracleResponse('oracle-response'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -499,6 +499,9 @@ class _MyAppState extends State<MyApp> {
             techWorld.setHideVideoBubbles(
                 await UserPreferences.hideVideoBubbles());
             techWorld.setReduceMotion(await UserPreferences.reduceMotion());
+            // A mention arriving while chat is already open auto-acks (the user
+            // has already "seen" it). `_chatCollapsed == false` means visible.
+            techWorld.isLocalChatOpen = () => !_chatCollapsed.value;
             await techWorld.connectToLiveKit(userId, _currentDisplayName);
 
             // Wire C: camera + mic (depends on server connection).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1174,6 +1174,10 @@ class _MyAppState extends State<MyApp> {
                                         initialDmPeerId: dmPeer,
                                         onDmPeerConsumed: () =>
                                             _activeDmPeer.value = null,
+                                        // Seeing chat acknowledges any mention of
+                                        // the local user (stops their pulse).
+                                        onOpened: () =>
+                                            locate<TechWorld>().onChatPanelOpened(),
                                       );
                                     },
                                   ),

--- a/test/chat/chat_message_test.dart
+++ b/test/chat/chat_message_test.dart
@@ -607,6 +607,15 @@ void main() {
         // The cap keeps the FIRST distinct UIDs (insertion order preserved).
         expect(parsed.first, equals('uid-0'));
       });
+
+      test('bounds the input SCAN even for a duplicate-stuffed hostile list',
+          () {
+        // 100k duplicates of one UID: only 1 distinct, but the scan must not
+        // walk the whole list — it stops at the scan cap and returns the UID.
+        final stuffed = List.filled(100000, 'spammer');
+        final parsed = ChatMessage.parseMentions(stuffed);
+        expect(parsed, equals(['spammer']));
+      });
     });
   });
 }

--- a/test/chat/chat_message_test.dart
+++ b/test/chat/chat_message_test.dart
@@ -577,5 +577,36 @@ void main() {
         expect(r.senderName, isNull);
       });
     });
+
+    group('parseMentions', () {
+      test('non-list drops to empty', () {
+        expect(ChatMessage.parseMentions('nope'), isEmpty);
+        expect(ChatMessage.parseMentions(null), isEmpty);
+        expect(ChatMessage.parseMentions(42), isEmpty);
+      });
+
+      test('keeps string elements, skips non-strings', () {
+        expect(
+          ChatMessage.parseMentions(['a', 1, null, 'b', true, 'c']),
+          equals(['a', 'b', 'c']),
+        );
+      });
+
+      test('dedupes repeated UIDs', () {
+        expect(
+          ChatMessage.parseMentions(['a', 'a', 'b', 'a']),
+          equals(['a', 'b']),
+        );
+      });
+
+      test('caps at maxMentions distinct UIDs (bounded resource at the wire)',
+          () {
+        final huge = List.generate(1000, (i) => 'uid-$i');
+        final parsed = ChatMessage.parseMentions(huge);
+        expect(parsed.length, equals(ChatMessage.maxMentions));
+        // The cap keeps the FIRST distinct UIDs (insertion order preserved).
+        expect(parsed.first, equals('uid-0'));
+      });
+    });
   });
 }

--- a/test/chat/chat_panel_test.dart
+++ b/test/chat/chat_panel_test.dart
@@ -203,6 +203,91 @@ void main() {
       expect(find.text('Original question'), findsNWidgets(2));
     });
   });
+
+  group('ChatPanel @mentions', () {
+    late _FakeLiveKit fakeLiveKit;
+    late ChatService chatService;
+
+    setUp(() {
+      fakeLiveKit = _FakeLiveKit();
+      chatService = ChatService(liveKitService: fakeLiveKit);
+      chatService.setBotStatusForTest(BotStatus.idle);
+    });
+
+    tearDown(() => chatService.dispose());
+
+    Future<void> pumpPanel(WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 1200,
+            child: ChatPanel(
+              chatService: chatService,
+              liveKitService: fakeLiveKit,
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('typing @ opens the picker; selecting inserts @Name and '
+        'publishes the UID', (tester) async {
+      await pumpPanel(tester);
+
+      // The local user "Me" is always a mention candidate. Type "@M".
+      await tester.enterText(find.byType(TextField), '@M');
+      await tester.pump();
+
+      // Picker row for "Me" appears.
+      expect(find.text('Me'), findsOneWidget);
+
+      // Select it → inserts "@Me " into the field.
+      await tester.tap(find.text('Me'));
+      await tester.pumpAndSettle();
+      expect(
+        find.widgetWithText(TextField, '@Me '),
+        findsOneWidget,
+      );
+
+      // Send → the published chat payload carries the structured mentions UID.
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      final chatPublish = fakeLiveKit.published.firstWhere(
+        (m) => (m['payload'] as Map)['type'] == 'chat',
+      );
+      final payload = chatPublish['payload'] as Map<String, dynamic>;
+      expect(payload['mentions'], equals(['me']));
+      expect(payload['text'], equals('@Me'));
+
+      // Group sendMessage opens a 30s response-timeout timer + a 100ms scroll
+      // timer; drain both so no timer outlives the tree.
+      await tester.pump(const Duration(seconds: 31));
+    });
+
+    testWidgets('an inbound message with @Name highlights the span',
+        (tester) async {
+      fakeLiveKit._data.add(DataChannelMessage(
+        senderId: 'peer',
+        topic: 'chat',
+        data: _utf8Json({
+          'text': 'hey @Me look here',
+          'id': 'g-1',
+          'senderName': 'Peer',
+        }),
+      ));
+      await tester.pump();
+      await pumpPanel(tester);
+
+      // The message renders via Text.rich; find the RichText carrying the body.
+      final richText = tester.widgetList<RichText>(find.byType(RichText)).where(
+        (rt) => rt.text.toPlainText().contains('hey @Me look here'),
+      );
+      expect(richText, isNotEmpty,
+          reason: 'the inbound mention message should render');
+    });
+  });
 }
 
 List<int> _utf8Json(Map<String, dynamic> map) => utf8.encode(jsonEncode(map));

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -1248,6 +1248,28 @@ void main() {
         expect(payload['mentions'], equals(['bob-uid']));
       });
 
+      test('sendMessage dispatches PlayersMentioned LOCALLY so the sender '
+          'witnesses their own mention (LiveKit does not loop self back)',
+          () async {
+        unawaited(chatService.sendMessage(
+          'hey @Bob',
+          mentions: ['bob-uid'],
+        ));
+        await pumpEventQueue();
+
+        expect(mentions(), hasLength(1));
+        // The mentioner is our own authenticated identity, not a payload value.
+        expect(mentions().single.mentionerUid, equals('test-user-id'));
+        expect(mentions().single.mentionedUids, equals(['bob-uid']));
+      });
+
+      test('sendMessage with no mentions dispatches no PlayersMentioned',
+          () async {
+        unawaited(chatService.sendMessage('plain'));
+        await pumpEventQueue();
+        expect(mentions(), isEmpty);
+      });
+
       test('sendMessage with no mentions omits the field entirely', () async {
         unawaited(chatService.sendMessage('plain message'));
         await pumpEventQueue();

--- a/test/chat/chat_service_test.dart
+++ b/test/chat/chat_service_test.dart
@@ -20,6 +20,8 @@ import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/chat_service.dart';
 import 'package:tech_world/livekit/data_topic.dart';
 import 'package:tech_world/chat/conversation.dart';
+import 'package:tech_world/events/dispatch.dart';
+import 'package:tech_world/events/types.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/flame/shared/direction.dart';
@@ -1215,6 +1217,123 @@ void main() {
         expect(reply.replyToMessageId, equals('someone:999'));
         expect(reply.replyToText, equals('a question'));
         expect(reply.replyToSenderName, equals('Asker'));
+      });
+    });
+
+    group('@mentions', () {
+      late List<AppEvent> dispatched;
+
+      setUp(() {
+        dispatched = [];
+        clearSinks();
+        registerSink(dispatched.add);
+      });
+
+      tearDown(clearSinks);
+
+      List<PlayersMentioned> mentions() =>
+          dispatched.whereType<PlayersMentioned>().toList();
+
+      test('sendMessage publishes an atomic mentions UID list', () async {
+        unawaited(chatService.sendMessage(
+          'hey @Bob',
+          mentions: ['bob-uid'],
+        ));
+        await pumpEventQueue();
+
+        final chatPublish = fakeLiveKit.publishedMessages.firstWhere(
+          (m) => m['topic'] == DataTopic.chat.wireName,
+        );
+        final payload = chatPublish['payload'] as Map<String, dynamic>;
+        expect(payload['mentions'], equals(['bob-uid']));
+      });
+
+      test('sendMessage with no mentions omits the field entirely', () async {
+        unawaited(chatService.sendMessage('plain message'));
+        await pumpEventQueue();
+
+        final chatPublish = fakeLiveKit.publishedMessages.firstWhere(
+          (m) => m['topic'] == DataTopic.chat.wireName,
+        );
+        final payload = chatPublish['payload'] as Map<String, dynamic>;
+        expect(payload.containsKey('mentions'), isFalse);
+      });
+
+      test('incoming mention dispatches PlayersMentioned with the named UID',
+          () async {
+        fakeLiveKit.simulateChatFromOtherUser('alice-uid', {
+          'id': 'msg-1',
+          'text': 'ping @Me',
+          'senderName': 'Alice',
+          'mentions': ['my-uid', 'other-uid'],
+        });
+        await pumpEventQueue();
+
+        expect(mentions(), hasLength(1));
+        expect(mentions().single.mentionedUids, equals(['my-uid', 'other-uid']));
+        expect(mentions().single.messageId, equals('msg-1'));
+      });
+
+      test(
+          'mentionerUid is the TRANSPORT senderId, never the spoofed payload '
+          'senderId', () async {
+        // Hostile payload claims to be from "victim-uid"; the transport layer
+        // says it came from "attacker-uid". The dispatched event must credit
+        // the transport identity — mirrors the PR #490 reply trust test.
+        fakeLiveKit.simulateChatFromOtherUser('attacker-uid', {
+          'id': 'msg-2',
+          'text': 'gotcha @X',
+          'senderName': 'Totally Not An Attacker',
+          'senderId': 'victim-uid', // spoof attempt in payload
+          'mentions': ['x-uid'],
+        });
+        await pumpEventQueue();
+
+        expect(mentions(), hasLength(1));
+        expect(mentions().single.mentionerUid, equals('attacker-uid'),
+            reason: 'transport identity must win over payload senderId');
+      });
+
+      test('malformed mentions field is dropped, no throw, no dispatch',
+          () async {
+        // A non-list mentions value must not throw or fabricate a mention.
+        fakeLiveKit.simulateChatFromOtherUser('alice-uid', {
+          'id': 'msg-3',
+          'text': 'garbage',
+          'senderName': 'Alice',
+          'mentions': 'not-a-list',
+        });
+        // Mixed list: non-string elements are skipped.
+        fakeLiveKit.simulateChatFromOtherUser('alice-uid', {
+          'id': 'msg-4',
+          'text': 'mixed',
+          'senderName': 'Alice',
+          'mentions': ['good-uid', 42, null, 'also-good'],
+        });
+        await pumpEventQueue();
+
+        // msg-3 had no valid mentions → no dispatch. msg-4 keeps the two strings.
+        expect(mentions(), hasLength(1));
+        expect(mentions().single.messageId, equals('msg-4'));
+        expect(mentions().single.mentionedUids, equals(['good-uid', 'also-good']));
+        // The chat messages themselves still landed (parse never threw).
+        expect(
+          chatService.currentMessages.where((m) => m.text == 'garbage'),
+          hasLength(1),
+        );
+      });
+
+      test('a chat message with an empty mentions list dispatches nothing',
+          () async {
+        fakeLiveKit.simulateChatFromOtherUser('alice-uid', {
+          'id': 'msg-5',
+          'text': 'no mentions here',
+          'senderName': 'Alice',
+          'mentions': <String>[],
+        });
+        await pumpEventQueue();
+
+        expect(mentions(), isEmpty);
       });
     });
   });

--- a/test/chat/mention_composer_test.dart
+++ b/test/chat/mention_composer_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/chat/mention_composer.dart';
+
+void main() {
+  const alice = MentionCandidate(uid: 'alice-uid', displayName: 'Alice');
+  const bob = MentionCandidate(uid: 'bob-uid', displayName: 'Bob');
+  const albert = MentionCandidate(uid: 'albert-uid', displayName: 'Albert');
+  final all = [alice, bob, albert];
+
+  group('activeQuery', () {
+    test('detects a bare @ at end of text', () {
+      final q = MentionComposer.activeQuery('hey @', 5);
+      expect(q, isNotNull);
+      expect(q!.query, equals(''));
+      expect(q.atIndex, equals(4));
+    });
+
+    test('detects a partial @query', () {
+      final q = MentionComposer.activeQuery('hey @Al', 7);
+      expect(q!.query, equals('Al'));
+      expect(q.atIndex, equals(4));
+    });
+
+    test('@ at the very start is valid', () {
+      final q = MentionComposer.activeQuery('@bo', 3);
+      expect(q!.query, equals('bo'));
+      expect(q.atIndex, equals(0));
+    });
+
+    test('an @ embedded in a word (email-like) is NOT a mention', () {
+      expect(MentionComposer.activeQuery('me@host', 7), isNull);
+    });
+
+    test('whitespace after @ ends the token', () {
+      // Cursor is after the space — no active mention.
+      expect(MentionComposer.activeQuery('@Alice ', 7), isNull);
+    });
+
+    test('cursor before the @ is not in the token', () {
+      expect(MentionComposer.activeQuery('hey @Al', 2), isNull);
+    });
+  });
+
+  group('filter', () {
+    test('blank query returns all', () {
+      expect(MentionComposer.filter(all, ''), equals(all));
+    });
+
+    test('case-insensitive substring match preserves order', () {
+      final r = MentionComposer.filter(all, 'al');
+      expect(r.map((c) => c.uid), equals(['alice-uid', 'albert-uid']));
+    });
+
+    test('no match returns empty', () {
+      expect(MentionComposer.filter(all, 'zzz'), isEmpty);
+    });
+  });
+
+  group('insert', () {
+    test('replaces the @query token with @Name and a trailing space', () {
+      final ins = MentionComposer.insert(
+        text: 'hey @Al',
+        atIndex: 4,
+        cursor: 7,
+        chosen: alice,
+      );
+      expect(ins.text, equals('hey @Alice '));
+      expect(ins.cursor, equals('hey @Alice '.length));
+      expect(ins.uid, equals('alice-uid'));
+    });
+
+    test('preserves text after the cursor', () {
+      final ins = MentionComposer.insert(
+        text: 'hey @Al you there',
+        atIndex: 4,
+        cursor: 7,
+        chosen: alice,
+      );
+      expect(ins.text, equals('hey @Alice  you there'));
+    });
+  });
+
+  group('survivingUids', () {
+    test('keeps a UID whose @Name token is still in the text', () {
+      expect(
+        MentionComposer.survivingUids('hi @Alice and @Bob', [alice, bob]),
+        equals(['alice-uid', 'bob-uid']),
+      );
+    });
+
+    test('drops a UID whose @Name token was deleted', () {
+      expect(
+        MentionComposer.survivingUids('hi @Bob', [alice, bob]),
+        equals(['bob-uid']),
+      );
+    });
+
+    test('does not match @Name as a substring of a longer token', () {
+      // @Alice picked, but text only has @AliceXYZ → not a real mention.
+      expect(
+        MentionComposer.survivingUids('hi @AliceXYZ', [alice]),
+        isEmpty,
+      );
+    });
+
+    test('dedupes repeated picks of the same UID', () {
+      expect(
+        MentionComposer.survivingUids('hi @Bob @Bob', [bob, bob]),
+        equals(['bob-uid']),
+      );
+    });
+  });
+}

--- a/test/chat/mention_text_test.dart
+++ b/test/chat/mention_text_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/chat/mention_text.dart';
+
+void main() {
+  const base = TextStyle(color: Color(0xFFFFFFFF));
+  const mention = TextStyle(color: Color(0xFFFFC247));
+
+  List<InlineSpan> spansFor(String t) =>
+      buildMentionSpans(t, baseStyle: base, mentionStyle: mention);
+
+  // Flatten to (text, isMention) pairs for assertions.
+  List<({String text, bool isMention})> flat(String t) => spansFor(t)
+      .whereType<TextSpan>()
+      .map((s) => (text: s.text ?? '', isMention: s.style == mention))
+      .toList();
+
+  test('plain text has no mention spans', () {
+    final f = flat('hello world');
+    expect(f.where((s) => s.isMention), isEmpty);
+    expect(f.map((s) => s.text).join(), equals('hello world'));
+  });
+
+  test('highlights an @mention mid-sentence', () {
+    final f = flat('hey @Alice how are you');
+    final mentions = f.where((s) => s.isMention).map((s) => s.text).toList();
+    expect(mentions, equals(['@Alice']));
+    // Round-trips to the original text.
+    expect(f.map((s) => s.text).join(), equals('hey @Alice how are you'));
+  });
+
+  test('highlights an @mention at the start', () {
+    final f = flat('@Bob hi');
+    expect(f.first.isMention, isTrue);
+    expect(f.first.text, equals('@Bob'));
+  });
+
+  test('does not highlight an email-like @', () {
+    final f = flat('email me@host.com please');
+    expect(f.where((s) => s.isMention), isEmpty);
+  });
+
+  test('highlights multiple mentions', () {
+    final f = flat('@Alice and @Bob');
+    expect(
+      f.where((s) => s.isMention).map((s) => s.text),
+      equals(['@Alice', '@Bob']),
+    );
+    expect(f.map((s) => s.text).join(), equals('@Alice and @Bob'));
+  });
+}

--- a/test/events/dispatch_test.dart
+++ b/test/events/dispatch_test.dart
@@ -167,6 +167,7 @@ void main() {
         RemoteDoorUnlocked() => 'remote_door',
         GroupMessageSent() => 'group_msg',
         DmSent() => 'dm',
+        PlayersMentioned() => 'mentioned',
         BotSpoke() => 'bot',
         AppLogRecord() => 'log',
         // AV pipeline diagnostics

--- a/test/events/pii_marker_test.dart
+++ b/test/events/pii_marker_test.dart
@@ -47,7 +47,7 @@ void main() {
   // classes do not expose their subtypes for runtime enumeration, so a
   // true exhaustiveness check at runtime would need code generation.
   //
-  // For the foreseeable scale (34 subtypes, low churn) the
+  // For the foreseeable scale (35 subtypes, low churn) the
   // compile-time gate is the load-bearing property; this test makes the
   // runtime classification of representatives explicit and pins them to
   // the declared switch values.
@@ -58,7 +58,7 @@ void main() {
     // asserts on a known concrete type.
     void check(AppEvent event, PiiPolicy expected) {
       final declared = switch (event) {
-        // PII subtypes (25)
+        // PII subtypes (26)
         SpellCastFailed() => PiiPolicy.pii,
         RoomJoined() => PiiPolicy.pii,
         UserSignedIn() => PiiPolicy.pii,
@@ -73,6 +73,7 @@ void main() {
         BotSpoke() => PiiPolicy.pii,
         GroupMessageSent() => PiiPolicy.pii,
         DmSent() => PiiPolicy.pii,
+        PlayersMentioned() => PiiPolicy.pii,
         AppLogRecord() => PiiPolicy.pii,
         // AV pipeline PII (10 — participant identity)
         AvPipelineSnapshot() => PiiPolicy.pii,
@@ -130,7 +131,7 @@ void main() {
       // here for the runtime classification to be pinned — see the
       // group comment above for what this list does and does not prove.
       final piiEvents = <AppEvent>[
-        // PII (25)
+        // PII (26)
         SpellCastFailed(
           reason: CastFailureReason.noMatch,
           transcript: 'ignis',
@@ -148,6 +149,11 @@ void main() {
         BotSpoke(text: 'hi', context: BotSpokeContext.group),
         GroupMessageSent(messageId: 'm'),
         DmSent(peerId: 'p', conversationId: 'c'),
+        PlayersMentioned(
+          mentionedUids: ['x'],
+          mentionerUid: 'y',
+          messageId: 'm',
+        ),
         AppLogRecord(
           loggerName: 'L',
           severity: LogSeverity.info,
@@ -240,8 +246,8 @@ void main() {
       // Cardinality cross-check: keeps this list and the switch above
       // honest against the same expected subtype count. Bump together
       // when adding a new subtype.
-      expect(events.length, 44);
-      expect(piiEvents.length, 25);
+      expect(events.length, 45);
+      expect(piiEvents.length, 26);
       expect(nonPiiEvents.length, 19);
 
       for (final event in piiEvents) {

--- a/test/flame/components/mention_beacon_component_test.dart
+++ b/test/flame/components/mention_beacon_component_test.dart
@@ -1,0 +1,74 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/components/mention_beacon_component.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+
+void main() {
+  group('MentionBeaconComponent', () {
+    late MentionPulseController controller;
+    late DateTime now;
+
+    setUp(() {
+      now = DateTime(2026, 6, 22, 12);
+      controller = MentionPulseController(clock: () => now);
+    });
+
+    MentionBeaconComponent build() => MentionBeaconComponent(
+          mentionedUid: 'bob',
+          controller: controller,
+          displayName: 'Bob',
+          reduceMotion: false,
+        );
+
+    test('is a world PositionComponent', () {
+      expect(build(), isA<PositionComponent>());
+    });
+
+    testWithGame<FlameGame>(
+      'self-removes from its parent once the pulse stops',
+      FlameGame.new,
+      (game) async {
+        controller.onMention(
+          mentionedUid: 'bob',
+          mentionerUid: 'alice',
+          messageId: 'm1',
+        );
+
+        final parent = PositionComponent();
+        await game.world.add(parent);
+        await game.ready();
+
+        final beacon = build();
+        await parent.add(beacon);
+        await game.ready();
+        expect(parent.children.contains(beacon), isTrue);
+
+        // Still pulsing → still attached after a frame.
+        game.update(0.016);
+        await game.ready();
+        expect(parent.children.contains(beacon), isTrue);
+
+        // Pulse stops (ack) → beacon removes itself on the next update.
+        controller.onAck(mentionedUid: 'bob', messageId: 'm1');
+        game.update(0.016);
+        await game.ready();
+        expect(parent.children.contains(beacon), isFalse,
+            reason: 'beacon should self-remove when no longer pulsing');
+      },
+    );
+
+    test('reduceMotion settles the bloom instantly (no animation gate)', () {
+      final beacon = MentionBeaconComponent(
+        mentionedUid: 'bob',
+        controller: controller,
+        displayName: 'Bob',
+        reduceMotion: true,
+      );
+      // With reduce-motion the bloom is immediate — exercised via render not
+      // throwing; the key guarantee is it doesn't depend on animated time.
+      expect(beacon.reduceMotion, isTrue);
+    });
+  });
+}

--- a/test/flame/mention_pulse_controller_test.dart
+++ b/test/flame/mention_pulse_controller_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+
+void main() {
+  group('MentionPulseController', () {
+    late MentionPulseController controller;
+    late DateTime now;
+
+    setUp(() {
+      now = DateTime(2026, 6, 22, 12, 0, 0);
+      controller = MentionPulseController(clock: () => now);
+    });
+
+    void advance(Duration d) => now = now.add(d);
+
+    test('a mention starts a pulse on the named avatar', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      expect(controller.isPulsing('bob'), isTrue);
+      expect(controller.isPulsing('carol'), isFalse);
+    });
+
+    test('a matching ack stops the pulse', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      controller.onAck(mentionedUid: 'bob', messageId: 'm1');
+
+      expect(controller.isPulsing('bob'), isFalse);
+    });
+
+    test('a non-matching ack (wrong messageId) does NOT stop the pulse', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      // Ack carries a stale / different messageId — must not cancel.
+      controller.onAck(mentionedUid: 'bob', messageId: 'WRONG');
+
+      expect(controller.isPulsing('bob'), isTrue);
+    });
+
+    test('an ack for a different player does NOT stop this pulse', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      controller.onAck(mentionedUid: 'carol', messageId: 'm1');
+
+      expect(controller.isPulsing('bob'), isTrue);
+    });
+
+    test('the pulse auto-times out after the timeout window', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      // Just before the timeout: still pulsing.
+      advance(MentionPulseController.pulseTimeout - const Duration(seconds: 1));
+      controller.tick();
+      expect(controller.isPulsing('bob'), isTrue);
+
+      // Past the timeout: stops everywhere even with no ack.
+      advance(const Duration(seconds: 2));
+      controller.tick();
+      expect(controller.isPulsing('bob'), isFalse);
+    });
+
+    test(
+        'concurrent mentions of the same player keep the LATEST messageId; '
+        'an ack for the stale id does not cancel', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      // A second mention of bob arrives (different sender, new message).
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'carol',
+        messageId: 'm2',
+      );
+
+      // Ack for the FIRST mention should not silence the live pulse, because
+      // bob only acks once and the active mention is now m2.
+      controller.onAck(mentionedUid: 'bob', messageId: 'm1');
+      expect(controller.isPulsing('bob'), isTrue);
+
+      // Ack for the current mention stops it.
+      controller.onAck(mentionedUid: 'bob', messageId: 'm2');
+      expect(controller.isPulsing('bob'), isFalse);
+    });
+
+    test('a re-mention refreshes the timeout (does not expire on the old clock)',
+        () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      // Almost expire, then a fresh mention lands.
+      advance(MentionPulseController.pulseTimeout - const Duration(seconds: 1));
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'carol',
+        messageId: 'm2',
+      );
+
+      // Advance past the ORIGINAL deadline but within the refreshed window.
+      advance(const Duration(seconds: 2));
+      controller.tick();
+      expect(controller.isPulsing('bob'), isTrue,
+          reason: 'the re-mention should have reset the timeout clock');
+    });
+
+    test('notifies listeners on start, ack, and timeout', () {
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      expect(notifications, 1);
+
+      controller.onAck(mentionedUid: 'bob', messageId: 'm1');
+      expect(notifications, 2);
+
+      controller.onMention(
+        mentionedUid: 'carol',
+        mentionerUid: 'alice',
+        messageId: 'm2',
+      );
+      expect(notifications, 3);
+
+      advance(MentionPulseController.pulseTimeout + const Duration(seconds: 1));
+      controller.tick();
+      expect(notifications, 4, reason: 'timeout should notify');
+    });
+
+    test('tick with no expirations does not notify', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      advance(const Duration(seconds: 1));
+      controller.tick();
+      expect(notifications, 0);
+    });
+
+    test('the mentioner of an active pulse is recorded for the arc', () {
+      controller.onMention(
+        mentionedUid: 'bob',
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      expect(controller.mentionerOf('bob'), equals('alice'));
+      expect(controller.mentionerOf('nobody'), isNull);
+    });
+  });
+}

--- a/test/flame/mention_world_controller_test.dart
+++ b/test/flame/mention_world_controller_test.dart
@@ -1,0 +1,178 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/components/mention_arc_component.dart';
+import 'package:tech_world/flame/components/mention_beacon_component.dart';
+import 'package:tech_world/flame/mention/mention_pulse_controller.dart';
+import 'package:tech_world/flame/mention/mention_world_controller.dart';
+
+/// A stand-in avatar — any PositionComponent works since the controller only
+/// needs a parent to attach the beacon to and a position to sample.
+class _FakeAvatar extends PositionComponent {
+  _FakeAvatar(Vector2 pos) {
+    position = pos;
+  }
+}
+
+void main() {
+  group('MentionWorldController', () {
+    late DateTime now;
+    late MentionPulseController pulse;
+    late List<Component> added; // components added to the "world"
+    late List<({String uid, String messageId})> acks;
+    late Map<String, _FakeAvatar> avatars;
+    late MentionWorldController controller;
+
+    setUp(() {
+      now = DateTime(2026, 6, 22, 12);
+      pulse = MentionPulseController(clock: () => now);
+      added = [];
+      acks = [];
+      avatars = {
+        'me': _FakeAvatar(Vector2(0, 0)),
+        'alice': _FakeAvatar(Vector2(100, 0)),
+        'bob': _FakeAvatar(Vector2(200, 0)),
+      };
+      controller = MentionWorldController(
+        pulseController: pulse,
+        localUid: 'me',
+        avatarLookup: (uid) => avatars[uid],
+        addToWorld: added.add,
+        publishAck: (uid, messageId) =>
+            acks.add((uid: uid, messageId: messageId)),
+        reduceMotion: false,
+      );
+    });
+
+    test('a mention of a present player attaches a beacon to that avatar', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      final beacon = avatars['bob']!.children.whereType<MentionBeaconComponent>();
+      expect(beacon, hasLength(1));
+      expect(beacon.single.mentionedUid, equals('bob'));
+      expect(pulse.isPulsing('bob'), isTrue);
+    });
+
+    test('an arc is spawned from mentioner to named when both are present', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      expect(added.whereType<MentionArcComponent>(), hasLength(1));
+    });
+
+    test('a mention of an absent player still pulses but skips the beacon/arc',
+        () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['ghost'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      // State still tracks the pulse (other clients may render it once the
+      // avatar spawns), but nothing is attached locally.
+      expect(pulse.isPulsing('ghost'), isTrue);
+      expect(added.whereType<MentionArcComponent>(), isEmpty);
+    });
+
+    test('an absent mentioner degrades: bloom present, arc skipped', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'ghost-sender',
+        messageId: 'm1',
+      );
+
+      expect(avatars['bob']!.children.whereType<MentionBeaconComponent>(),
+          hasLength(1));
+      expect(added.whereType<MentionArcComponent>(), isEmpty,
+          reason: 'no arc when the mentioner avatar is not present locally');
+    });
+
+    test('does NOT self-pulse: the local user opening chat is not a mention',
+        () {
+      // Mentioning myself is allowed to bloom (others see it), but it must not
+      // broadcast an ack on its own — ack is a separate, deliberate signal.
+      controller.onPlayersMentioned(
+        mentionedUids: ['me'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      expect(acks, isEmpty);
+      expect(pulse.isPulsing('me'), isTrue);
+    });
+
+    test('opening chat acks every pulse currently naming the local user', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['me'],
+        mentionerUid: 'alice',
+        messageId: 'm-self',
+      );
+      // A pulse naming someone else must not be acked by me opening chat.
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm-bob',
+      );
+
+      controller.onLocalChatOpened();
+
+      expect(acks, hasLength(1));
+      expect(acks.single.uid, equals('me'));
+      expect(acks.single.messageId, equals('m-self'));
+    });
+
+    test('receiving a matching ack stops the local pulse', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      expect(pulse.isPulsing('bob'), isTrue);
+
+      controller.onMentionAck(
+        ackerUid: 'bob',
+        messageId: 'm1',
+      );
+
+      expect(pulse.isPulsing('bob'), isFalse);
+    });
+
+    test('an ack from the WRONG sender for a victim is ignored (trust)', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      // attacker tries to ack bob's pulse by claiming bob's uid in the payload,
+      // but onMentionAck is fed the TRANSPORT senderId by the bridge — which is
+      // 'attacker', not 'bob'. So it targets attacker's (nonexistent) pulse.
+      controller.onMentionAck(
+        ackerUid: 'attacker',
+        messageId: 'm1',
+      );
+
+      expect(pulse.isPulsing('bob'), isTrue,
+          reason: 'only the named player (transport identity) can ack');
+    });
+
+    test('tick drives auto-timeout', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+
+      now = now.add(MentionPulseController.pulseTimeout +
+          const Duration(seconds: 1));
+      controller.tick();
+
+      expect(pulse.isPulsing('bob'), isFalse);
+    });
+  });
+}

--- a/test/flame/mention_world_controller_test.dart
+++ b/test/flame/mention_world_controller_test.dart
@@ -18,8 +18,9 @@ void main() {
     late DateTime now;
     late MentionPulseController pulse;
     late List<Component> added; // components added to the "world"
-    late List<({String uid, String messageId})> acks;
+    late List<String> acks;
     late Map<String, _FakeAvatar> avatars;
+    late bool chatOpen;
     late MentionWorldController controller;
 
     setUp(() {
@@ -27,6 +28,7 @@ void main() {
       pulse = MentionPulseController(clock: () => now);
       added = [];
       acks = [];
+      chatOpen = false;
       avatars = {
         'me': _FakeAvatar(Vector2(0, 0)),
         'alice': _FakeAvatar(Vector2(100, 0)),
@@ -37,9 +39,9 @@ void main() {
         localUid: 'me',
         avatarLookup: (uid) => avatars[uid],
         addToWorld: added.add,
-        publishAck: (uid, messageId) =>
-            acks.add((uid: uid, messageId: messageId)),
+        publishAck: acks.add,
         reduceMotion: false,
+        isLocalChatOpen: () => chatOpen,
       );
     });
 
@@ -121,9 +123,7 @@ void main() {
 
       controller.onLocalChatOpened();
 
-      expect(acks, hasLength(1));
-      expect(acks.single.uid, equals('me'));
-      expect(acks.single.messageId, equals('m-self'));
+      expect(acks, equals(['m-self']));
     });
 
     test('receiving a matching ack stops the local pulse', () {
@@ -173,6 +173,73 @@ void main() {
       controller.tick();
 
       expect(pulse.isPulsing('bob'), isFalse);
+    });
+
+    test('a duplicate UID in the list does not create duplicate arcs', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob', 'bob', 'bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      expect(added.whereType<MentionArcComponent>(), hasLength(1));
+      expect(avatars['bob']!.children.whereType<MentionBeaconComponent>(),
+          hasLength(1));
+    });
+
+    test('reconcileBeaconFor attaches a beacon to a late-spawning avatar', () {
+      // Mention arrives before the avatar exists locally.
+      controller.onPlayersMentioned(
+        mentionedUids: ['ghost'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      expect(pulse.isPulsing('ghost'), isTrue);
+
+      // The avatar spawns later → reconcile attaches the beacon.
+      final ghost = _FakeAvatar(Vector2(300, 0));
+      controller.reconcileBeaconFor('ghost', ghost);
+      expect(ghost.children.whereType<MentionBeaconComponent>(), hasLength(1));
+    });
+
+    test('reconcileBeaconFor is a no-op when not pulsing', () {
+      final fresh = _FakeAvatar(Vector2(0, 0));
+      controller.reconcileBeaconFor('nobody', fresh);
+      expect(fresh.children.whereType<MentionBeaconComponent>(), isEmpty);
+    });
+
+    test('reconcileBeaconFor does not double-attach if a beacon exists', () {
+      controller.onPlayersMentioned(
+        mentionedUids: ['bob'],
+        mentionerUid: 'alice',
+        messageId: 'm1',
+      );
+      controller.reconcileBeaconFor('bob', avatars['bob']!);
+      expect(avatars['bob']!.children.whereType<MentionBeaconComponent>(),
+          hasLength(1));
+    });
+
+    test('a mention of me while chat is ALREADY open auto-acks immediately',
+        () {
+      chatOpen = true;
+      controller.onPlayersMentioned(
+        mentionedUids: ['me'],
+        mentionerUid: 'alice',
+        messageId: 'm-self',
+      );
+      expect(acks, equals(['m-self']),
+          reason: 'already-open chat should ack without waiting for re-open');
+      expect(pulse.isPulsing('me'), isFalse);
+    });
+
+    test('a mention of me while chat is CLOSED does not auto-ack', () {
+      chatOpen = false;
+      controller.onPlayersMentioned(
+        mentionedUids: ['me'],
+        mentionerUid: 'alice',
+        messageId: 'm-self',
+      );
+      expect(acks, isEmpty);
+      expect(pulse.isPulsing('me'), isTrue);
     });
   });
 }


### PR DESCRIPTION
## @mentions that light up the world

Typing `@Name` in group chat names a player. Their **avatar** blooms in the world (witnessed by everyone), a **light arc** travels from the mentioner's avatar to the named one, and if they haven't answered (chat closed) the bloom settles into a slow **public pulse** everyone sees — until they open chat (**ack**) or it **auto-times-out (~45s)**.

### Part 1 — plumbing
- **@-picker** in the group composer: filterable participant list (mirrors the reply-compose banner UX). Pure text logic extracted to `MentionComposer` (unit-tested: token detection, filter, insert, surviving-mention reconciliation).
- **Wire field**: `mentions: [uid,...]` on the chat payload. Parsed **defensively + atomically** via `ChatMessage.parseMentions` (`whereType<String>`, drop-whole-field on malformed) — same discipline as PR #490's reply-snapshot parse. The structured UID list is the **trust anchor**; inline `@Name` text is display-only.
- **Highlight** `@Name` spans in **both** group (`chat_panel.dart`) and DM (`dm_thread_view.dart`) via shared `buildMentionSpans`.

### Part 2 — the world event
- `ChatService` dispatches a `PlayersMentioned` domain event; the **bridge** routes chat-topic mentions + the new `mention-ack` topic to the world (mirrors `onDoorUnlock` / `onSpeechTranscript`).
- **Beacon on the AVATAR** (`PlayerComponent`), not the proximity-gated/hideable video bubble — a mention crosses the room to someone you're not near. `MentionBeaconComponent` is a child of the avatar (auto-follows). Reuses the ripple/glow math from `video_bubble_component.dart`; follows `countdown_clock_component.dart`'s shape.
- **Arc**: `MentionArcComponent` draws the fading light thread; degrades gracefully (skips) when either avatar isn't present locally, still blooms the named one if present.
- **Pulse lifecycle** (`MentionPulseController`, DI'd clock, fully unit-tested):
  - starts on mention,
  - stops on a **matching** `mention-ack` (stable `messageId` match key → concurrent mentions don't cross-cancel, stale acks don't silence),
  - independent **~45s auto-timeout** bounds it (never permanent),
  - re-mention refreshes both timeout and active messageId.
  - The **named player's own client** broadcasts the ack when it opens chat. A peer can only ack **its own** mention (ack UID = transport `senderId`).

### Trust boundary
`mentionerUid` and the ack's `ackerUid` are **always** the LiveKit transport-verified `senderId`, never the payload's self-reported one. Regression test: a payload claiming `senderId: victim` over transport `attacker` → the event credits **attacker** (verified by breaking the code → test fails → restore).

### Tunable feel — needs Nick's live eyes
**The VISUAL FEEL is unverified — I can't see the render.** Structure/wire/state-lifecycle are correct and tested; the look needs tuning live. All visual constants are NAMED at the top of:
- `lib/flame/components/mention_beacon_component.dart` — bloom duration/radius, pulse radius/amplitude/period, ripple lobes, color, label offset.
- `lib/flame/components/mention_arc_component.dart` — arc duration, stroke width, bow height.
- `MentionPulseController.pulseTimeout` — the ~45s timeout.

### Gate
`flutter analyze --fatal-infos` (lib+test) clean. `flutter test` → **2077 green** (added: composer, span builder, pulse-controller lifecycle, world-controller, beacon self-removal under a real Flame game, ChatService mention parse + trust test, picker widget test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
