### PR TITLE
feat(chat): mouse-selectable messages + clickable links

### DIFF
--- a/lib/chat/bubble_footer.dart
+++ b/lib/chat/bubble_footer.dart
@@ -22,35 +22,40 @@ class BubbleFooter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 2, left: 4),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(child: ChatTimestamp(timestamp: timestamp)),
-          const SizedBox(width: 4),
-          GestureDetector(
-            onTap: onReply,
-            behavior: HitTestBehavior.opaque,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.reply, size: 12, color: Colors.grey[600]),
-                  const SizedBox(width: 2),
-                  Text(
-                    'Reply',
-                    style: TextStyle(
-                      color: Colors.grey[600],
-                      fontSize: 11,
+    // Excluded from the enclosing SelectionArea: drag-selecting a
+    // conversation should copy the messages, not interleave "5 min ago
+    // Reply" between every line.
+    return SelectionContainer.disabled(
+      child: Padding(
+        padding: const EdgeInsets.only(top: 2, left: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(child: ChatTimestamp(timestamp: timestamp)),
+            const SizedBox(width: 4),
+            GestureDetector(
+              onTap: onReply,
+              behavior: HitTestBehavior.opaque,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.reply, size: 12, color: Colors.grey[600]),
+                    const SizedBox(width: 2),
+                    Text(
+                      'Reply',
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 11,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/chat/chat_panel.dart
+++ b/lib/chat/chat_panel.dart
@@ -313,8 +313,7 @@ class _ChatPanelState extends State<ChatPanel>
                     // DMs tab with unread badge
                     Tab(
                       child: ValueListenableBuilder<int>(
-                        valueListenable:
-                            widget.chatService.totalUnreadNotifier,
+                        valueListenable: widget.chatService.totalUnreadNotifier,
                         builder: (context, unread, _) {
                           if (unread == 0) {
                             return const Text('DMs');
@@ -430,29 +429,34 @@ class _ChatPanelState extends State<ChatPanel>
                 );
               }
 
-              return ListView.builder(
-                controller: _scrollController,
-                padding: const EdgeInsets.all(16),
-                itemCount: messages.length,
-                itemBuilder: (context, index) {
-                  final message = messages[index];
-                  return _MessageBubble(
-                    message: message,
-                    onReply: () => _startReply(message),
-                    onSenderTap: message.isLocalUser || message.isBot
-                        ? null
-                        : () {
-                            // Open a DM with this sender.
-                            final senderId = message.senderId;
-                            if (senderId == null) return;
-                            _tabController.animateTo(1);
-                            _openDmForPeer(
-                              senderId,
-                              displayName: message.senderName,
-                            );
-                          },
-                  );
-                },
+              // SelectionArea: drag the mouse across messages to select +
+              // copy (Nick's 2026-07-18 request). Timestamps/Reply hints are
+              // excluded inside BubbleFooter so copied text stays clean.
+              return SelectionArea(
+                child: ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(16),
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    final message = messages[index];
+                    return _MessageBubble(
+                      message: message,
+                      onReply: () => _startReply(message),
+                      onSenderTap: message.isLocalUser || message.isBot
+                          ? null
+                          : () {
+                              // Open a DM with this sender.
+                              final senderId = message.senderId;
+                              if (senderId == null) return;
+                              _tabController.animateTo(1);
+                              _openDmForPeer(
+                                senderId,
+                                displayName: message.senderName,
+                              );
+                            },
+                    );
+                  },
+                ),
               );
             },
           ),
@@ -534,11 +538,9 @@ class _ChatPanelState extends State<ChatPanel>
                           valueListenable: _sttService.listening,
                           builder: (context, isListening, _) {
                             return IconButton(
-                              onPressed:
-                                  isAbsent ? null : _handleMicPress,
-                              icon: Icon(isListening
-                                  ? Icons.mic
-                                  : Icons.mic_none),
+                              onPressed: isAbsent ? null : _handleMicPress,
+                              icon: Icon(
+                                  isListening ? Icons.mic : Icons.mic_none),
                               color: isAbsent
                                   ? Colors.grey[600]
                                   : isListening
@@ -548,10 +550,8 @@ class _ChatPanelState extends State<ChatPanel>
                                 backgroundColor: isAbsent
                                     ? Colors.grey.withValues(alpha: 0.1)
                                     : isListening
-                                        ? Colors.red
-                                            .withValues(alpha: 0.2)
-                                        : clawdOrange
-                                            .withValues(alpha: 0.1),
+                                        ? Colors.red.withValues(alpha: 0.2)
+                                        : clawdOrange.withValues(alpha: 0.1),
                               ),
                             );
                           },
@@ -560,8 +560,7 @@ class _ChatPanelState extends State<ChatPanel>
                       IconButton(
                         onPressed: isAbsent ? null : _sendMessage,
                         icon: const Icon(Icons.send),
-                        color:
-                            isAbsent ? Colors.grey[600] : clawdOrange,
+                        color: isAbsent ? Colors.grey[600] : clawdOrange,
                         style: IconButton.styleFrom(
                           backgroundColor: isAbsent
                               ? Colors.grey.withValues(alpha: 0.1)
@@ -596,10 +595,10 @@ class _ChatPanelState extends State<ChatPanel>
         StreamBuilder<List<Conversation>>(
           stream: widget.chatService.conversations,
           builder: (context, snapshot) {
-            final conversations = (snapshot.data ??
-                    widget.chatService.currentConversations)
-                .where((c) => c.type == ConversationType.dm)
-                .toList();
+            final conversations =
+                (snapshot.data ?? widget.chatService.currentConversations)
+                    .where((c) => c.type == ConversationType.dm)
+                    .toList();
 
             if (conversations.isEmpty) {
               return Center(
@@ -676,8 +675,7 @@ class _ChatPanelState extends State<ChatPanel>
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: const Color(0xFF2D2D4D),
-        title:
-            const Text('New message', style: TextStyle(color: Colors.white)),
+        title: const Text('New message', style: TextStyle(color: Colors.white)),
         content: SizedBox(
           width: double.maxFinite,
           child: participants.isEmpty
@@ -805,8 +803,7 @@ class _MessageBubble extends StatelessWidget {
                           decoration: onSenderTap != null
                               ? TextDecoration.underline
                               : null,
-                          decorationColor:
-                              clawdOrange.withValues(alpha: 0.4),
+                          decorationColor: clawdOrange.withValues(alpha: 0.4),
                         ),
                       ),
                     ),
@@ -834,20 +831,22 @@ class _MessageBubble extends StatelessWidget {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (message.isReply) QuotedMessage(message: message),
-                        Text.rich(
-                          TextSpan(
-                            children: buildMentionSpans(
-                              message.text,
-                              baseStyle: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 14,
-                              ),
-                              mentionStyle: const TextStyle(
-                                color: clawdOrange,
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
+                        MessageText(
+                          message.text,
+                          baseStyle: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 14,
+                          ),
+                          mentionStyle: const TextStyle(
+                            color: clawdOrange,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          linkStyle: const TextStyle(
+                            color: Color(0xFF7EB6FF),
+                            fontSize: 14,
+                            decoration: TextDecoration.underline,
+                            decorationColor: Color(0xFF7EB6FF),
                           ),
                         ),
                       ],
@@ -902,8 +901,7 @@ class _MentionPicker extends StatelessWidget {
           return InkWell(
             onTap: () => onPick(c),
             child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
               child: Row(
                 children: [
                   CircleAvatar(

--- a/lib/chat/dm_thread_view.dart
+++ b/lib/chat/dm_thread_view.dart
@@ -151,8 +151,7 @@ class _DmThreadViewState extends State<DmThreadView> {
   @override
   Widget build(BuildContext context) {
     final isBotDm = widget.conversation.peerId == 'bot-claude';
-    final displayName =
-        widget.conversation.peerDisplayName ?? 'Unknown';
+    final displayName = widget.conversation.peerDisplayName ?? 'Unknown';
 
     return Column(
       children: [
@@ -173,8 +172,7 @@ class _DmThreadViewState extends State<DmThreadView> {
                 color: Colors.grey[400],
                 iconSize: 20,
                 padding: EdgeInsets.zero,
-                constraints:
-                    const BoxConstraints(minWidth: 28, minHeight: 28),
+                constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
                 tooltip: 'Back to conversations',
               ),
               const SizedBox(width: 8),
@@ -188,9 +186,7 @@ class _DmThreadViewState extends State<DmThreadView> {
                 ),
                 child: Center(
                   child: Text(
-                    displayName.isNotEmpty
-                        ? displayName[0].toUpperCase()
-                        : '?',
+                    displayName.isNotEmpty ? displayName[0].toUpperCase() : '?',
                     style: TextStyle(
                       color: isBotDm ? _clawdOrange : Colors.blue,
                       fontSize: 12,
@@ -219,8 +215,7 @@ class _DmThreadViewState extends State<DmThreadView> {
         Expanded(
           child: StreamBuilder<List<ChatMessage>>(
             stream: widget.conversation.peerId != null
-                ? widget.chatService
-                    .dmMessages(widget.conversation.peerId!)
+                ? widget.chatService.dmMessages(widget.conversation.peerId!)
                 : const Stream.empty(),
             initialData: widget.conversation.peerId != null
                 ? widget.chatService
@@ -258,22 +253,26 @@ class _DmThreadViewState extends State<DmThreadView> {
                 }
               });
 
-              return ListView.builder(
-                controller: _scrollController,
-                padding: const EdgeInsets.all(16),
-                itemCount: messages.length,
-                itemBuilder: (context, index) {
-                  final message = messages[index];
-                  return _DmBubble(
-                    key: _keyFor(message.stableId),
-                    message: message,
-                    highlighted: message.stableId == _highlightedId,
-                    onReply: () => _startReply(message),
-                    onQuoteTap: message.isReply
-                        ? () => _scrollToQuoted(message.replyToMessageId!)
-                        : null,
-                  );
-                },
+              // SelectionArea: drag-select + copy across DM messages, same
+              // treatment as the group tab.
+              return SelectionArea(
+                child: ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(16),
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    final message = messages[index];
+                    return _DmBubble(
+                      key: _keyFor(message.stableId),
+                      message: message,
+                      highlighted: message.stableId == _highlightedId,
+                      onReply: () => _startReply(message),
+                      onQuoteTap: message.isReply
+                          ? () => _scrollToQuoted(message.replyToMessageId!)
+                          : null,
+                    );
+                  },
+                ),
               );
             },
           ),
@@ -304,20 +303,19 @@ class _DmThreadViewState extends State<DmThreadView> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (replyTarget != null) ReplyComposingBanner(
-          target: replyTarget,
-          onCancel: _cancelReply,
-        ),
+        if (replyTarget != null)
+          ReplyComposingBanner(
+            target: replyTarget,
+            onCancel: _cancelReply,
+          ),
         if (showBanner)
           Container(
             width: double.infinity,
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             color: Colors.amber.shade800.withValues(alpha: 0.3),
             child: Row(
               children: [
-                Icon(Icons.cloud_off,
-                    size: 16, color: Colors.amber.shade300),
+                Icon(Icons.cloud_off, size: 16, color: Colors.amber.shade300),
                 const SizedBox(width: 8),
                 Text(
                   'Clawd is offline',
@@ -344,9 +342,8 @@ class _DmThreadViewState extends State<DmThreadView> {
                   controller: _textController,
                   focusNode: _focusNode,
                   enabled: !disabled,
-                  hintText: disabled
-                      ? 'Clawd is offline...'
-                      : 'Type a message...',
+                  hintText:
+                      disabled ? 'Clawd is offline...' : 'Type a message...',
                   onSend: _sendMessage,
                 ),
               ),
@@ -438,9 +435,8 @@ class _DmBubble extends StatelessWidget {
             child: GestureDetector(
               onLongPress: onReply,
               child: Column(
-                crossAxisAlignment: isLocal
-                    ? CrossAxisAlignment.end
-                    : CrossAxisAlignment.start,
+                crossAxisAlignment:
+                    isLocal ? CrossAxisAlignment.end : CrossAxisAlignment.start,
                 children: [
                   AnimatedContainer(
                     // No key toggle here: changing a widget's key forces a
@@ -472,20 +468,22 @@ class _DmBubble extends StatelessWidget {
                           const SizedBox.shrink(key: ValueKey('dm-highlight')),
                         if (message.isReply)
                           QuotedMessage(message: message, onTap: onQuoteTap),
-                        Text.rich(
-                          TextSpan(
-                            children: buildMentionSpans(
-                              message.text,
-                              baseStyle: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 14,
-                              ),
-                              mentionStyle: const TextStyle(
-                                color: _clawdOrange,
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
+                        MessageText(
+                          message.text,
+                          baseStyle: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 14,
+                          ),
+                          mentionStyle: const TextStyle(
+                            color: _clawdOrange,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          linkStyle: const TextStyle(
+                            color: Color(0xFF7EB6FF),
+                            fontSize: 14,
+                            decoration: TextDecoration.underline,
+                            decorationColor: Color(0xFF7EB6FF),
                           ),
                         ),
                       ],

--- a/lib/chat/mention_text.dart
+++ b/lib/chat/mention_text.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Builds a [TextSpan] tree that highlights `@Name` mention spans within a chat
 /// message body, used by both the group panel and the DM thread view so the two
@@ -25,7 +27,8 @@ List<InlineSpan> buildMentionSpans(
     final mentionStart = m.start + (m.group(1)?.length ?? 0);
 
     if (leadStart > last) {
-      spans.add(TextSpan(text: text.substring(last, leadStart), style: baseStyle));
+      spans.add(
+          TextSpan(text: text.substring(last, leadStart), style: baseStyle));
     }
     final lead = m.group(1) ?? '';
     if (lead.isNotEmpty) {
@@ -39,4 +42,175 @@ List<InlineSpan> buildMentionSpans(
     spans.add(TextSpan(text: text.substring(last), style: baseStyle));
   }
   return spans;
+}
+
+/// A URL detected in a plain-text run: its [start]/[end] offsets within the
+/// run and the [href] to open (bare `www.` links get `https://` prefixed).
+typedef LinkMatch = ({int start, int end, String href});
+
+/// Find URLs in [text]: `http(s)://…` or bare `www.…`.
+///
+/// Deliberately conservative about boundaries: trailing sentence punctuation
+/// (`.,;:!?'"`) is not part of the link, and a trailing `)` is included only
+/// when the URL body contains a matching `(` (so a parenthesized "(see
+/// https://example.com)" stays clean while a Wikipedia-style
+/// `…/Foo_(bar)` survives intact).
+List<LinkMatch> findLinks(String text) {
+  final matches = <LinkMatch>[];
+  final pattern = RegExp(r'(https?://[^\s]+|www\.[^\s]+)');
+  for (final m in pattern.allMatches(text)) {
+    var raw = m.group(0)!;
+    // Trim trailing punctuation that reads as sentence structure, not URL.
+    while (raw.isNotEmpty) {
+      final tail = raw[raw.length - 1];
+      if ('.,;:!?\'"'.contains(tail)) {
+        raw = raw.substring(0, raw.length - 1);
+        continue;
+      }
+      if (tail == ')' &&
+          ')'.allMatches(raw).length > '('.allMatches(raw).length) {
+        raw = raw.substring(0, raw.length - 1);
+        continue;
+      }
+      break;
+    }
+    // A bare "www." with nothing meaningful after it isn't a link.
+    if (raw == 'www.' || raw.isEmpty) continue;
+    final href = raw.startsWith('www.') ? 'https://$raw' : raw;
+    matches.add((start: m.start, end: m.start + raw.length, href: href));
+  }
+  return matches;
+}
+
+/// Renders a chat message body with `@mention` highlighting AND clickable
+/// links, owning the [TapGestureRecognizer] lifecycle.
+///
+/// Stateful because recognizers attached to [TextSpan]s are NOT disposed by
+/// the framework — a stateless builder would leak one recognizer per link per
+/// rebuild. This widget rebuilds its span tree (and re-mints recognizers) only
+/// when the message [text] changes, and disposes every recognizer it created.
+///
+/// Mentions are detected first (via [buildMentionSpans]); the base-styled
+/// segments between/around them are then linkified. A mention is never
+/// linkified and a link never mention-styled.
+class MessageText extends StatefulWidget {
+  const MessageText(
+    this.text, {
+    required this.baseStyle,
+    required this.mentionStyle,
+    required this.linkStyle,
+    this.onOpenLink,
+    super.key,
+  });
+
+  final String text;
+  final TextStyle baseStyle;
+  final TextStyle mentionStyle;
+  final TextStyle linkStyle;
+
+  /// Test seam — defaults to launching the URL in a new tab/external app.
+  final void Function(String href)? onOpenLink;
+
+  @override
+  State<MessageText> createState() => _MessageTextState();
+}
+
+class _MessageTextState extends State<MessageText> {
+  final List<TapGestureRecognizer> _recognizers = [];
+  late List<InlineSpan> _spans;
+
+  @override
+  void initState() {
+    super.initState();
+    _spans = _build();
+  }
+
+  @override
+  void didUpdateWidget(covariant MessageText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text ||
+        oldWidget.baseStyle != widget.baseStyle) {
+      _disposeRecognizers();
+      _spans = _build();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  void _disposeRecognizers() {
+    for (final r in _recognizers) {
+      r.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  void _open(String href) {
+    final opener = widget.onOpenLink;
+    if (opener != null) {
+      opener(href);
+      return;
+    }
+    final uri = Uri.tryParse(href);
+    if (uri == null) return;
+    // New tab on web; external browser elsewhere. Fire-and-forget — a failed
+    // launch (popup blocker, malformed host) is not worth surfacing in-world.
+    launchUrl(uri, webOnlyWindowName: '_blank');
+  }
+
+  /// Split a base-styled run into plain + link spans.
+  List<InlineSpan> _linkified(String segment) {
+    final links = findLinks(segment);
+    if (links.isEmpty) {
+      return [TextSpan(text: segment, style: widget.baseStyle)];
+    }
+    final out = <InlineSpan>[];
+    var last = 0;
+    for (final link in links) {
+      if (link.start > last) {
+        out.add(TextSpan(
+            text: segment.substring(last, link.start),
+            style: widget.baseStyle));
+      }
+      final recognizer = TapGestureRecognizer()..onTap = () => _open(link.href);
+      _recognizers.add(recognizer);
+      out.add(TextSpan(
+        text: segment.substring(link.start, link.end),
+        style: widget.linkStyle,
+        recognizer: recognizer,
+      ));
+      last = link.end;
+    }
+    if (last < segment.length) {
+      out.add(TextSpan(text: segment.substring(last), style: widget.baseStyle));
+    }
+    return out;
+  }
+
+  List<InlineSpan> _build() {
+    final withMentions = buildMentionSpans(
+      widget.text,
+      baseStyle: widget.baseStyle,
+      mentionStyle: widget.mentionStyle,
+    );
+    final out = <InlineSpan>[];
+    for (final span in withMentions) {
+      if (span is TextSpan &&
+          span.style == widget.baseStyle &&
+          span.text != null) {
+        out.addAll(_linkified(span.text!));
+      } else {
+        out.add(span);
+      }
+    }
+    return out;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(TextSpan(children: _spans));
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1405,7 +1405,7 @@ packages:
     source: hosted
     version: "2.3.1"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
   path_provider: ^2.1.5
+  url_launcher: ^6.3.2
 
 
 dev_dependencies:

--- a/test/chat/link_text_test.dart
+++ b/test/chat/link_text_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tech_world/chat/mention_text.dart';
+
+void main() {
+  group('findLinks', () {
+    test('detects an https URL mid-sentence', () {
+      final links = findLinks('see https://example.com/page for more');
+      expect(links, hasLength(1));
+      expect(links.single.href, 'https://example.com/page');
+    });
+
+    test('bare www gets https prefixed', () {
+      final links = findLinks('go to www.example.com now');
+      expect(links.single.href, 'https://www.example.com');
+    });
+
+    test('trailing sentence punctuation is not part of the link', () {
+      expect(findLinks('read https://example.com/a.').single.href,
+          'https://example.com/a');
+      expect(findLinks('read https://example.com/a, then b').single.href,
+          'https://example.com/a');
+      expect(findLinks('really? https://example.com/a!').single.href,
+          'https://example.com/a');
+    });
+
+    test('parenthesized link sheds the closing paren', () {
+      expect(findLinks('(see https://example.com/a)').single.href,
+          'https://example.com/a');
+    });
+
+    test('wikipedia-style balanced parens survive', () {
+      expect(
+          findLinks('https://en.wikipedia.org/wiki/Foo_(bar)').single.href,
+          'https://en.wikipedia.org/wiki/Foo_(bar)');
+    });
+
+    test('no links in plain text or timestamps', () {
+      expect(findLinks('meet at 12:30 tomorrow'), isEmpty);
+      expect(findLinks('hello world'), isEmpty);
+      expect(findLinks('www.'), isEmpty);
+    });
+
+    test('multiple links in one message', () {
+      final links =
+          findLinks('https://a.com and https://b.com are both good');
+      expect(links.map((l) => l.href), ['https://a.com', 'https://b.com']);
+    });
+  });
+
+  group('MessageText', () {
+    const base = TextStyle(color: Colors.white, fontSize: 14);
+    const mention =
+        TextStyle(color: Colors.orange, fontSize: 14, fontWeight: FontWeight.w600);
+    const link = TextStyle(
+        color: Colors.blue, fontSize: 14, decoration: TextDecoration.underline);
+
+    Future<Text> pump(WidgetTester tester, String text,
+        {void Function(String)? onOpenLink}) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MessageText(
+              text,
+              baseStyle: base,
+              mentionStyle: mention,
+              linkStyle: link,
+              onOpenLink: onOpenLink,
+            ),
+          ),
+        ),
+      );
+      return tester.widget<Text>(find.byType(Text));
+    }
+
+    List<TextSpan> flatSpans(Text t) {
+      final spans = <TextSpan>[];
+      (t.textSpan as TextSpan).visitChildren((s) {
+        if (s is TextSpan && s.text != null) spans.add(s);
+        return true;
+      });
+      return spans;
+    }
+
+    testWidgets('link span carries link style and a tap recognizer',
+        (tester) async {
+      final opened = <String>[];
+      final t = await pump(tester, 'go to https://example.com now',
+          onOpenLink: opened.add);
+      final spans = flatSpans(t);
+
+      final linkSpan =
+          spans.firstWhere((s) => s.text == 'https://example.com');
+      expect(linkSpan.style, link);
+      expect(linkSpan.recognizer, isA<TapGestureRecognizer>());
+
+      (linkSpan.recognizer as TapGestureRecognizer).onTap!();
+      expect(opened, ['https://example.com']);
+    });
+
+    testWidgets('mention and link coexist without cross-styling',
+        (tester) async {
+      final t =
+          await pump(tester, '@Andy check https://example.com please');
+      final spans = flatSpans(t);
+
+      expect(spans.firstWhere((s) => s.text == '@Andy').style, mention);
+      expect(spans.firstWhere((s) => s.text == 'https://example.com').style,
+          link);
+      // The mention was not linkified: no recognizer on it.
+      expect(spans.firstWhere((s) => s.text == '@Andy').recognizer, isNull);
+    });
+
+    testWidgets('plain text has no recognizers', (tester) async {
+      final t = await pump(tester, 'just words here');
+      for (final s in flatSpans(t)) {
+        expect(s.recognizer, isNull);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Two of Nick's requests from the 2026-07-18 live session.

## Selectable messages (drag + copy)
`SelectionArea` wraps the group and DM message lists — drag the mouse across any messages, Cmd/Ctrl-C copies. Timestamps and Reply hints are excluded via `SelectionContainer.disabled` in `BubbleFooter` so a copied conversation doesn't interleave "5 min ago Reply" between lines. Long-press quote-reply is untouched (drag ≠ long-press).

## Clickable links
URLs in messages are underlined, colored, and open in a new tab. Conservative boundary detection: trailing sentence punctuation excluded, trailing `)` kept only when balanced (Wikipedia URLs survive), bare `www.` hosts get `https://`. New `MessageText` stateful widget is the single span-builder for both surfaces and owns the `TapGestureRecognizer` lifecycle (recognizers must be disposed — the previous stateless `Text.rich` couldn't host them). Mentions detected first, links second; the two never cross-style.

## Verification
- analyzer clean; **2167 tests green** (10 new: link-boundary cases incl. parens/timestamps/multi-link, span styling + recognizer wiring, mention+link coexistence, no-recognizers-on-plain-text)
- Gates: merge → CI deploy → live check (drag-select a conversation; click a link; confirm reply + mention still behave)

🤖 Generated with [Claude Code](https://claude.com/claude-code)