### PR TITLE
fix(flame): restore player occlusion behind wall tops/archways

### DIFF
--- a/lib/flame/components/tile_object_layer_component.dart
+++ b/lib/flame/components/tile_object_layer_component.dart
@@ -124,7 +124,10 @@ class TileObjectLayerComponent extends Component {
               x * gridSquareSizeDouble + 2,
               y * gridSquareSizeDouble + 2,
             ),
-            priority: 9999, // always on top
+            // Above every scaled tile/character priority (max row 49 →
+            // 49 * kPriorityStride + tie-break). A bare 9999 now sorts BEHIND
+            // any tile on row 10+, hiding labels exactly when debugging scale.
+            priority: gridSize * kPriorityStride, // always on top
             textRenderer: TextPaint(
               style: TextStyle(
                 fontSize: 8,

--- a/lib/flame/components/tile_object_layer_component.dart
+++ b/lib/flame/components/tile_object_layer_component.dart
@@ -63,7 +63,14 @@ class TileObjectLayerComponent extends Component {
         final sprite = registry.getSpriteForTile(ref.tilesetId, ref.tileIndex);
         if (sprite == null) continue;
 
-        final effectivePriority = priorityOverrides?[(x, y)] ?? y;
+        // Scale to the same priority space as characters, which use
+        // `row * kPriorityStride + xTieBreak` (see PlayerComponent.update).
+        // Overrides and the default are grid rows; without this multiply every
+        // tile sorts ~kPriorityStride× below any character, so the player
+        // renders in front of all wall tops and archways — occlusion dies.
+        // Regression from #376, which scaled only the character side.
+        final effectivePriority =
+            (priorityOverrides?[(x, y)] ?? y) * kPriorityStride;
         final isLintelOverlay =
             lintelOverlayPositions?.contains((x, y)) ?? false;
 

--- a/test/flame/components/y_occlusion_test.dart
+++ b/test/flame/components/y_occlusion_test.dart
@@ -1,187 +1,185 @@
 import 'package:flame/components.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tech_world/flame/components/player_component.dart';
 import 'package:tech_world/flame/components/tile_object_layer_component.dart';
 import 'package:tech_world/flame/shared/constants.dart';
+import 'package:tech_world/flame/tech_world_game.dart';
 import 'package:tech_world/flame/tiles/tile_layer_data.dart';
 import 'package:tech_world/flame/tiles/tile_ref.dart';
+import 'package:tech_world/flame/tiles/tileset.dart';
 import 'package:tech_world/flame/tiles/tileset_registry.dart';
 
-/// Tests verifying the y-based occlusion contract between tile sprites and
-/// player components.
+/// A [TechWorldGame] with mock images so real [PlayerComponent]s load their
+/// sprite sheets, plus a pre-registered 1×1 tileset so
+/// [TileObjectLayerComponent] produces real sprites. [PlayerComponent] asserts
+/// its game is a [TechWorldGame], so a bare [FlameGame] won't do.
+class _OcclusionTestGame extends TechWorldGame {
+  _OcclusionTestGame() : super(world: World());
+
+  late final TilesetRegistry registry;
+
+  @override
+  Future<void> onLoad() async {
+    // Player sprite sheet (12 frames of 32×64 across 4 directions).
+    images.add('NPC11.png', await generateImage(384, 256));
+
+    registry = TilesetRegistry(images: images);
+    registry.loadFromImage(
+      const Tileset(
+        id: 't',
+        name: 'test',
+        imagePath: 't.png',
+        tileSize: gridSquareSize,
+        columns: 1,
+        rows: 1,
+      ),
+      await generateImage(gridSquareSize, gridSquareSize),
+    );
+    camera.viewfinder.anchor = Anchor.center;
+  }
+}
+
+/// Tests verifying the y-based occlusion contract *between* real
+/// [TileObjectLayerComponent] sprites and real [PlayerComponent]s.
 ///
 /// ## How y-occlusion works
 ///
-/// Both [TileObjectLayerComponent] and [PlayerComponent] use the grid row
-/// (y index) as their rendering priority:
+/// Flame's [World] sorts children by `priority` (higher renders on top).
+/// Depth-sorting characters against wall tiles requires both to live in the
+/// **same priority space**:
 ///
-/// - Tile sprites: `priority = y` (grid row, set at construction)
-/// - Player: `priority = position.y.round() ~/ gridSquareSize` (updated per
-///   frame)
+/// - Characters: `priority = row * kPriorityStride + xTieBreak`, where
+///   `xTieBreak ∈ [0, kPriorityStride)` — see [PlayerComponent.update].
+/// - Object tiles: `priority = (override ?? row) * kPriorityStride`.
 ///
-/// Flame's [World] sorts children by priority, so components with higher
-/// priority (further south / higher y) render on top. This means:
+/// Because the character tie-break is strictly less than `kPriorityStride`, a
+/// character on the *same* effective row as a tile deterministically renders
+/// in front (the goal of PR #376), while a character one row north renders
+/// behind (occluded by the wall top / archway).
 ///
-/// - Player north of wall tile → player priority < tile priority → player
-///   renders behind the wall.
-/// - Player south of wall tile → player priority > tile priority → player
-///   renders in front of the wall.
+/// ## Regression guard (PR #376 → this fix)
 ///
-/// Auto-barriers ensure the player can never occupy the same grid cell as a
-/// wall tile, so the priority boundary is always clean (no ties between
-/// player and wall at the same y).
+/// #376 scaled only the *character* side by `kPriorityStride` and left the
+/// object layer at raw grid-y. That put every wall top ~1000× below any
+/// character, so the player rendered in front of all wall tops and archways —
+/// occlusion silently died for months. These tests read the **real** priority
+/// fields off both components (never re-deriving the formula) so the scale
+/// contract can never drift apart again undetected.
 void main() {
-  group('Y-based occlusion', () {
-    group('PlayerComponent priority', () {
-      test('priority formula matches grid row from position', () {
-        final player = PlayerComponent(
-          position: Vector2(0, 0),
-          id: 'test',
-          displayName: 'Test',
-        );
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-        // Simulate what update() does: priority = position.y.round() ~/ gridSquareSize
-        for (final row in [0, 1, 5, 10, 25, 49]) {
-          player.position.y = row * gridSquareSizeDouble;
-          final expectedPriority = player.position.y.round() ~/ gridSquareSize;
-          expect(
-            expectedPriority,
-            equals(row),
-            reason: 'Player at grid row $row should have priority $row',
-          );
-        }
-      });
+  // A north-facing wall face sits at [barrierRow]; its cap tile renders one
+  // row north (at [capRow]) but is priority-bumped to the barrier row so it
+  // sorts with the wall face and occludes a player walking above it.
+  const barrierRow = 10;
+  const capRow = barrierRow - 1;
+  const capX = 5;
 
-      test('priority is stable within a grid cell', () {
-        final player = PlayerComponent(
-          position: Vector2(0, 0),
-          id: 'test',
-          displayName: 'Test',
-        );
+  /// Loads an object layer holding a single wall-cap tile at ([capX], [capRow])
+  /// whose priority override is the barrier row, and returns the real sprite.
+  Future<SpriteComponent> loadCapSprite(_OcclusionTestGame game) async {
+    final layer = TileLayerData()
+      ..setTile(capX, capRow, const TileRef(tilesetId: 't', tileIndex: 0));
 
-        // Within a single cell (e.g. row 10), any sub-pixel offset should
-        // still yield the same priority.
-        const row = 10;
-        for (final offset in [0.0, 0.5, 15.0, 31.0]) {
-          player.position.y = row * gridSquareSizeDouble + offset;
-          final priority = player.position.y.round() ~/ gridSquareSize;
-          expect(
-            priority,
-            equals(row),
-            reason: 'Offset $offset within row $row should still yield '
-                'priority $row',
-          );
-        }
-      });
-    });
+    final objectLayer = TileObjectLayerComponent(
+      layerData: layer,
+      registry: game.registry,
+      priorityOverrides: const {(capX, capRow): barrierRow},
+    );
+    await game.world.add(objectLayer);
+    await game.ready();
 
-    group('TileObjectLayerComponent priority contract', () {
-      test('creates sprite with priority equal to grid row y', () {
-        // The contract: in TileObjectLayerComponent.onLoad(), each sprite is
-        // created with `priority: y` where y is the grid row (0-indexed).
-        //
-        // We verify this by constructing a SpriteComponent the same way the
-        // production code does and checking its priority.
-        for (final y in [0, 1, 10, 25, 49]) {
-          final component = SpriteComponent(
-            position: Vector2(
-              3 * gridSquareSizeDouble, // x doesn't affect priority
-              y * gridSquareSizeDouble,
-            ),
-            size: Vector2.all(gridSquareSizeDouble),
-            priority: y,
-          );
+    final capPos =
+        Vector2(capX * gridSquareSizeDouble, capRow * gridSquareSizeDouble);
+    return game.world.children
+        .whereType<SpriteComponent>()
+        .firstWhere((s) => s.position == capPos);
+  }
 
-          expect(
-            component.priority,
-            equals(y),
-            reason: 'Tile at grid row $y should have priority $y',
-          );
-        }
-      });
+  /// Adds a real player, positions it at [row], drives one frame so
+  /// [PlayerComponent.update] sets `priority`, and returns the live component.
+  Future<PlayerComponent> playerAtRow(_OcclusionTestGame game, int row) async {
+    final player = PlayerComponent(
+      position: Vector2(0, row * gridSquareSizeDouble),
+      id: 'p',
+      displayName: 'P',
+    );
+    await game.world.add(player);
+    await game.ready();
+    game.update(0); // triggers the per-frame priority computation
+    return player;
+  }
 
-      test('tile and player at same grid row have equal priority', () {
-        // This proves depth sorting is clean: when a player is at the same
-        // y-row as a tile, they have equal priority (same depth layer).
-        // Auto-barriers prevent this for wall tiles specifically, but the
-        // math must still be consistent for floor/object tiles.
-        const row = 15;
+  group('Y-based occlusion (real component priorities)', () {
+    testWithGame<_OcclusionTestGame>(
+      'wall cap and characters share the same priority scale',
+      _OcclusionTestGame.new,
+      (game) async {
+        final cap = await loadCapSprite(game);
+        // Cap is bumped to the barrier row, on the character scale.
+        expect(cap.priority, equals(barrierRow * kPriorityStride));
+      },
+    );
 
-        // Tile priority (set directly)
-        const tilePriority = row;
-
-        // Player priority (computed from pixel position)
-        final playerY = row * gridSquareSizeDouble;
-        final playerPriority = playerY.round() ~/ gridSquareSize;
-
-        expect(playerPriority, equals(tilePriority));
-      });
-
-      test('player north of tile has lower priority (renders behind)', () {
-        const wallRow = 10;
-        const playerRow = 9; // north = lower y
-
-        const tilePriority = wallRow;
-        final playerY = playerRow * gridSquareSizeDouble;
-        final playerPriority = playerY.round() ~/ gridSquareSize;
-
+    testWithGame<_OcclusionTestGame>(
+      'player north of the wall renders BEHIND its cap (occluded)',
+      _OcclusionTestGame.new,
+      (game) async {
+        final cap = await loadCapSprite(game);
+        final player = await playerAtRow(game, capRow); // north of wall face
         expect(
-          playerPriority,
-          lessThan(tilePriority),
-          reason: 'Player at row $playerRow should render behind wall at '
-              'row $wallRow',
+          player.priority,
+          lessThan(cap.priority),
+          reason: 'A player above the wall must be occluded by the wall top. '
+              'This is the exact behavior PR #376 broke.',
         );
-      });
+      },
+    );
 
-      test('player south of tile has higher priority (renders in front)', () {
-        const wallRow = 10;
-        const playerRow = 11; // south = higher y
-
-        const tilePriority = wallRow;
-        final playerY = playerRow * gridSquareSizeDouble;
-        final playerPriority = playerY.round() ~/ gridSquareSize;
-
+    testWithGame<_OcclusionTestGame>(
+      'player at the wall row renders IN FRONT (deterministic tie-break)',
+      _OcclusionTestGame.new,
+      (game) async {
+        final cap = await loadCapSprite(game);
+        final player = await playerAtRow(game, barrierRow);
         expect(
-          playerPriority,
-          greaterThan(tilePriority),
-          reason: 'Player at row $playerRow should render in front of wall '
-              'at row $wallRow',
+          player.priority,
+          greaterThanOrEqualTo(cap.priority),
+          reason: 'Same-row player wins the tie (renders in front) — the '
+              'deterministic same-y ordering #376 set out to provide.',
         );
-      });
-    });
+      },
+    );
 
-    group('TileObjectLayerComponent construction', () {
-      test('can be constructed with layer data and registry', () {
-        final layer = TileLayerData();
-        final registry = TilesetRegistry.forTesting();
-
-        final component = TileObjectLayerComponent(
-          layerData: layer,
-          registry: registry,
+    testWithGame<_OcclusionTestGame>(
+      'player south of the wall renders IN FRONT',
+      _OcclusionTestGame.new,
+      (game) async {
+        final cap = await loadCapSprite(game);
+        final player = await playerAtRow(game, barrierRow + 1);
+        expect(
+          player.priority,
+          greaterThan(cap.priority),
+          reason: 'A player below the wall is closer to camera; renders '
+              'in front.',
         );
+      },
+    );
+  });
 
-        expect(component.layerData, same(layer));
-        expect(component.registry, same(registry));
-      });
+  group('TileObjectLayerComponent construction', () {
+    test('can be constructed with layer data and registry', () {
+      final layer = TileLayerData();
+      final registry = TilesetRegistry.forTesting();
 
-      test('accepts layer with tiles at various y positions', () {
-        final layer = TileLayerData();
-        // Place tiles at different rows — their priority should match y.
-        layer.setTile(5, 0, const TileRef(tilesetId: 'test', tileIndex: 0));
-        layer.setTile(5, 25, const TileRef(tilesetId: 'test', tileIndex: 0));
-        layer.setTile(5, 49, const TileRef(tilesetId: 'test', tileIndex: 0));
+      final component = TileObjectLayerComponent(
+        layerData: layer,
+        registry: registry,
+      );
 
-        final component = TileObjectLayerComponent(
-          layerData: layer,
-          registry: TilesetRegistry.forTesting(),
-        );
-
-        // The component stores tiles but defers sprite creation to onLoad.
-        // Verify layer data is preserved.
-        expect(component.layerData.tileAt(5, 0), isNotNull);
-        expect(component.layerData.tileAt(5, 25), isNotNull);
-        expect(component.layerData.tileAt(5, 49), isNotNull);
-      });
+      expect(component.layerData, same(layer));
+      expect(component.registry, same(registry));
     });
   });
 }

--- a/test/flame/components/y_occlusion_test.dart
+++ b/test/flame/components/y_occlusion_test.dart
@@ -99,9 +99,16 @@ void main() {
 
   /// Adds a real player, positions it at [row], drives one frame so
   /// [PlayerComponent.update] sets `priority`, and returns the live component.
+  ///
+  /// The player is placed at a **non-zero grid x** on purpose: the character
+  /// priority is `row * kPriorityStride + (x.abs() % kPriorityStride)`, so at
+  /// x=0 the tie-break is 0 and a same-row player would exactly *equal* the
+  /// tile priority — a Flame stable-sort coin-flip, not the deterministic
+  /// "player in front" this suite claims. A non-zero x gives a strictly
+  /// positive tie-break, so same-row ordering is a hard inequality.
   Future<PlayerComponent> playerAtRow(_OcclusionTestGame game, int row) async {
     final player = PlayerComponent(
-      position: Vector2(0, row * gridSquareSizeDouble),
+      position: Vector2(3 * gridSquareSizeDouble, row * gridSquareSizeDouble),
       id: 'p',
       displayName: 'P',
     );
@@ -119,6 +126,33 @@ void main() {
         final cap = await loadCapSprite(game);
         // Cap is bumped to the barrier row, on the character scale.
         expect(cap.priority, equals(barrierRow * kPriorityStride));
+      },
+    );
+
+    testWithGame<_OcclusionTestGame>(
+      'a tile with NO override still scales its default grid-y',
+      _OcclusionTestGame.new,
+      (game) async {
+        // The regression was "one side of the seam forgotten" — the default
+        // `?? y` arm, not just the override arm. Strike it with a real sprite.
+        const plainX = 2;
+        const plainRow = 7;
+        final layer = TileLayerData()
+          ..setTile(plainX, plainRow,
+              const TileRef(tilesetId: 't', tileIndex: 0));
+        await game.world.add(TileObjectLayerComponent(
+          layerData: layer,
+          registry: game.registry,
+          // No priorityOverrides at all → exercises the `?? y` default.
+        ));
+        await game.ready();
+        final sprite = game.world.children.whereType<SpriteComponent>().firstWhere(
+              (s) =>
+                  s.position ==
+                  Vector2(plainX * gridSquareSizeDouble,
+                      plainRow * gridSquareSizeDouble),
+            );
+        expect(sprite.priority, equals(plainRow * kPriorityStride));
       },
     );
 
@@ -145,9 +179,10 @@ void main() {
         final player = await playerAtRow(game, barrierRow);
         expect(
           player.priority,
-          greaterThanOrEqualTo(cap.priority),
+          greaterThan(cap.priority),
           reason: 'Same-row player wins the tie (renders in front) — the '
-              'deterministic same-y ordering #376 set out to provide.',
+              'deterministic same-y ordering #376 set out to provide. Strict '
+              '> holds for any non-zero player x (positive tie-break).',
         );
       },
     );


### PR DESCRIPTION
## The regression

Players stopped being hidden behind wall tops and archways sometime between April and July — occlusion silently broke and nobody noticed for months, because nothing watches the pixels.

**Root cause: PR #376.** Before #376, both characters *and* object-layer tiles used `priority = gridRow`. #376 introduced deterministic same-y tie-breaking and rescaled **every character** to `row * kPriorityStride + xTieBreak` (`kPriorityStride = 1000`) — but it never touched `tile_object_layer_component.dart`, which kept setting tile priority to raw `gridRow`. The two halves of the depth comparison drifted onto scales 1000× apart, so a player at row 9 (priority ~9000) always rendered in front of the wall top that should occlude it (priority 9).

The bisect confirmed #376 is the only commit that scaled characters; `git log -S kPriorityStride` shows the object layer has **never** referenced the constant.

## The fix

One line in `TileObjectLayerComponent.onLoad`: scale the tile priority (override or default-y) by `kPriorityStride` so tiles and characters share one priority space. This restores every `>` relationship the wall-cap / doorway-lintel logic was originally tuned around (that logic predates #376 and was written on the raw scale), and completes the deterministic same-row tie-break #376 set out to add — a same-row player wins (renders in front), a player one row north renders behind the wall top.

## Why the test didn't catch it (and now does)

`y_occlusion_test.dart` existed the whole time but **asserted below the bug**: every assertion re-derived the *pre-#376* formula inline (`playerY ~/ gridSquareSize`) and compared it to a raw literal — it never read the actual `player.priority` field or exercised `TileObjectLayerComponent.onLoad()`. `y == y` stayed green through three months of broken pixels.

Rewritten to read the **real** priority fields off real `PlayerComponent` + `TileObjectLayerComponent` sprites and assert the cross-component ordering. This test is RED against the unfixed code (`Expected: < 10, Actual: 9000`) and GREEN after the fix.

## Verification

- RED → GREEN on the rewritten contract test.
- Before/after pixel renders (throwaway probe, not committed): broken = player drawn in front of the wall band; fixed = player's lower half hidden behind it.
- Full `flutter test test/flame/` — 749 pass. `flutter analyze --fatal-infos` clean.

Fixes #2138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)