### PR TITLE
fix(video): cap decoded bubble texture to display size (WebGL context loss)

### DIFF
--- a/lib/native/canvas_capture_web.dart
+++ b/lib/native/canvas_capture_web.dart
@@ -114,6 +114,12 @@ class CanvasCapture implements FrameSource {
             _offscreen!.getContext('2d')! as web.CanvasRenderingContext2D;
       }
 
+      // Clear first: the offscreen canvas is reused across frames, and the
+      // Dreamfinder source canvas can contain transparency — without a clear,
+      // source-over compositing would leave stale pixels showing through
+      // transparent regions.
+      _offscreenCtx!.clearRect(0, 0, w.toDouble(), h.toDouble());
+
       // Direct canvas-to-canvas copy via 2D context. The 5-arg drawImage
       // scales the full-res source down into the capped offscreen canvas.
       _offscreenCtx!.drawImage(

--- a/lib/native/canvas_capture_web.dart
+++ b/lib/native/canvas_capture_web.dart
@@ -17,6 +17,7 @@ import 'dart:js_interop';
 import 'dart:ui' as ui;
 
 import 'package:logging/logging.dart';
+import 'package:tech_world/native/decode_size.dart';
 import 'package:web/web.dart' as web;
 
 import 'frame_source.dart';
@@ -87,14 +88,21 @@ class CanvasCapture implements FrameSource {
     if (!_isCapturing) return;
     if (_frameInFlight) return;
 
-    final w = _canvas.width;
-    final h = _canvas.height;
-    if (w == 0 || h == 0) return;
+    final srcW = _canvas.width;
+    final srcH = _canvas.height;
+    if (srcW == 0 || srcH == 0) return;
+
+    // Cap the decoded texture to the displayed bubble size — decoding the
+    // source canvas at full res for a small bubble is the GPU memory pressure
+    // that triggers WebGL context loss (see kMaxBubbleDecodeDimension).
+    final decode = scaledDecodeSize(srcW, srcH, kMaxBubbleDecodeDimension);
+    final w = decode.width;
+    final h = decode.height;
 
     _frameInFlight = true;
 
     try {
-      // Ensure offscreen canvas matches source dimensions.
+      // Ensure offscreen canvas matches the (capped) decode dimensions.
       if (_offscreen == null ||
           _offscreen!.width != w ||
           _offscreen!.height != h) {
@@ -106,8 +114,15 @@ class CanvasCapture implements FrameSource {
             _offscreen!.getContext('2d')! as web.CanvasRenderingContext2D;
       }
 
-      // Direct canvas-to-canvas copy via 2D context.
-      _offscreenCtx!.drawImage(_canvas as web.CanvasImageSource, 0, 0);
+      // Direct canvas-to-canvas copy via 2D context. The 5-arg drawImage
+      // scales the full-res source down into the capped offscreen canvas.
+      _offscreenCtx!.drawImage(
+        _canvas as web.CanvasImageSource,
+        0,
+        0,
+        w.toDouble(),
+        h.toDouble(),
+      );
 
       // Read raw RGBA pixels via getImageData. This bypasses
       // createImageFromImageBitmap (CanvasKit's MakeLazyImageFromTextureSource)

--- a/lib/native/decode_size.dart
+++ b/lib/native/decode_size.dart
@@ -1,0 +1,38 @@
+// Pure, platform-independent sizing logic for decoded video-bubble textures.
+//
+// Kept free of `dart:ui` / `package:web` imports so it can be unit-tested in
+// the plain VM test runner (the web capture files that use it cannot — see
+// the dart_webrtc / package:web note in video_frame_web_v2.dart).
+
+/// Longest-side cap (px) for decoded video-bubble textures.
+///
+/// Video bubbles render as small circles (`bubbleSize` 64px, a few hundred px
+/// at high DPR), but cameras deliver 640x480–1280x720 frames. Decoding at the
+/// full camera resolution uploads a multi-megabyte RGBA texture every frame
+/// just to draw a thumbnail — tens-of-x more GPU memory than the display needs.
+/// That churn drives CanvasKit's WebGL context into memory pressure and, on
+/// Firefox, into context loss + heap corruption (the engine's own recovery then
+/// fails inside `MakeGrContext` with "index out of bounds"). Capping the
+/// longest side keeps the uploaded texture proportional to what's drawn: 256px
+/// gives crisp headroom for a 64px bubble even at 3x DPR (192px) while shrinking
+/// a 1280x720 frame's texture ~24x.
+const int kMaxBubbleDecodeDimension = 256;
+
+/// The readback/decode size for a [srcW]x[srcH] source frame, with the longest
+/// side capped to [maxDim] and aspect ratio preserved.
+///
+/// - Frames already within [maxDim] on both sides pass through unchanged (no
+///   upscaling — we only ever shrink).
+/// - Never returns a zero dimension for a non-empty source: extreme aspect
+///   ratios clamp the short side to a minimum of 1px.
+/// - Non-positive source dimensions pass through unchanged so callers can keep
+///   their existing zero-size guards.
+({int width, int height}) scaledDecodeSize(int srcW, int srcH, int maxDim) {
+  if (srcW <= 0 || srcH <= 0) return (width: srcW, height: srcH);
+  if (srcW <= maxDim && srcH <= maxDim) return (width: srcW, height: srcH);
+  final int longest = srcW >= srcH ? srcW : srcH;
+  final double scale = maxDim / longest;
+  final int w = (srcW * scale).round().clamp(1, maxDim);
+  final int h = (srcH * scale).round().clamp(1, maxDim);
+  return (width: w, height: h);
+}

--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -826,8 +826,21 @@ class VideoElementCapture implements FrameSource {
       // Then draw bitmap to canvas for pixel readback. We can't draw
       // HTMLVideoElement directly because the CanvasImageSource cast
       // may fail at runtime in package:web.
+      //
+      // resizeWidth/resizeHeight cap the ImageBitmap allocation itself at the
+      // decode size — without them createImageBitmap decodes the full-res
+      // frame (the bulk of the GPU pressure this fix targets) and the
+      // subsequent draw into the smaller readback canvas would CROP to the
+      // top-left rather than scale.
       final imageBitmap = await web.window
-          .createImageBitmap(_videoElement as web.ImageBitmapSource)
+          .createImageBitmap(
+            _videoElement as web.ImageBitmapSource,
+            web.ImageBitmapOptions(
+              resizeWidth: _width,
+              resizeHeight: _height,
+              resizeQuality: 'high',
+            ),
+          )
           .toDart;
 
       if (_readbackCanvas == null ||
@@ -841,7 +854,17 @@ class VideoElementCapture implements FrameSource {
             as web.CanvasRenderingContext2D;
       }
 
-      _readbackCtx!.drawImage(imageBitmap as web.CanvasImageSource, 0, 0);
+      // 5-arg drawImage scales to the decode size. The bitmap is already
+      // resized above, so this is a 1:1 draw in the happy path — but it
+      // guarantees correct scaling (not a crop) even if a browser ignores
+      // the createImageBitmap resize options.
+      _readbackCtx!.drawImage(
+        imageBitmap as web.CanvasImageSource,
+        0,
+        0,
+        _width.toDouble(),
+        _height.toDouble(),
+      );
       imageBitmap.close();
 
       final imageData =

--- a/lib/native/video_frame_web_v2.dart
+++ b/lib/native/video_frame_web_v2.dart
@@ -15,6 +15,7 @@ import 'dart:js_interop';
 import 'dart:ui' as ui;
 
 import 'package:logging/logging.dart';
+import 'package:tech_world/native/decode_size.dart';
 // dart_webrtc doesn't conditionally export MediaStreamTrackWeb, so
 // importing the barrel pulls in dart:js_interop and breaks native tests.
 // This file is web-only (conditional import in direct_track_capture.dart).
@@ -353,19 +354,26 @@ class DirectTrackCapture {
         return;
       }
 
-      // Update dimensions
-      _width = videoFrame.displayWidth;
-      _height = videoFrame.displayHeight;
+      // Source camera dimensions. The decoded texture is capped to what the
+      // small bubble actually draws — uploading a full-res frame every tick is
+      // the GPU memory pressure that triggers WebGL context loss on Firefox
+      // (see kMaxBubbleDecodeDimension in decode_size.dart).
+      final srcW = videoFrame.displayWidth;
+      final srcH = videoFrame.displayHeight;
 
       if (_frameNumber == 0) {
-        _log.fine('DirectTrackCapture: first VideoFrame ${_width}x$_height');
+        _log.fine('DirectTrackCapture: first VideoFrame ${srcW}x$srcH');
       }
 
-      if (_width == 0 || _height == 0) {
+      if (srcW == 0 || srcH == 0) {
         videoFrame.close();
         _frameInFlight = false;
         return;
       }
+
+      final decode = scaledDecodeSize(srcW, srcH, kMaxBubbleDecodeDimension);
+      _width = decode.width;
+      _height = decode.height;
 
       // Draw VideoFrame directly to offscreen canvas, read pixels, decode.
       // Mirrors canvas_capture_web.dart — no ImageBitmap, no createImageFromImageBitmap.
@@ -380,7 +388,15 @@ class DirectTrackCapture {
             as web.CanvasRenderingContext2D;
       }
 
-      _readbackCtx!.drawImage(videoFrame as web.CanvasImageSource, 0, 0);
+      // 5-arg drawImage scales the full-res source frame down into the
+      // capped readback canvas (_width/_height are the decode size).
+      _readbackCtx!.drawImage(
+        videoFrame as web.CanvasImageSource,
+        0,
+        0,
+        _width.toDouble(),
+        _height.toDouble(),
+      );
       // Close VideoFrame immediately to release video decoder resources.
       videoFrame.close();
 
@@ -799,8 +815,12 @@ class VideoElementCapture implements FrameSource {
     _frameInFlight = true;
 
     try {
-      _width = videoWidth;
-      _height = videoHeight;
+      // Cap the decoded texture to the displayed bubble size — see
+      // kMaxBubbleDecodeDimension. Avoids uploading full-res remote frames.
+      final decode =
+          scaledDecodeSize(videoWidth, videoHeight, kMaxBubbleDecodeDimension);
+      _width = decode.width;
+      _height = decode.height;
 
       // Create ImageBitmap from video (this works — original code did it).
       // Then draw bitmap to canvas for pixel readback. We can't draw

--- a/test/native/decode_size_test.dart
+++ b/test/native/decode_size_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/native/decode_size.dart';
+
+void main() {
+  group('scaledDecodeSize', () {
+    test('passes through when both sides are within the cap', () {
+      final r = scaledDecodeSize(200, 150, 256);
+      expect(r.width, 200);
+      expect(r.height, 150);
+    });
+
+    test('exactly at the cap is a pass-through (no upscaling)', () {
+      final r = scaledDecodeSize(256, 256, 256);
+      expect(r.width, 256);
+      expect(r.height, 256);
+    });
+
+    test('caps the longest side preserving aspect ratio (landscape 16:9)', () {
+      final r = scaledDecodeSize(1280, 720, 256);
+      expect(r.width, 256);
+      expect(r.height, 144); // 720 * 256/1280
+    });
+
+    test('caps the longest side preserving aspect ratio (portrait 9:16)', () {
+      final r = scaledDecodeSize(720, 1280, 256);
+      expect(r.height, 256);
+      expect(r.width, 144);
+    });
+
+    test('square frame caps to maxDim x maxDim', () {
+      final r = scaledDecodeSize(1000, 1000, 256);
+      expect(r.width, 256);
+      expect(r.height, 256);
+    });
+
+    test('never returns a zero dimension for extreme aspect ratios', () {
+      final r = scaledDecodeSize(4096, 8, 256);
+      expect(r.width, 256);
+      expect(r.height, greaterThanOrEqualTo(1));
+    });
+
+    test('common webcam 640x480 shrinks with 4:3 preserved', () {
+      final r = scaledDecodeSize(640, 480, 256);
+      expect(r.width, 256);
+      expect(r.height, 192); // 480 * 256/640
+    });
+
+    test('non-positive source dimensions pass through unchanged', () {
+      final r = scaledDecodeSize(0, 0, 256);
+      expect(r.width, 0);
+      expect(r.height, 0);
+    });
+  });
+}


### PR DESCRIPTION
## What happened

Andy's video froze mid-meetup while audio kept working (Firefox 152, M3 Max). Console showed `failed to create GrContext. Error: RuntimeError: index out of bounds` → CPU fallback → repeated `index out of bounds` in `canvaskit.wasm`.

That line is **Flutter's own WebGL context-loss recovery failing**, not the absence of recovery. The engine *does* self-heal context loss (`canvas_provider.dart:30` listener → `surface.onContextLost()` acquires a fresh canvas → `recreateContextForCanvas()`), but in Andy's case the recreate itself threw `index out of bounds` (wasm heap corruption), then software fallback also threw — so the canvas froze while LiveKit audio (separate pipeline) kept going. "Video froze, audio fine" is the fingerprint.

## Root cause: massive wasted GPU texture churn

Video bubbles render as **64px circles** (`bubbleSize`), but all three web capture paths decoded **every frame at full camera resolution**: `_readbackCanvas` sized to `videoFrame.displayWidth × displayHeight`, `drawImage(source, 0, 0)` at full size, `decodeImageFromPixels` at full size. A 1280×720 frame uploads a **3.5MB RGBA texture every 66ms, per bubble**, to draw a thumbnail. The draw already downscales on the GPU (`drawImageRect` into the small circle) — the waste is in the *upload*, not the draw.

At 15fps × 2 player bubbles that's ~105 MB/s of texture upload churn → the GPU memory pressure that tips Firefox's WebGL context into loss + heap corruption.

## The fix

Cap the decoded texture's longest side to **256px** (aspect-ratio preserved, never upscaled) across all three web decode paths — `DirectTrackCapture` (local), `VideoElementCapture` (remote), `CanvasCapture` (Dreamfinder). A 5-arg `drawImage` scales the source down into the capped readback canvas.

| Source | Before/frame | After | Reduction |
|---|---|---|---|
| 1280×720 | 3.5 MB | 144 KB | ~25× |
| 640×480 | 1.2 MB | 196 KB | ~6× |

256px into a 64px bubble is 4× supersampled at 1× DPR (1.3× at retina) — quality should be crisp or imperceptibly different.

## Why this is safe regardless of the crash

Correct on two independent grounds: (1) pure waste elimination — uploading 3.5MB to draw a 64px circle is wrong regardless of whether it cures the crash; (2) it directly attacks the leading crash hypothesis (GPU memory pressure). No downside path.

## Design

Pure sizing logic in `lib/native/decode_size.dart` (no `dart:ui`/`package:web`) so it's unit-testable in the VM runner (the web capture files can't be — `package:web`/`dart_webrtc`). 8 tests in `test/native/decode_size_test.dart`, all green. `flutter analyze --fatal-infos` clean.

## Verification status

- **Proven:** texture churn ↓ ~6–25×; logic unit-tested; analyzer clean.
- **Pending:** live Firefox confirmation that it *cures* the context-loss crash (can't repro the GPU/driver event headlessly) and that bubble sharpness is unaffected. Ship-then-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)