### PR TITLE
fix(rules): pin presence lastSeen to request.time

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,9 +23,15 @@ service cloud.firestore {
       allow read: if request.auth != null;
       // Create/update: the doc key must be the caller's UID AND the userId
       // field must match — nobody can plant presence as someone else.
+      // lastSeen must be the server clock (request.time): the livekitWebhook
+      // freshness watermark reaps ghosts by comparing lastSeen against the
+      // LiveKit event time, so a client-chosen lastSeen could future-pin a
+      // ghost to dodge cleanup (or backdate to self-grief). Pin it server-side;
+      // the client writes FieldValue.serverTimestamp() which resolves here.
       allow create, update: if request.auth != null &&
         request.auth.uid == userId &&
-        request.resource.data.userId == userId;
+        request.resource.data.userId == userId &&
+        request.resource.data.lastSeen == request.time;
       // Delete: only your own doc (request.resource is null on delete, so the
       // field check above cannot apply here).
       allow delete: if request.auth != null && request.auth.uid == userId;


### PR DESCRIPTION
Root task: tech_world issue-tracker task #36.

## Problem

The `/presence/{userId}` rule constrains the doc key (`request.auth.uid == userId`) and the `userId` field, but leaves **`lastSeen` client-writable**. That is a self-griefing hole now that presence-ghost cleanup depends on `lastSeen`.

The `livekitWebhook` freshness watermark (deployed 2026-07-18) reaps ghost presence docs by comparing the stored `lastSeen` against the LiveKit event time (`shouldReapPresence`: `lastSeen.toMillis() < event.createdAt - SKEW_BUDGET_MS`). If a client can pick its own `lastSeen`, it can:

- **future-pin** `lastSeen` so a ghost doc always looks "newer than the event" and dodges cleanup forever, or
- backdate it to grief itself out of a live room.

So `lastSeen` must be **server-authoritative**.

## Fix

Add `request.resource.data.lastSeen == request.time` to the create/update condition. The Flutter client already writes `FieldValue.serverTimestamp()` in `PresenceService.enter()` (`lib/rooms/presence_service.dart`), which resolves to `request.time` server-side, so no client change is needed. Verified the only write path spreads `entry.toFirestore()` then overrides `lastSeen` with the server timestamp — nothing sets it to a client-chosen value.

## Deploy gate

Merging this **auto-deploys** via `.github/workflows/deploy-firebase-rules.yml` (firestore rules on merge to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)