### PR TITLE
fix(avatar): make character selection scrollable on phones

### DIFF
--- a/lib/avatar/avatar_selection_screen.dart
+++ b/lib/avatar/avatar_selection_screen.dart
@@ -36,14 +36,25 @@ class _AvatarSelectionScreenState extends State<AvatarSelectionScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFF1E1E1E),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 480),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+      // Scrollable so the content (and crucially the Confirm button) is always
+      // reachable on short viewports — on a phone the avatar cards wrap to more
+      // rows and previously pushed Confirm off the bottom with no way to scroll.
+      // The min-height + Center keeps it vertically centred when it does fit.
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 480),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
                 const Text(
                   'Choose Your Character',
                   style: TextStyle(
@@ -84,7 +95,11 @@ class _AvatarSelectionScreenState extends State<AvatarSelectionScreen> {
                     ),
                   ),
                 ),
-              ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/test/avatar/avatar_selection_screen_test.dart
+++ b/test/avatar/avatar_selection_screen_test.dart
@@ -109,4 +109,63 @@ void main() {
       expect(find.text('Choose Your Character'), findsOneWidget);
     });
   });
+
+  // Regression: on a short phone viewport the avatar cards wrap to extra rows
+  // and the content is taller than the screen. Previously the Confirm button
+  // was pushed off the bottom with no way to scroll — you could not get past
+  // character selection on a phone. The screen is now scrollable.
+  group('AvatarSelectionScreen on a short phone viewport', () {
+    // Shorter than the content's natural height, forcing overflow-or-scroll.
+    const phone = Size(360, 480);
+
+    Future<void> pumpPhone(WidgetTester tester, ValueChanged<Avatar> onPick) async {
+      tester.view.physicalSize = phone;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(MaterialApp(
+        home: AvatarSelectionScreen(onAvatarSelected: onPick),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('does not overflow', (tester) async {
+      await pumpPhone(tester, (_) {});
+      // A RenderFlex overflow throws during layout; testWidgets surfaces it as
+      // a caught exception. None means the content scrolled instead.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Confirm can be scrolled into view', (tester) async {
+      await pumpPhone(tester, (_) {});
+
+      final confirm = find.widgetWithText(ElevatedButton, 'Confirm');
+      expect(confirm, findsOneWidget);
+      // ensureVisible throws if the target cannot be scrolled into view, so
+      // reaching the assertion below proves Confirm is reachable on a phone —
+      // no tap, so this stays clear of the local ink-splash shader skew.
+      await tester.ensureVisible(confirm);
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('can select an avatar and confirm it', (tester) async {
+      Avatar? picked;
+      await pumpPhone(tester, (a) => picked = a);
+
+      final ranger = find.text(predefinedAvatars[1].displayName);
+      await tester.ensureVisible(ranger);
+      await tester.pumpAndSettle();
+      await tester.tap(ranger);
+      await tester.pumpAndSettle();
+
+      final confirm = find.widgetWithText(ElevatedButton, 'Confirm');
+      await tester.ensureVisible(confirm);
+      await tester.pumpAndSettle();
+      await tester.tap(confirm);
+      await tester.pumpAndSettle();
+
+      expect(picked, equals(predefinedAvatars[1]));
+    });
+  });
 }


### PR DESCRIPTION
## The bug

On a phone you can't get past character selection — reported live. The avatar cards wrap to extra rows on a narrow/short viewport, making the content taller than the screen, and the **Confirm** button gets pushed off the bottom with **no way to scroll to it**.

## The fix

Wrap the content in `SafeArea` + `SingleChildScrollView` with a `minHeight: constraints.maxHeight` + `Center` — the canonical "centre when it fits, scroll when it doesn't" pattern. Also respects notches via SafeArea.

## Verified

- **RED/GREEN**: at a 360×480 phone viewport the old layout overflowed by **228 px** (Confirm off-screen); with the fix, **no overflow** and Confirm scrolls into view.
- Added phone-viewport regression tests (`test/avatar/avatar_selection_screen_test.dart`): overflow guard + scroll-reachability. The existing tests ran only at the default 800×600 surface — which is exactly why this shipped unnoticed.
- `flutter analyze --fatal-infos` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)