### PR TITLE
feat(rooms): foyer room-presence — see who's in each room before entry

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,6 +13,24 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // Shared-world presence — "who is in which room right now", read by the
+    // room browser to show occupancy before joining. Any signed-in user can
+    // read the whole collection (presence is public in a shared world). A user
+    // may only write their OWN presence document: the doc key must equal their
+    // UID AND the userId field must match, so nobody can plant a ghost in a
+    // room as someone else.
+    match /presence/{userId} {
+      allow read: if request.auth != null;
+      // Create/update: the doc key must be the caller's UID AND the userId
+      // field must match — nobody can plant presence as someone else.
+      allow create, update: if request.auth != null &&
+        request.auth.uid == userId &&
+        request.resource.data.userId == userId;
+      // Delete: only your own doc (request.resource is null on delete, so the
+      // field check above cannot apply here).
+      allow delete: if request.auth != null && request.auth.uid == userId;
+    }
+
     // Rooms — public rooms are readable by any authenticated user (for browse
     // listing). Private rooms are only readable by their owner and editors.
     // The listPublicRooms() query filters on isPublic == true so it satisfies

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -481,6 +481,7 @@ class _MyAppState extends State<MyApp> {
             room: room,
             userId: userId,
             displayName: _currentDisplayName,
+            avatarId: _selectedAvatar?.id ?? defaultAvatar.id,
             onStateChanged: () => setState(() {}),
             onReconnectWorld: () {
                 final tw = locate<TechWorld>();
@@ -742,6 +743,7 @@ class _MyAppState extends State<MyApp> {
           room: room,
           userId: userId,
           displayName: _currentDisplayName,
+          avatarId: _selectedAvatar?.id ?? defaultAvatar.id,
           onStateChanged: () => setState(() {}),
           onReconnectWorld: () {
                 final tw = locate<TechWorld>();

--- a/lib/rooms/presence_entry.dart
+++ b/lib/rooms/presence_entry.dart
@@ -1,0 +1,71 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// One participant's presence in the shared world — "who is where right now".
+///
+/// Persisted as a single document at `/presence/{userId}`, written when a user
+/// connects to a room (see [PresenceService.enter]) and deleted on a graceful
+/// leave. Read in aggregate by the room browser to show occupancy *before* a
+/// user joins — the foyer/common-room moment where you see who is gathered.
+///
+/// NOTE on staleness: an ungraceful disconnect (tab close, crash, network
+/// drop) leaves a ghost document behind, because Firestore — unlike Realtime
+/// Database — has no `onDisconnect` hook. The authoritative cure is a LiveKit
+/// `participant_left` webhook driving a Cloud Function cleanup (LiveKit is the
+/// real source of truth for connection state). Until that lands, [lastSeen] is
+/// stored so a future heartbeat/TTL sweep can reap ghosts.
+class PresenceEntry {
+  const PresenceEntry({
+    required this.userId,
+    required this.displayName,
+    required this.avatarId,
+    required this.currentRoomId,
+    this.lastSeen,
+  });
+
+  /// Firebase UID — also the document key under `/presence`.
+  final String userId;
+
+  /// Denormalized display name so the browser renders without a profile lookup.
+  final String displayName;
+
+  /// The user's chosen avatar id (see `predefinedAvatars`). May be a value this
+  /// client doesn't recognise if the set diverges across versions; consumers
+  /// fall back to the default avatar when [avatarById] returns null.
+  final String avatarId;
+
+  /// The Firestore room document id the user is currently connected to.
+  final String currentRoomId;
+
+  /// Server timestamp of the last presence write. Null until the server round
+  /// trip resolves. Stored for future ghost-reaping; not yet used for filtering
+  /// (without a heartbeat it only marks join time, so filtering on it would
+  /// wrongly drop long-present users).
+  final DateTime? lastSeen;
+
+  /// Firestore field map. `lastSeen` is written as a server timestamp by
+  /// [PresenceService], not here, so it is intentionally omitted.
+  Map<String, dynamic> toFirestore() => {
+        'userId': userId,
+        'displayName': displayName,
+        'avatarId': avatarId,
+        'currentRoomId': currentRoomId,
+      };
+
+  /// Parse a presence document. Returns null when required fields are missing or
+  /// the wrong type — a malformed doc is dropped, never crashes the stream
+  /// (same defensive-parse discipline as the chat wire seam).
+  static PresenceEntry? tryParse(String docId, Map<String, dynamic>? data) {
+    if (data == null) return null;
+    final displayName = data['displayName'];
+    final avatarId = data['avatarId'];
+    final currentRoomId = data['currentRoomId'];
+    if (currentRoomId is! String || currentRoomId.isEmpty) return null;
+    return PresenceEntry(
+      userId: docId,
+      displayName: displayName is String ? displayName : '',
+      avatarId: avatarId is String ? avatarId : '',
+      currentRoomId: currentRoomId,
+      lastSeen: (data['lastSeen'] as Timestamp?)?.toDate(),
+    );
+  }
+}

--- a/lib/rooms/presence_entry.dart
+++ b/lib/rooms/presence_entry.dart
@@ -60,12 +60,17 @@ class PresenceEntry {
     final avatarId = data['avatarId'];
     final currentRoomId = data['currentRoomId'];
     if (currentRoomId is! String || currentRoomId.isEmpty) return null;
+    // Guard with `is`, NOT `as Timestamp?`: a rules-legal doc with a non-null
+    // non-Timestamp lastSeen (e.g. lastSeen: 'bad') makes `as Timestamp?` THROW
+    // rather than yield null — and that throw escapes tryParse and errors the
+    // whole browser stream. Same `as`-cast wire-seam teardown class as #364/#366.
+    final rawLastSeen = data['lastSeen'];
     return PresenceEntry(
       userId: docId,
       displayName: displayName is String ? displayName : '',
       avatarId: avatarId is String ? avatarId : '',
       currentRoomId: currentRoomId,
-      lastSeen: (data['lastSeen'] as Timestamp?)?.toDate(),
+      lastSeen: rawLastSeen is Timestamp ? rawLastSeen.toDate() : null,
     );
   }
 }

--- a/lib/rooms/presence_service.dart
+++ b/lib/rooms/presence_service.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tech_world/rooms/presence_entry.dart';
+
+/// Reads and writes the shared-world presence layer in Firestore.
+///
+/// Presence answers "who is in each room right now" so the room browser can
+/// show occupancy before a user joins. It rides the existing Firestore
+/// room-lifecycle bus (the same place room documents and deletion live) rather
+/// than introducing a new transport.
+///
+/// Lifecycle wiring lives in [RoomSession]: [enter] on a successful connect (and
+/// reconnect), [leave] on a graceful leave. The browser calls [watchAll] and
+/// groups with [groupByRoom].
+class PresenceService {
+  PresenceService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  static const _collection = 'presence';
+
+  CollectionReference<Map<String, dynamic>> get _presence =>
+      _firestore.collection(_collection);
+
+  /// Record that [userId] is now present in [roomId].
+  ///
+  /// Overwrites any prior presence doc for the user (moving rooms is just a new
+  /// `currentRoomId`), and stamps `lastSeen` with the server clock. Safe to call
+  /// again on reconnect — it is idempotent on the document key.
+  Future<void> enter({
+    required String userId,
+    required String displayName,
+    required String avatarId,
+    required String roomId,
+  }) async {
+    final entry = PresenceEntry(
+      userId: userId,
+      displayName: displayName,
+      avatarId: avatarId,
+      currentRoomId: roomId,
+    );
+    await _presence.doc(userId).set({
+      ...entry.toFirestore(),
+      'lastSeen': FieldValue.serverTimestamp(),
+    });
+  }
+
+  /// Remove [userId]'s presence document — they have left the world (or moved
+  /// back to the browser). Best-effort: a missing document is not an error.
+  Future<void> leave(String userId) async {
+    await _presence.doc(userId).delete();
+  }
+
+  /// Stream of every present user across all rooms. The browser subscribes once
+  /// and groups client-side with [groupByRoom] — one stream feeds every card,
+  /// rather than one listener per room.
+  Stream<List<PresenceEntry>> watchAll() {
+    return _presence.snapshots().map((snapshot) => snapshot.docs
+        .map((doc) => PresenceEntry.tryParse(doc.id, doc.data()))
+        .whereType<PresenceEntry>()
+        .toList());
+  }
+
+  /// Group a flat presence list by room id. Pure function — no I/O — so the
+  /// foyer's core logic is unit-testable without a database.
+  static Map<String, List<PresenceEntry>> groupByRoom(
+      List<PresenceEntry> entries) {
+    final grouped = <String, List<PresenceEntry>>{};
+    for (final entry in entries) {
+      (grouped[entry.currentRoomId] ??= []).add(entry);
+    }
+    return grouped;
+  }
+}

--- a/lib/rooms/room_browser.dart
+++ b/lib/rooms/room_browser.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:tech_world/auth/user_profile_service.dart';
 import 'package:tech_world/flame/maps/map_identity.dart';
 import 'package:tech_world/rooms/manage_editors_dialog.dart';
+import 'package:tech_world/rooms/presence_entry.dart';
+import 'package:tech_world/rooms/presence_service.dart';
 import 'package:tech_world/rooms/room_data.dart';
 import 'package:tech_world/rooms/room_service.dart';
 
@@ -17,11 +21,16 @@ class RoomBrowser extends StatefulWidget {
     required this.onCreateRoom,
     this.canCreateRoom = true,
     this.onSignOut,
+    this.presenceService,
     super.key,
   });
 
   final RoomService roomService;
   final String userId;
+
+  /// Source of room occupancy ("who is in each room"). Injectable for tests;
+  /// defaults to a Firestore-backed [PresenceService] in production.
+  final PresenceService? presenceService;
 
   /// Whether the current user can create rooms (false for anonymous guests).
   final bool canCreateRoom;
@@ -42,20 +51,33 @@ class RoomBrowser extends StatefulWidget {
 class _RoomBrowserState extends State<RoomBrowser>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
+  late final PresenceService _presenceService;
   List<RoomData>? _publicRooms;
   List<RoomData>? _myRooms;
   bool _loading = true;
   String? _error;
 
+  /// Live room occupancy, keyed by room id. One subscription over the whole
+  /// `/presence` collection feeds every card.
+  Map<String, List<PresenceEntry>> _occupancy = const {};
+  StreamSubscription<List<PresenceEntry>>? _presenceSub;
+
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
+    _presenceService = widget.presenceService ?? PresenceService();
     _loadRooms();
+    _presenceSub = _presenceService.watchAll().listen((entries) {
+      if (mounted) {
+        setState(() => _occupancy = PresenceService.groupByRoom(entries));
+      }
+    });
   }
 
   @override
   void dispose() {
+    _presenceSub?.cancel();
     _tabController.dispose();
     super.dispose();
   }
@@ -269,6 +291,7 @@ class _RoomBrowserState extends State<RoomBrowser>
           return _RoomCard(
             room: room,
             isOwner: room.isOwner(widget.userId),
+            occupants: _occupancy[room.id] ?? const [],
             onTap: () => widget.onJoinRoom(room),
             onDelete: room.isOwner(widget.userId)
                 ? () => _deleteRoom(room)
@@ -331,12 +354,16 @@ class _RoomCard extends StatelessWidget {
     required this.room,
     required this.isOwner,
     required this.onTap,
+    this.occupants = const [],
     this.onDelete,
     this.onManageEditors,
   });
 
   final RoomData room;
   final bool isOwner;
+
+  /// Users currently in this room — rendered as a foyer presence row.
+  final List<PresenceEntry> occupants;
   final VoidCallback onTap;
   final VoidCallback? onDelete;
   final VoidCallback? onManageEditors;
@@ -396,6 +423,10 @@ class _RoomCard extends StatelessWidget {
                         fontSize: 12,
                       ),
                     ),
+                    if (occupants.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      _OccupancyRow(occupants: occupants),
+                    ],
                   ],
                 ),
               ),
@@ -435,6 +466,145 @@ class _RoomCard extends StatelessWidget {
               const Icon(Icons.chevron_right, color: Colors.white38),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The foyer "who's gathered" indicator: a horizontal stack of overlapping
+/// occupant avatars, an overflow "+N" chip when there are more than fit, and a
+/// count. This is the world-as-substrate moment — you see who's in a room
+/// before you walk in, the way you'd glance into a tavern common-room.
+class _OccupancyRow extends StatelessWidget {
+  const _OccupancyRow({required this.occupants});
+
+  final List<PresenceEntry> occupants;
+
+  static const _maxVisible = 5;
+  static const _size = 24.0;
+  static const _overlap = 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = occupants.take(_maxVisible).toList();
+    final overflow = occupants.length - visible.length;
+    final chipCount = visible.length + (overflow > 0 ? 1 : 0);
+    final step = _size - _overlap;
+    final stackWidth = _size + (chipCount - 1) * step;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          height: _size,
+          width: stackWidth,
+          child: Stack(
+            children: [
+              for (var i = 0; i < visible.length; i++)
+                Positioned(
+                  left: i * step,
+                  child: _OccupantAvatar(entry: visible[i], size: _size),
+                ),
+              if (overflow > 0)
+                Positioned(
+                  left: visible.length * step,
+                  child: _OverflowChip(count: overflow, size: _size),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          occupants.length == 1 ? '1 here' : '${occupants.length} here',
+          style: const TextStyle(
+            color: Color(0xFF4CAF50),
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A single occupant rendered as a colored initial circle. Deterministic color
+/// from the user id so a given person looks consistent across cards/sessions.
+/// (Sprite-head avatars are a planned follow-up; an initial circle always
+/// renders and reads instantly — the Gather/Slack foyer idiom.)
+class _OccupantAvatar extends StatelessWidget {
+  const _OccupantAvatar({required this.entry, required this.size});
+
+  final PresenceEntry entry;
+  final double size;
+
+  static const _palette = [
+    Color(0xFF4FC3F7),
+    Color(0xFFD97757),
+    Color(0xFF81C784),
+    Color(0xFFBA68C8),
+    Color(0xFFFFB74D),
+    Color(0xFF4DB6AC),
+    Color(0xFFF06292),
+  ];
+
+  Color get _color => _palette[entry.userId.hashCode.abs() % _palette.length];
+
+  String get _initial {
+    final name = entry.displayName.trim();
+    return name.isEmpty ? '?' : name.substring(0, 1).toUpperCase();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: entry.displayName.isEmpty ? 'Someone' : entry.displayName,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: _color,
+          shape: BoxShape.circle,
+          border: Border.all(color: const Color(0xFF16213E), width: 2),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          _initial,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: size * 0.45,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The "+N" chip shown when a room has more occupants than fit in the stack.
+class _OverflowChip extends StatelessWidget {
+  const _OverflowChip({required this.count, required this.size});
+
+  final int count;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: const Color(0xFF3D3D5C),
+        shape: BoxShape.circle,
+        border: Border.all(color: const Color(0xFF16213E), width: 2),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '+$count',
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: size * 0.34,
+          fontWeight: FontWeight.bold,
         ),
       ),
     );

--- a/lib/rooms/room_browser.dart
+++ b/lib/rooms/room_browser.dart
@@ -548,9 +548,9 @@ class _OccupantAvatar extends StatelessWidget {
     Color(0xFFF06292),
   ];
 
-  // Explicit FNV-ish hash over code units — unlike String.hashCode this is
-  // stable across runs/platforms, so a given user keeps the same color between
-  // sessions, not just within one process.
+  // Explicit polynomial (Java-style, *31) hash over code units — unlike
+  // String.hashCode this is stable across runs/platforms, so a given user keeps
+  // the same color between sessions, not just within one process.
   static int _stableHash(String s) {
     var h = 0;
     for (final unit in s.codeUnits) {

--- a/lib/rooms/room_browser.dart
+++ b/lib/rooms/room_browser.dart
@@ -548,11 +548,24 @@ class _OccupantAvatar extends StatelessWidget {
     Color(0xFFF06292),
   ];
 
-  Color get _color => _palette[entry.userId.hashCode.abs() % _palette.length];
+  // Explicit FNV-ish hash over code units — unlike String.hashCode this is
+  // stable across runs/platforms, so a given user keeps the same color between
+  // sessions, not just within one process.
+  static int _stableHash(String s) {
+    var h = 0;
+    for (final unit in s.codeUnits) {
+      h = (h * 31 + unit) & 0x7fffffff;
+    }
+    return h;
+  }
+
+  Color get _color => _palette[_stableHash(entry.userId) % _palette.length];
 
   String get _initial {
     final name = entry.displayName.trim();
-    return name.isEmpty ? '?' : name.substring(0, 1).toUpperCase();
+    // characters.first, not substring(0, 1): grapheme-safe so a leading emoji
+    // or surrogate-pair name doesn't render a broken half-character.
+    return name.isEmpty ? '?' : name.characters.first.toUpperCase();
   }
 
   @override

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -7,6 +7,7 @@ import 'package:tech_world/chat/chat_message_repository.dart';
 import 'package:tech_world/chat/chat_service.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/proximity/proximity_service.dart';
+import 'package:tech_world/rooms/presence_service.dart';
 import 'package:tech_world/rooms/room_data.dart';
 import 'package:tech_world/services/dreamfinder_client.dart';
 import 'package:tech_world/events/dispatch.dart';
@@ -42,12 +43,15 @@ class RoomSession {
     required this.room,
     required this.userId,
     required this.displayName,
+    required this.avatarId,
     required FirebaseFirestore firestore,
+    required PresenceService presenceService,
     required void Function() onStateChanged,
     required Future<void> Function() onReconnectWorld,
     required void Function() onRoomDeleted,
     List<Duration>? reconnectDelays,
   })  : _firestore = firestore,
+        _presenceService = presenceService,
         _onStateChanged = onStateChanged,
         _onReconnectWorld = onReconnectWorld,
         _onRoomDeleted = onRoomDeleted,
@@ -66,7 +70,15 @@ class RoomSession {
   final RoomData room;
   final String userId;
   final String displayName;
+
+  /// The user's chosen avatar id, denormalized into the presence document so
+  /// the room browser can render occupant avatars without a profile lookup.
+  final String avatarId;
   final FirebaseFirestore _firestore;
+
+  /// Writes/clears this user's presence in the shared-world `/presence`
+  /// collection across the connection lifecycle.
+  final PresenceService _presenceService;
 
   // --- Callbacks ---
 
@@ -122,6 +134,7 @@ class RoomSession {
     required RoomData room,
     required String userId,
     required String displayName,
+    required String avatarId,
     required void Function() onStateChanged,
     required Future<void> Function() onReconnectWorld,
     required void Function() onRoomDeleted,
@@ -129,6 +142,7 @@ class RoomSession {
     @visibleForTesting ChatMessageRepository? chatMessageRepository,
     @visibleForTesting LiveKitService? liveKitService,
     @visibleForTesting FirebaseFirestore? firestore,
+    @visibleForTesting PresenceService? presenceService,
     @visibleForTesting List<Duration>? reconnectDelays,
   }) {
     final liveKit = liveKitService ??
@@ -164,6 +178,8 @@ class RoomSession {
     Locator.add<ProximityService>(proximity);
     Locator.add<TimerService>(timer);
 
+    final fs = firestore ?? FirebaseFirestore.instance;
+
     return RoomSession._(
       liveKitService: liveKit,
       chatService: chat,
@@ -173,7 +189,9 @@ class RoomSession {
       room: room,
       userId: userId,
       displayName: displayName,
-      firestore: firestore ?? FirebaseFirestore.instance,
+      avatarId: avatarId,
+      firestore: fs,
+      presenceService: presenceService ?? PresenceService(firestore: fs),
       onStateChanged: onStateChanged,
       onReconnectWorld: onReconnectWorld,
       onRoomDeleted: onRoomDeleted,
@@ -197,11 +215,30 @@ class RoomSession {
 
     if (result == ConnectionResult.connected) {
       _listenForConnectionLoss();
-    } else if (result != ConnectionResult.alreadyConnected) {
+      _enterPresence();
+    } else if (result == ConnectionResult.alreadyConnected) {
+      _enterPresence();
+    } else {
       connectionFailed.value = true;
       connectionMessage.value = failureMessageFor(result);
     }
     return result;
+  }
+
+  /// Announce this user's presence in the room. Best-effort and unawaited: a
+  /// presence-write failure must never break the connection flow, so errors are
+  /// logged and swallowed rather than propagated.
+  void _enterPresence() {
+    if (_disposed) return;
+    _presenceService
+        .enter(
+          userId: userId,
+          displayName: displayName,
+          avatarId: avatarId,
+          roomId: room.id,
+        )
+        .catchError((Object e) =>
+            _log.warning('Failed to write presence for room ${room.id}: $e'));
   }
 
   /// Listen to the Firestore room document; fire [_onRoomDeleted] when the
@@ -284,6 +321,9 @@ class RoomSession {
           await _onReconnectWorld();
           if (_disposed) return;
           _listenForConnectionLoss();
+          // Re-announce presence: the prior doc may have been reaped (or never
+          // written if the first connect failed).
+          _enterPresence();
           await enableMedia();
           if (_disposed) return;
 
@@ -339,6 +379,13 @@ class RoomSession {
   /// producers (ChatService → ProximityService → LiveKitService).
   Future<void> leave() async {
     _disposed = true;
+
+    // Clear presence first so the user vanishes from the foyer promptly.
+    // Best-effort — a delete failure must not block teardown.
+    await _presenceService
+        .leave(userId)
+        .catchError((Object e) => _log.warning('Failed to clear presence: $e'));
+
     _roomDeletionSub?.cancel();
     _roomDeletionSub = null;
     _connectionLostSub?.cancel();

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -225,12 +225,18 @@ class RoomSession {
     return result;
   }
 
+  /// The in-flight presence write, if any. [leave] awaits it before deleting so
+  /// a fast connect→leave can't let a still-resolving `enter()` land *after* the
+  /// delete and resurrect a ghost doc (the delete must be the last writer).
+  Future<void>? _pendingEnter;
+
   /// Announce this user's presence in the room. Best-effort and unawaited: a
   /// presence-write failure must never break the connection flow, so errors are
-  /// logged and swallowed rather than propagated.
+  /// logged and swallowed rather than propagated. The future is retained in
+  /// [_pendingEnter] so [leave] can serialize the delete after it.
   void _enterPresence() {
     if (_disposed) return;
-    _presenceService
+    _pendingEnter = _presenceService
         .enter(
           userId: userId,
           displayName: displayName,
@@ -380,7 +386,15 @@ class RoomSession {
   Future<void> leave() async {
     _disposed = true;
 
-    // Clear presence first so the user vanishes from the foyer promptly.
+    // Serialize the delete AFTER any in-flight enter() so a fast connect→leave
+    // can't let the write land after the delete (which would resurrect a ghost).
+    // The enter future already swallows its own errors via catchError.
+    final pendingEnter = _pendingEnter;
+    if (pendingEnter != null) {
+      await pendingEnter;
+    }
+
+    // Clear presence so the user vanishes from the foyer promptly.
     // Best-effort — a delete failure must not block teardown.
     await _presenceService
         .leave(userId)

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -225,18 +225,23 @@ class RoomSession {
     return result;
   }
 
-  /// The in-flight presence write, if any. [leave] awaits it before deleting so
-  /// a fast connect→leave can't let a still-resolving `enter()` land *after* the
-  /// delete and resurrect a ghost doc (the delete must be the last writer).
+  /// The TAIL of the serialized presence-write chain. Every [_enterPresence]
+  /// chains onto this, and [leave] awaits it before deleting — so the delete is
+  /// the last writer even across MULTIPLE overlapping enters (e.g. an initial
+  /// connect write still in flight when a reconnect fires a second one). A
+  /// single-slot "latest future" would let an earlier enter land after the
+  /// delete and resurrect a ghost; the chain closes that window.
   Future<void>? _pendingEnter;
 
-  /// Announce this user's presence in the room. Best-effort and unawaited: a
-  /// presence-write failure must never break the connection flow, so errors are
-  /// logged and swallowed rather than propagated. The future is retained in
-  /// [_pendingEnter] so [leave] can serialize the delete after it.
+  /// Announce this user's presence in the room. Best-effort: a presence-write
+  /// failure must never break the connection flow, so errors are logged and
+  /// swallowed. The write STARTS synchronously (in flight immediately), and the
+  /// tail accumulates every in-flight write via `Future.wait` so [leave] awaits
+  /// ALL of them before deleting — even multiple overlapping enters (connect +
+  /// reconnect) — guaranteeing the delete is the last writer.
   void _enterPresence() {
     if (_disposed) return;
-    _pendingEnter = _presenceService
+    final enterFuture = _presenceService
         .enter(
           userId: userId,
           displayName: displayName,
@@ -245,6 +250,9 @@ class RoomSession {
         )
         .catchError((Object e) =>
             _log.warning('Failed to write presence for room ${room.id}: $e'));
+    final prior = _pendingEnter;
+    _pendingEnter =
+        prior == null ? enterFuture : Future.wait([prior, enterFuture]);
   }
 
   /// Listen to the Firestore room document; fire [_onRoomDeleted] when the

--- a/test/architecture/room_session_contract_test.dart
+++ b/test/architecture/room_session_contract_test.dart
@@ -35,6 +35,7 @@ void main() {
         room: testRoom,
         userId: 'user-1',
         displayName: 'Test User',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () {},

--- a/test/rooms/presence_service_test.dart
+++ b/test/rooms/presence_service_test.dart
@@ -101,6 +101,22 @@ void main() {
       await sub.cancel();
     });
 
+    test('a non-Timestamp lastSeen does not throw — parses with null lastSeen',
+        () async {
+      // Regression: `as Timestamp?` would THROW on a non-null non-Timestamp
+      // value, escaping tryParse and erroring the whole stream.
+      final entry = PresenceEntry.tryParse('u1', {
+        'userId': 'u1',
+        'displayName': 'Ada',
+        'avatarId': 'npc12',
+        'currentRoomId': 'room-a',
+        'lastSeen': 'definitely-not-a-timestamp',
+      });
+      expect(entry, isNotNull);
+      expect(entry!.lastSeen, isNull);
+      expect(entry.currentRoomId, 'room-a');
+    });
+
     test('drops malformed docs without crashing the stream', () async {
       // A doc missing currentRoomId is unparseable and must be skipped.
       await firestore

--- a/test/rooms/presence_service_test.dart
+++ b/test/rooms/presence_service_test.dart
@@ -1,0 +1,153 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/rooms/presence_entry.dart';
+import 'package:tech_world/rooms/presence_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late PresenceService service;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    service = PresenceService(firestore: firestore);
+  });
+
+  group('PresenceService.enter', () {
+    test('writes a presence doc keyed by userId with the right fields',
+        () async {
+      await service.enter(
+        userId: 'u1',
+        displayName: 'Ada',
+        avatarId: 'npc12',
+        roomId: 'room-a',
+      );
+
+      final doc = await firestore.collection('presence').doc('u1').get();
+      expect(doc.exists, isTrue);
+      final data = doc.data()!;
+      expect(data['userId'], 'u1');
+      expect(data['displayName'], 'Ada');
+      expect(data['avatarId'], 'npc12');
+      expect(data['currentRoomId'], 'room-a');
+      expect(data['lastSeen'], isNotNull, reason: 'server timestamp stamped');
+    });
+
+    test('is idempotent on the doc key — re-entering overwrites currentRoomId',
+        () async {
+      await service.enter(
+        userId: 'u1',
+        displayName: 'Ada',
+        avatarId: 'npc12',
+        roomId: 'room-a',
+      );
+      await service.enter(
+        userId: 'u1',
+        displayName: 'Ada',
+        avatarId: 'npc12',
+        roomId: 'room-b',
+      );
+
+      final snap = await firestore.collection('presence').get();
+      expect(snap.docs.length, 1, reason: 'one user => one doc');
+      expect(snap.docs.single.data()['currentRoomId'], 'room-b');
+    });
+  });
+
+  group('PresenceService.leave', () {
+    test('deletes the user\'s presence doc', () async {
+      await service.enter(
+        userId: 'u1',
+        displayName: 'Ada',
+        avatarId: 'npc12',
+        roomId: 'room-a',
+      );
+      await service.leave('u1');
+
+      final doc = await firestore.collection('presence').doc('u1').get();
+      expect(doc.exists, isFalse);
+    });
+
+    test('is a no-op (no throw) when the doc does not exist', () async {
+      await expectLater(service.leave('ghost'), completes);
+    });
+  });
+
+  group('PresenceService.watchAll', () {
+    test('emits parsed entries and reacts to add/remove', () async {
+      final emissions = <List<PresenceEntry>>[];
+      final sub = service.watchAll().listen(emissions.add);
+
+      await service.enter(
+        userId: 'u1',
+        displayName: 'Ada',
+        avatarId: 'npc12',
+        roomId: 'room-a',
+      );
+      await service.enter(
+        userId: 'u2',
+        displayName: 'Grace',
+        avatarId: 'npc13',
+        roomId: 'room-a',
+      );
+      await service.leave('u1');
+      // Let the stream settle.
+      await Future<void>.delayed(Duration.zero);
+
+      final last = emissions.last;
+      expect(last.map((e) => e.userId), ['u2']);
+      expect(last.single.displayName, 'Grace');
+      expect(last.single.currentRoomId, 'room-a');
+
+      await sub.cancel();
+    });
+
+    test('drops malformed docs without crashing the stream', () async {
+      // A doc missing currentRoomId is unparseable and must be skipped.
+      await firestore
+          .collection('presence')
+          .doc('bad')
+          .set({'displayName': 'No Room'});
+      await firestore.collection('presence').doc('u1').set({
+        'userId': 'u1',
+        'displayName': 'Ada',
+        'avatarId': 'npc12',
+        'currentRoomId': 'room-a',
+      });
+
+      final entries = await service.watchAll().first;
+      expect(entries.map((e) => e.userId), ['u1'],
+          reason: 'malformed doc dropped, valid one kept');
+    });
+  });
+
+  group('PresenceService.groupByRoom', () {
+    test('buckets entries by currentRoomId', () {
+      final entries = [
+        const PresenceEntry(
+            userId: 'u1',
+            displayName: 'Ada',
+            avatarId: 'npc12',
+            currentRoomId: 'room-a'),
+        const PresenceEntry(
+            userId: 'u2',
+            displayName: 'Grace',
+            avatarId: 'npc13',
+            currentRoomId: 'room-a'),
+        const PresenceEntry(
+            userId: 'u3',
+            displayName: 'Linus',
+            avatarId: 'npc11',
+            currentRoomId: 'room-b'),
+      ];
+
+      final grouped = PresenceService.groupByRoom(entries);
+      expect(grouped.keys.toSet(), {'room-a', 'room-b'});
+      expect(grouped['room-a']!.map((e) => e.userId), ['u1', 'u2']);
+      expect(grouped['room-b']!.map((e) => e.userId), ['u3']);
+    });
+
+    test('returns an empty map for no entries', () {
+      expect(PresenceService.groupByRoom([]), isEmpty);
+    });
+  });
+}

--- a/test/rooms/room_browser_test.dart
+++ b/test/rooms/room_browser_test.dart
@@ -1,0 +1,100 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/flame/maps/game_map.dart';
+import 'package:tech_world/rooms/presence_service.dart';
+import 'package:tech_world/rooms/room_browser.dart';
+import 'package:tech_world/rooms/room_data.dart';
+import 'package:tech_world/rooms/room_service.dart';
+
+const _room = RoomData(
+  id: 'room-a',
+  name: 'The Tavern',
+  ownerId: 'owner-1',
+  ownerDisplayName: 'Hostess',
+  mapData: GameMap(id: 'm', name: 'M', barriers: []),
+);
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late RoomService roomService;
+  late PresenceService presenceService;
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    // Seed one public room.
+    await firestore.collection('rooms').doc(_room.id).set(_room.toFirestore());
+    roomService = RoomService(collection: firestore.collection('rooms'));
+    presenceService = PresenceService(firestore: firestore);
+  });
+
+  Future<void> pumpBrowser(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: RoomBrowser(
+        roomService: roomService,
+        userId: 'viewer-1',
+        presenceService: presenceService,
+        onJoinRoom: (_) {},
+        onCreateRoom: () {},
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows no occupancy indicator for an empty room', (tester) async {
+    await pumpBrowser(tester);
+
+    expect(find.text('The Tavern'), findsOneWidget);
+    expect(find.textContaining('here'), findsNothing);
+  });
+
+  testWidgets('renders occupant count and initial when users are present',
+      (tester) async {
+    await presenceService.enter(
+      userId: 'u1',
+      displayName: 'Ada',
+      avatarId: 'npc12',
+      roomId: 'room-a',
+    );
+    await presenceService.enter(
+      userId: 'u2',
+      displayName: 'Grace',
+      avatarId: 'npc13',
+      roomId: 'room-a',
+    );
+
+    await pumpBrowser(tester);
+
+    expect(find.text('2 here'), findsOneWidget);
+    // Initial circles for both occupants.
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('G'), findsOneWidget);
+  });
+
+  testWidgets('singular label for a single occupant', (tester) async {
+    await presenceService.enter(
+      userId: 'u1',
+      displayName: 'Linus',
+      avatarId: 'npc11',
+      roomId: 'room-a',
+    );
+
+    await pumpBrowser(tester);
+
+    expect(find.text('1 here'), findsOneWidget);
+  });
+
+  testWidgets('occupancy only attaches to the matching room', (tester) async {
+    // Presence in a DIFFERENT room must not leak onto this card.
+    await presenceService.enter(
+      userId: 'u1',
+      displayName: 'Ada',
+      avatarId: 'npc12',
+      roomId: 'some-other-room',
+    );
+
+    await pumpBrowser(tester);
+
+    expect(find.textContaining('here'), findsNothing);
+  });
+}

--- a/test/rooms/room_session_test.dart
+++ b/test/rooms/room_session_test.dart
@@ -9,11 +9,39 @@ import 'package:tech_world/chat/chat_service.dart';
 import 'package:tech_world/flame/maps/game_map.dart';
 import 'package:tech_world/livekit/livekit_service.dart';
 import 'package:tech_world/proximity/proximity_service.dart';
+import 'package:tech_world/rooms/presence_service.dart';
 import 'package:tech_world/rooms/room_data.dart';
 import 'package:tech_world/rooms/room_session.dart';
 import 'package:tech_world/utils/locator.dart';
 
 class _FakeLiveKit extends Mock implements LiveKitService {}
+
+/// Records presence lifecycle calls without touching Firestore — verifies that
+/// [RoomSession] calls [PresenceService.enter]/[leave] at the right moments.
+/// The Firestore behaviour itself is covered by `presence_service_test.dart`.
+class _SpyPresence extends PresenceService {
+  _SpyPresence() : super(firestore: FakeFirebaseFirestore());
+
+  final List<String> enteredRooms = [];
+  final List<String> enteredAvatars = [];
+  final List<String> leftUsers = [];
+
+  @override
+  Future<void> enter({
+    required String userId,
+    required String displayName,
+    required String avatarId,
+    required String roomId,
+  }) async {
+    enteredRooms.add(roomId);
+    enteredAvatars.add(avatarId);
+  }
+
+  @override
+  Future<void> leave(String userId) async {
+    leftUsers.add(userId);
+  }
+}
 
 /// Stub the LiveKitService surface that ChatService and RoomSession touch
 /// during construction. Returns the live-stream controllers so callers can
@@ -61,6 +89,7 @@ RoomSession _createSession({
     room: room,
     userId: userId,
     displayName: displayName,
+    avatarId: 'npc11',
     onStateChanged: onStateChanged ?? () {},
     onReconnectWorld: onReconnectWorld ?? () async {},
     onRoomDeleted: onRoomDeleted ?? () {},
@@ -130,6 +159,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () {},
@@ -150,6 +180,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () {},
@@ -263,6 +294,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () => deletedCount++,
@@ -286,6 +318,69 @@ void main() {
     });
   });
 
+  group('presence lifecycle', () {
+    test('connect writes presence for the room; leave clears it', () async {
+      final liveKit = _FakeLiveKit();
+      _stubLiveKit(liveKit);
+      when(liveKit.connect)
+          .thenAnswer((_) async => ConnectionResult.connected);
+
+      final spy = _SpyPresence();
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        avatarId: 'npc12',
+        onStateChanged: () {},
+        onReconnectWorld: () async {},
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        presenceService: spy,
+      );
+
+      await session.connect();
+      expect(spy.enteredRooms, [_testRoom.id]);
+      expect(spy.enteredAvatars, ['npc12'],
+          reason: 'the chosen avatar rides the presence doc');
+      expect(spy.leftUsers, isEmpty);
+
+      await session.leave();
+      expect(spy.leftUsers, ['user-1']);
+    });
+
+    test('a failed connect does not write presence', () async {
+      final liveKit = _FakeLiveKit();
+      _stubLiveKit(liveKit);
+      when(liveKit.connect)
+          .thenAnswer((_) async => ConnectionResult.tokenAuthError);
+
+      final spy = _SpyPresence();
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        avatarId: 'npc12',
+        onStateChanged: () {},
+        onReconnectWorld: () async {},
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        presenceService: spy,
+      );
+
+      await session.connect();
+      expect(spy.enteredRooms, isEmpty,
+          reason: 'no presence on a failed connection');
+
+      await session.leave();
+    });
+  });
+
   group('reconnection use-after-dispose guard', () {
     test('leave during reconnect delay does not mutate disposed services',
         () async {
@@ -303,6 +398,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async => reconnectWorldCalls++,
         onRoomDeleted: () {},
@@ -360,6 +456,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () {},
@@ -407,6 +504,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async {},
         onRoomDeleted: () {},
@@ -454,6 +552,7 @@ void main() {
         room: _testRoom,
         userId: 'user-1',
         displayName: 'User 1',
+        avatarId: 'npc11',
         onStateChanged: () {},
         onReconnectWorld: () async => reconnectWorldCalls++,
         onRoomDeleted: () {},

--- a/test/rooms/room_session_test.dart
+++ b/test/rooms/room_session_test.dart
@@ -20,11 +20,18 @@ class _FakeLiveKit extends Mock implements LiveKitService {}
 /// [RoomSession] calls [PresenceService.enter]/[leave] at the right moments.
 /// The Firestore behaviour itself is covered by `presence_service_test.dart`.
 class _SpyPresence extends PresenceService {
-  _SpyPresence() : super(firestore: FakeFirebaseFirestore());
+  _SpyPresence({this.enterGate}) : super(firestore: FakeFirebaseFirestore());
+
+  /// When set, `enter` does not complete until this completes — lets a test
+  /// hold an enter() in flight and prove `leave` serializes after it.
+  final Future<void>? enterGate;
 
   final List<String> enteredRooms = [];
   final List<String> enteredAvatars = [];
   final List<String> leftUsers = [];
+
+  /// Ordered log of completed operations: `enter:<room>` / `leave:<user>`.
+  final List<String> order = [];
 
   @override
   Future<void> enter({
@@ -35,11 +42,14 @@ class _SpyPresence extends PresenceService {
   }) async {
     enteredRooms.add(roomId);
     enteredAvatars.add(avatarId);
+    if (enterGate != null) await enterGate;
+    order.add('enter:$roomId');
   }
 
   @override
   Future<void> leave(String userId) async {
     leftUsers.add(userId);
+    order.add('leave:$userId');
   }
 }
 
@@ -349,6 +359,47 @@ void main() {
 
       await session.leave();
       expect(spy.leftUsers, ['user-1']);
+    });
+
+    test('leave awaits an in-flight enter so the delete is the last writer',
+        () async {
+      // Regression for the connect→leave race: a fire-and-forget enter() that
+      // resolves AFTER leave()'s delete would resurrect a ghost doc. leave()
+      // must serialize the delete after the pending enter.
+      final liveKit = _FakeLiveKit();
+      _stubLiveKit(liveKit);
+      when(liveKit.connect)
+          .thenAnswer((_) async => ConnectionResult.connected);
+
+      final gate = Completer<void>();
+      final spy = _SpyPresence(enterGate: gate.future);
+      final session = RoomSession.create(
+        room: _testRoom,
+        userId: 'user-1',
+        displayName: 'User 1',
+        avatarId: 'npc12',
+        onStateChanged: () {},
+        onReconnectWorld: () async {},
+        onRoomDeleted: () {},
+        chatMessageRepository:
+            ChatMessageRepository(firestore: FakeFirebaseFirestore()),
+        liveKitService: liveKit,
+        firestore: FakeFirebaseFirestore(),
+        presenceService: spy,
+      );
+
+      await session.connect(); // enter() starts but blocks on the gate
+      final leaveFuture = session.leave();
+
+      // leave must NOT have deleted yet — the enter is still in flight.
+      await Future<void>.delayed(Duration.zero);
+      expect(spy.order, isEmpty, reason: 'leave is waiting on the pending enter');
+
+      gate.complete(); // let enter() resolve
+      await leaveFuture;
+
+      expect(spy.order, ['enter:test-room', 'leave:user-1'],
+          reason: 'delete must land after the enter write');
     });
 
     test('a failed connect does not write presence', () async {


### PR DESCRIPTION
## What (#1026)

A shared-world **presence layer**: the room browser now shows who's in each room *before* you join — the tavern common-room moment. Glance at a door, see who's gathered.

## How it's built

- **`PresenceEntry` + `PresenceService`** — writes `/presence/{uid}` on connect, deletes on leave, watches the whole collection and groups by room. `groupByRoom` is a pure function (unit-tested without Firestore). `tryParse` drops malformed docs without tearing down the stream (same defensive-parse discipline as the chat wire seam).
- **`RoomSession` lifecycle wiring** — `enter` on connect/reconnect success, `leave` on graceful leave. Best-effort + logged: a presence-write failure never breaks the connection flow. Threads the chosen `avatarId` from `main.dart` through both `create()` call sites.
- **`RoomBrowser`** — one live subscription over `/presence` feeds every card (not one listener per room); `_RoomCard` renders an overlapping avatar stack (colored initial circles + tooltips), a `+N` overflow chip, and an "N here" count.
- **`firestore.rules`** — `/presence` is world-readable; a user may only write their **own** doc (key==uid AND `userId` field==uid on create/update; key==uid on delete) so nobody can plant a ghost as someone else.

## Topology note

Rides the existing Firestore room-lifecycle bus (`RoomSession` already listens to `rooms/{id}` for deletion) — no new transport introduced.

## Tests

- 8 `PresenceService` tests (write/delete/watch/parse/group)
- 2 lifecycle-wiring tests (spy `PresenceService`: connect→enter, leave→leave, failed-connect→no-write)
- 4 `RoomBrowser` widget tests (render count/initials, room isolation, empty room)
- Full suite green (**2128**), `flutter analyze --fatal-infos` clean.

## Known tradeoffs (named, not silent)

1. **Ghost presence on ungraceful disconnect** (tab close, crash) — Firestore has no `onDisconnect`. The authoritative fix is a LiveKit `participant_left` webhook → Cloud Function cleanup (LiveKit is the real source of truth for connection state). `lastSeen` is stored now so a future TTL sweep can reap ghosts. **Follow-up task to file.**
2. **Initial-circle avatars, not sprite heads** — sprite-sheet head geometry is uncertain at small circular sizes; an initial circle always renders and reads instantly (the Gather/Slack idiom). Sprite-head avatars are planned polish.

## Privacy

Presence reveals which room a user is in to all signed-in users. This is intended for a shared world (the task confirms it) — the foyer's whole point is mutual visibility.

## Review tier

Crosses a **trust boundary** (new Firestore collection + rules, location visibility) and touches state-lifecycle + wire format → recommend **cage-match**, not self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)