### PR TITLE
demo prep: join muted (audio off, video on) + decouple group chat from bot

### DIFF
--- a/lib/chat/chat_panel.dart
+++ b/lib/chat/chat_panel.dart
@@ -5,7 +5,6 @@ import 'package:tech_world/chat/chat_message.dart';
 import 'package:tech_world/chat/composer_field.dart';
 import 'package:tech_world/chat/reply_widgets.dart';
 import 'package:tech_world/chat/chat_service.dart';
-import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/chat/conversation.dart';
 import 'package:tech_world/chat/conversation_list_tile.dart';
 import 'package:tech_world/chat/dm_thread_view.dart';
@@ -497,11 +496,14 @@ class _ChatPanelState extends State<ChatPanel>
           ),
         ),
 
-        // Input (with offline banner)
-        ValueListenableBuilder<BotStatus>(
-          valueListenable: widget.chatService.botStatus,
-          builder: (context, botStatus, _) {
-            final isAbsent = botStatus == BotStatus.absent;
+        // Input row. The Group tab is human chat ("Clawd + all players"), so
+        // the composer is NEVER gated on bot presence — humans must be able to
+        // chat whether or not the Clawd bot is online. (Previously the whole
+        // composer disabled + showed a "Clawd is offline" banner when the bot
+        // was absent, silencing everyone. Decoupled: bot absence is invisible
+        // here.)
+        Builder(
+          builder: (context) {
             final replyTarget = _replyTarget;
             return Column(
               mainAxisSize: MainAxisSize.min,
@@ -520,30 +522,6 @@ class _ChatPanelState extends State<ChatPanel>
                     target: replyTarget,
                     onCancel: _cancelReply,
                   ),
-                // Offline banner
-                if (isAbsent)
-                  Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 8,
-                    ),
-                    color: Colors.amber.shade800.withValues(alpha: 0.3),
-                    child: Row(
-                      children: [
-                        Icon(Icons.cloud_off,
-                            size: 16, color: Colors.amber.shade300),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Clawd is offline',
-                          style: TextStyle(
-                            color: Colors.amber.shade300,
-                            fontSize: 13,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
                 // Input row
                 Container(
                   padding: const EdgeInsets.all(16),
@@ -559,10 +537,8 @@ class _ChatPanelState extends State<ChatPanel>
                         child: ChatComposerField(
                           controller: _textController,
                           focusNode: _focusNode,
-                          enabled: !isAbsent,
-                          hintText: isAbsent
-                              ? 'Clawd is offline...'
-                              : 'Type a message...',
+                          enabled: true,
+                          hintText: 'Type a message...',
                           onSend: _sendMessage,
                           onChanged: (_) => _onComposerChanged(),
                         ),
@@ -573,33 +549,25 @@ class _ChatPanelState extends State<ChatPanel>
                           valueListenable: _sttService.listening,
                           builder: (context, isListening, _) {
                             return IconButton(
-                              onPressed: isAbsent ? null : _handleMicPress,
+                              onPressed: _handleMicPress,
                               icon: Icon(
                                   isListening ? Icons.mic : Icons.mic_none),
-                              color: isAbsent
-                                  ? Colors.grey[600]
-                                  : isListening
-                                      ? Colors.red
-                                      : clawdOrange,
+                              color: isListening ? Colors.red : clawdOrange,
                               style: IconButton.styleFrom(
-                                backgroundColor: isAbsent
-                                    ? Colors.grey.withValues(alpha: 0.1)
-                                    : isListening
-                                        ? Colors.red.withValues(alpha: 0.2)
-                                        : clawdOrange.withValues(alpha: 0.1),
+                                backgroundColor: isListening
+                                    ? Colors.red.withValues(alpha: 0.2)
+                                    : clawdOrange.withValues(alpha: 0.1),
                               ),
                             );
                           },
                         ),
                       const SizedBox(width: 4),
                       IconButton(
-                        onPressed: isAbsent ? null : _sendMessage,
+                        onPressed: _sendMessage,
                         icon: const Icon(Icons.send),
-                        color: isAbsent ? Colors.grey[600] : clawdOrange,
+                        color: clawdOrange,
                         style: IconButton.styleFrom(
-                          backgroundColor: isAbsent
-                              ? Colors.grey.withValues(alpha: 0.1)
-                              : clawdOrange.withValues(alpha: 0.1),
+                          backgroundColor: clawdOrange.withValues(alpha: 0.1),
                         ),
                       ),
                     ],

--- a/lib/rooms/room_session.dart
+++ b/lib/rooms/room_session.dart
@@ -271,11 +271,18 @@ class RoomSession {
     });
   }
 
-  /// Enable camera and microphone.
+  /// Enable camera on room entry, but join **muted** (microphone off).
+  ///
+  /// Join-muted is the safe default for a co-located audience — several devices
+  /// with live mics + speakers in one room is an audio-feedback loop. It's also
+  /// standard video-call UX (Zoom/Meet join muted). Capability is preserved, not
+  /// amputated: the mic toggle in the toolbar (`_MicButton`, main.dart) unmutes
+  /// on demand, so remote users can still speak. Video stays on so players see
+  /// each other's bubbles in-world.
   Future<void> enableMedia() async {
     await Future.wait([
       liveKitService.setCameraEnabled(true),
-      liveKitService.setMicrophoneEnabled(true),
+      liveKitService.setMicrophoneEnabled(false),
     ]);
     dispatch([MediaEnabled()]);
   }


### PR DESCRIPTION
Demo-prep for a **same-room, everyone-joins-on-their-own-device** meetup demo. Two independent changes:

## 1. Join muted — audio off, video on (`room_session.dart`)
Several devices with live mics + speakers in one room is an audio-feedback loop. `enableMedia` now enables the camera but **not** the mic on room entry. Video stays on so players see each other's bubbles in-world; they talk in real life. Capability preserved — the toolbar mic toggle unmutes on demand, so remote users can still speak. Standard join-muted UX.

## 2. Decouple group chat from bot presence (`chat_panel.dart`)
**Bug found while scoping the "hide the offline bot" ask:** the Group tab is human chat (*"Clawd + all players"*), but the entire composer — input, mic, send — was `enabled: !isAbsent`, i.e. **disabled whenever the Clawd bot was offline** (its normal state now). A dead bot was silencing every human in the room — exactly the wrong failure mode for a demo about being together.

Fix: the group composer is never gated on bot presence. Humans can always chat; bot absence is invisible here. Removes the "Clawd is offline" banner and the now-unused `BotStatus` listener + import. (This also satisfies the "hide the offline-bot UI" ask — properly, by fixing the underlying coupling rather than just hiding a banner over a dead input.)

## Testing
- `flutter analyze --fatal-infos` clean; 289 chat + rooms tests pass.
- **Gate: locally verified.** Visual confirmation pending — join a room and confirm (a) mic starts muted / video on, (b) group chat is typeable with the bot offline.

## Review tier
Self-review — two single-file, low-blast-radius changes, no trust boundary. Not cage-match tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)