### PR TITLE
feat(media): mute/unmute local mic and camera from the toolbar

### DIFF
--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -384,6 +384,27 @@ class BubbleManager {
         'local-player-bubble-refreshed');
   }
 
+  /// Downgrade the LOCAL player's video bubble to a static avatar — e.g. when
+  /// the local camera is turned off.
+  ///
+  /// Without this, the local video bubble keeps its last decoded frame (a
+  /// freeze) and, because it stays a [VideoBubbleComponent],
+  /// [refreshLocalPlayerBubble]'s guard makes turning the camera back on a
+  /// no-op. Mirrors [downgradeVideoBubble] for remote players. The camera is
+  /// already off by the time this fires, so [_createLocalPlayerBubble] builds a
+  /// static [PlayerBubbleComponent].
+  void downgradeLocalPlayerBubble() {
+    final existing = _playerBubbles[_localPlayerBubbleKey];
+    if (existing is! VideoBubbleComponent) return;
+
+    _log.fine('Downgrading local player bubble after camera disabled');
+    final position = existing.position.clone();
+    final newBubble = _createLocalPlayerBubble();
+    newBubble.position = position;
+    _replaceBubble(_localPlayerBubbleKey, newBubble,
+        'local-video-downgraded-to-static');
+  }
+
   /// Downgrade a video bubble to a static placeholder.
   void downgradeVideoBubble(String playerId) {
     final existingBubble = _playerBubbles[playerId];

--- a/lib/flame/livekit_game_bridge.dart
+++ b/lib/flame/livekit_game_bridge.dart
@@ -99,6 +99,7 @@ class LiveKitGameBridge {
   StreamSubscription<(Participant, VideoTrack)>? _trackSubscribedSub;
   StreamSubscription<(Participant, VideoTrack)>? _trackUnsubscribedSub;
   StreamSubscription<LocalTrackPublication>? _localTrackPublishedSub;
+  StreamSubscription<LocalTrackPublication>? _localTrackUnpublishedSub;
   StreamSubscription<PlayerPath>? _positionSub;
   StreamSubscription<PositionHeartbeat>? _heartbeatSub;
   StreamSubscription<RemoteParticipant>? _participantJoinedSub;
@@ -209,6 +210,14 @@ class LiveKitGameBridge {
       }
     });
 
+    _localTrackUnpublishedSub =
+        _liveKitService.localTrackUnpublished.listen((publication) {
+      if (publication.kind == TrackType.VIDEO) {
+        _log.fine('Local video track unpublished, downgrading bubble');
+        _bubbleManager.downgradeLocalPlayerBubble();
+      }
+    });
+
     // ── Data channels ────────────────────────────────────────────────────
     _speechTranscriptSub = _liveKitService.dataReceived
         .where((msg) => msg.topic == DataTopic.speechTranscript.wireName)
@@ -272,6 +281,8 @@ class LiveKitGameBridge {
     _trackUnsubscribedSub = null;
     _localTrackPublishedSub?.cancel();
     _localTrackPublishedSub = null;
+    _localTrackUnpublishedSub?.cancel();
+    _localTrackUnpublishedSub = null;
     _positionSub?.cancel();
     _positionSub = null;
     _heartbeatSub?.cancel();

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -445,15 +445,34 @@ class LiveKitService {
     _listener = null;
     _room = null;
     _connectionState = _ConnectionState.disconnected;
+    // Nothing is published while disconnected; keep the mute toolbar honest
+    // across a reconnect (enableMedia re-flips these true on rejoin).
+    cameraEnabled.value = false;
+    micEnabled.value = false;
 
     _log.info('Disconnected');
   }
+
+  /// Whether the local camera is currently publishing (true = live/unmuted).
+  ///
+  /// Reactive so the mute toolbar button reflects reality. Session-scoped:
+  /// starts `false` (fast-connect publishes nothing), flips `true` once
+  /// [enableMedia] succeeds on room entry, and tracks every [setCameraEnabled].
+  final ValueNotifier<bool> cameraEnabled = ValueNotifier<bool>(false);
+
+  /// Whether the local microphone is currently publishing (true = live/unmuted).
+  ///
+  /// See [cameraEnabled] for lifecycle. Tracks every [setMicrophoneEnabled].
+  final ValueNotifier<bool> micEnabled = ValueNotifier<bool>(false);
 
   /// Enable/disable local camera
   Future<void> setCameraEnabled(bool enabled) async {
     if (_room?.localParticipant == null) return;
     try {
       await _room!.localParticipant!.setCameraEnabled(enabled);
+      // Only reflect state after the toggle actually lands, so a failed
+      // enable (e.g. permission denied) leaves the button showing muted.
+      cameraEnabled.value = enabled;
       _log.info('Camera ${enabled ? 'enabled' : 'disabled'}');
     } catch (e) {
       _log.warning('Failed to set camera', e);
@@ -465,6 +484,7 @@ class LiveKitService {
     if (_room?.localParticipant == null) return;
     try {
       await _room!.localParticipant!.setMicrophoneEnabled(enabled);
+      micEnabled.value = enabled;
       _log.info('Microphone ${enabled ? 'enabled' : 'disabled'}');
     } catch (e) {
       _log.warning('Failed to set microphone', e);

--- a/lib/livekit/livekit_service.dart
+++ b/lib/livekit/livekit_service.dart
@@ -156,6 +156,8 @@ class LiveKitService {
       StreamController<(Participant, VideoTrack)>.broadcast();
   final _localTrackPublishedController =
       StreamController<LocalTrackPublication>.broadcast();
+  final _localTrackUnpublishedController =
+      StreamController<LocalTrackPublication>.broadcast();
   final _trackUnsubscribedController =
       StreamController<(Participant, VideoTrack)>.broadcast();
   final _dataReceivedController =
@@ -185,6 +187,12 @@ class LiveKitService {
   /// Stream of local track publication events (fires when camera/mic is published)
   Stream<LocalTrackPublication> get localTrackPublished =>
       _localTrackPublishedController.stream;
+
+  /// Stream of local track UN-publication events (fires when the camera/mic is
+  /// turned off). The game bridge downgrades the local video bubble to a static
+  /// avatar so it doesn't freeze on its last decoded frame.
+  Stream<LocalTrackPublication> get localTrackUnpublished =>
+      _localTrackUnpublishedController.stream;
 
   /// Stream of data channel messages received from other participants
   Stream<DataChannelMessage> get dataReceived => _dataReceivedController.stream;
@@ -1032,6 +1040,11 @@ class LiveKitService {
             'Local track published: ${event.publication.kind}');
         _localTrackPublishedController.add(event.publication);
       })
+      ..on<LocalTrackUnpublishedEvent>((event) {
+        _log.fine(
+            'Local track unpublished: ${event.publication.kind}');
+        _localTrackUnpublishedController.add(event.publication);
+      })
       ..on<DataReceivedEvent>((event) {
         _log.fine(
             'Data received from: ${event.participant?.identity}, topic: ${event.topic}');
@@ -1055,6 +1068,7 @@ class LiveKitService {
     _trackSubscribedController.close();
     _trackUnsubscribedController.close();
     _localTrackPublishedController.close();
+    _localTrackUnpublishedController.close();
     _dataReceivedController.close();
     _connectionLostController.close();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1258,6 +1258,14 @@ class _MyAppState extends State<MyApp> {
                               techWorld: locate<TechWorld>(),
                             ),
                           ],
+                          const SizedBox(width: 8),
+                          _MicMuteButton(
+                            liveKitService: _session?.liveKitService,
+                          ),
+                          const SizedBox(width: 8),
+                          _CameraMuteButton(
+                            liveKitService: _session?.liveKitService,
+                          ),
                           if (kIsWeb || lkPlatformIsDesktop()) ...[
                             const SizedBox(width: 8),
                             _ScreenShareButton(
@@ -1770,6 +1778,85 @@ class _DreamfinderSilenceButton extends StatelessWidget {
           backgroundColor: silenced
               ? Colors.amber.shade300.withValues(alpha: 0.2)
               : Colors.black54,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Toolbar button to mute/unmute the local microphone.
+///
+/// Drives [LiveKitService.setMicrophoneEnabled] and reflects
+/// [LiveKitService.micEnabled]. Muted = the mic track stops publishing, so
+/// every other player stops hearing you immediately (this is a publish-side
+/// mute, distinct from the proximity/DF-silence receive-side gates).
+class _MicMuteButton extends StatelessWidget {
+  const _MicMuteButton({required this.liveKitService});
+
+  final LiveKitService? liveKitService;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = liveKitService;
+    if (service == null) {
+      return const SizedBox.shrink();
+    }
+    return ValueListenableBuilder<bool>(
+      valueListenable: service.micEnabled,
+      builder: (context, enabled, _) => IconButton(
+        onPressed: () => service.setMicrophoneEnabled(!enabled),
+        icon: Icon(
+          enabled ? Icons.mic : Icons.mic_off,
+          color: enabled ? Colors.white70 : Colors.red.shade300,
+          size: 20,
+        ),
+        tooltip: enabled ? 'Mute microphone' : 'Unmute microphone',
+        style: IconButton.styleFrom(
+          backgroundColor: enabled
+              ? Colors.black54
+              : Colors.red.shade300.withValues(alpha: 0.2),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Toolbar button to mute/unmute the local camera.
+///
+/// Drives [LiveKitService.setCameraEnabled] and reflects
+/// [LiveKitService.cameraEnabled]. Muted = the camera track stops publishing,
+/// so your video bubble disappears for every other player.
+class _CameraMuteButton extends StatelessWidget {
+  const _CameraMuteButton({required this.liveKitService});
+
+  final LiveKitService? liveKitService;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = liveKitService;
+    if (service == null) {
+      return const SizedBox.shrink();
+    }
+    return ValueListenableBuilder<bool>(
+      valueListenable: service.cameraEnabled,
+      builder: (context, enabled, _) => IconButton(
+        onPressed: () => service.setCameraEnabled(!enabled),
+        icon: Icon(
+          enabled ? Icons.videocam : Icons.videocam_off,
+          color: enabled ? Colors.white70 : Colors.red.shade300,
+          size: 20,
+        ),
+        tooltip: enabled ? 'Turn off camera' : 'Turn on camera',
+        style: IconButton.styleFrom(
+          backgroundColor: enabled
+              ? Colors.black54
+              : Colors.red.shade300.withValues(alpha: 0.2),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),

--- a/test/livekit/livekit_service_media_mute_test.dart
+++ b/test/livekit/livekit_service_media_mute_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/livekit/livekit_service.dart';
+
+/// Tests for the local mic/camera mute state notifiers ([micEnabled] /
+/// [cameraEnabled]) that drive the mute toolbar buttons.
+///
+/// The notifiers must only reflect state AFTER a toggle actually lands on the
+/// live `LocalParticipant`. Without a room, [setMicrophoneEnabled] /
+/// [setCameraEnabled] return early — so the notifier must stay `false` rather
+/// than optimistically flip, otherwise the toolbar would show "live" while
+/// nothing is being published.
+void main() {
+  group('local media mute notifiers', () {
+    late LiveKitService service;
+
+    setUp(() {
+      service = LiveKitService(userId: 'user-1', displayName: 'User 1');
+    });
+
+    tearDown(() async {
+      await service.dispose();
+    });
+
+    test('mic + camera enabled default to false (nothing published yet)', () {
+      expect(service.micEnabled.value, isFalse);
+      expect(service.cameraEnabled.value, isFalse);
+    });
+
+    test('setMicrophoneEnabled with no room does not flip the notifier',
+        () async {
+      await service.setMicrophoneEnabled(true);
+      expect(service.micEnabled.value, isFalse);
+    });
+
+    test('setCameraEnabled with no room does not flip the notifier', () async {
+      await service.setCameraEnabled(true);
+      expect(service.cameraEnabled.value, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Formalizes the branch that has been hand-deployed to production since 2026-07-04 (`e7cc6365`, the currently-served build) — two weeks of live testing by Nick and meetup participants.

- `03eaccb5` feat(media): mute/unmute local mic and camera from the toolbar
- `e7cc6365` fix(media): downgrade local video bubble when camera turns off (the missing local track-REMOVED quadrant)

**Why merge now:** prod serves this branch, but CI deploys `main` on every merge — so any other PR landing first would silently remove the mute feature from prod. This PR must merge BEFORE #503 (chat timestamps/composer).

Gates: CI → approve → merge → (deploy happens with the next main deploy, already live-equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)