### PR TITLE
feat(dreamfinder): stationary standing-host mode for demos

### DIFF
--- a/lib/flame/components/dreamfinder_component.dart
+++ b/lib/flame/components/dreamfinder_component.dart
@@ -19,6 +19,16 @@ import 'package:tech_world/flame/tech_world_game.dart';
 ///   Row 0 (y=0):   Walk cycle — 4 directions × 4 frames
 ///   Row 1 (y=64):  Working idle — 4 frames, looping
 ///   Row 2 (y=128): Surprise — 4 frames, one-shot
+///
+/// See [kDreamfinderStationary] for the "standing host" demo mode.
+
+/// When true, Dreamfinder stays planted at his spawn spot: no autonomous
+/// wandering and no walking over to greet arrivals. He still reacts in place
+/// (surprise glance, working-idle animation), so he reads as an attentive host
+/// rather than a frozen statue. A roaming host is distracting during a live
+/// demo — flip to false to restore the full wandering behaviour.
+const bool kDreamfinderStationary = true;
+
 class DreamfinderComponent
     extends SpriteAnimationGroupComponent<DreamfinderState>
     with HasGameReference<TechWorldGame>
@@ -43,6 +53,12 @@ class DreamfinderComponent
   bool _isWandering = false;
   bool _isGreeting = false;
   bool _serverControlled = false;
+
+  /// See [kDreamfinderStationary]. When true, suppresses both movement sources
+  /// (autonomous wander and the greeting-walk) so DF never changes position;
+  /// he still plays the working-idle and surprise animations in place.
+  /// Mutable so tests (and any future runtime toggle) can flip it.
+  bool stationary = kDreamfinderStationary;
   double _wanderCooldown = 0;
   List<MoveEffect> _moveEffects = [];
   List<Direction> _directions = [];
@@ -78,7 +94,8 @@ class DreamfinderComponent
         (position.x.round().abs() % kPriorityStride);
 
     // Tick the wander cooldown when idle/working and not otherwise occupied.
-    if (!_isWandering && !_isGreeting && !_serverControlled &&
+    // In [stationary] mode DF never wanders, so skip the whole cooldown.
+    if (!_isWandering && !_isGreeting && !_serverControlled && !stationary &&
         _wanderCooldown > 0) {
       _wanderCooldown -= dt;
       if (_wanderCooldown <= 0) {
@@ -199,6 +216,17 @@ class DreamfinderComponent
   }
 
   void _walkToPlayer(Vector2 targetPosition) {
+    // Standing-host mode: the surprise glance has already played; settle back
+    // to the working idle at the same spot instead of walking over. Mirrors the
+    // "already near the player" settle path below.
+    if (stationary) {
+      _isGreeting = false;
+      current = DreamfinderState.working;
+      playing = true;
+      _wanderCooldown = _postGreetingDelay;
+      return;
+    }
+
     final targetGrid = (
       (targetPosition.x / gridSquareSizeDouble).round().clamp(0, gridSize - 1),
       (targetPosition.y / gridSquareSizeDouble).round().clamp(0, gridSize - 1),

--- a/test/flame/components/dreamfinder_component_test.dart
+++ b/test/flame/components/dreamfinder_component_test.dart
@@ -190,6 +190,7 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
+        df.stationary = false; // opt into the wandering loop under test
 
         final initialPos = df.position.clone();
 
@@ -218,6 +219,7 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
+        df.stationary = false; // opt into the wandering loop under test
 
         // Needs enough time for: initial cooldown (3-8s) + path walk +
         // arrival + working cooldown (5-12s) + second wander start + arrival.
@@ -249,6 +251,7 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
+        df.stationary = false; // opt into the wandering loop under test
 
         df.noticePlayer(Vector2(320, 160));
 
@@ -286,6 +289,74 @@ void main() {
         }
 
         expect(df.position, equals(posAfterServer));
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // Stationary mode (kDreamfinderStationary) — the "standing host" default
+    // -----------------------------------------------------------------------
+
+    testWithGame<TestGameWithDreamfinder>(
+      'stationary DF stays put after cooldown (never wanders)',
+      TestGameWithDreamfinder.new,
+      (game) async {
+        final df = DreamfinderComponent(
+          position: Vector2(256, 160),
+          id: 'bot-dreamfinder',
+          displayName: 'Dreamfinder',
+          pathComponent: pathComponent,
+        );
+
+        await game.world.add(pathComponent);
+        await game.world.add(df);
+        await game.ready();
+
+        // Default is stationary (kDreamfinderStationary). Assert the premise so
+        // this test is meaningful even if that default is later flipped.
+        expect(df.stationary, isTrue);
+
+        final initialPos = df.position.clone();
+        for (var i = 0; i < 200; i++) {
+          game.update(0.1);
+        }
+
+        expect(df.position, equals(initialPos),
+            reason: 'Stationary Dreamfinder must never change position');
+        expect(df.current, equals(DreamfinderState.working),
+            reason: 'Stationary Dreamfinder stays in the working idle');
+      },
+    );
+
+    testWithGame<TestGameWithDreamfinder>(
+      'stationary DF reacts in place, does not walk over to greet',
+      TestGameWithDreamfinder.new,
+      (game) async {
+        final df = DreamfinderComponent(
+          position: Vector2(256, 160),
+          id: 'bot-dreamfinder',
+          displayName: 'Dreamfinder',
+          pathComponent: pathComponent,
+        );
+
+        await game.world.add(pathComponent);
+        await game.world.add(df);
+        await game.ready();
+        expect(df.stationary, isTrue);
+
+        final initialPos = df.position.clone();
+
+        // A player arrives far away — DF should glance (surprise) but not walk.
+        df.noticePlayer(Vector2(800, 800));
+        expect(df.current, equals(DreamfinderState.surprised));
+
+        for (var i = 0; i < 200; i++) {
+          game.update(0.1);
+        }
+
+        expect(df.position, equals(initialPos),
+            reason: 'Stationary Dreamfinder greets in place, never walks over');
+        expect(df.current, equals(DreamfinderState.working),
+            reason: 'After the surprise glance, DF settles back to working');
       },
     );
   });


### PR DESCRIPTION
Dreamfinder wanders too much for a live demo — a roaming host pulls focus. This adds a **stationary "standing host" mode**, default on.

## What
A `stationary` flag (default from `kDreamfinderStationary = true`) plants DF at his spawn spot by gating **both** movement sources:
- **Autonomous wander** — the `update()` cooldown loop that roams to random/terminal cells.
- **Greeting-walk** — `_walkToPlayer()`, which otherwise walks over to each arrival (still movement, still distracting).

He keeps his **in-place life**: working-idle animation and the surprise glance when someone approaches. Standing host, not frozen statue.

## Why a flag, not a deletion
The wander behaviour is *gated*, not removed — flip `kDreamfinderStationary` to `false` to restore the full wandering host. No amputation.

## Scope note
`kDreamfinderStationary` is a **global** default, so DF stands still in all sessions until flipped — not demo-only (there's no demo-mode toggle infra, and "wanders too much" read as a general complaint). Easy to scope later if wandering should return outside demos.

## Tests
- 3 existing wander tests now explicitly opt into wandering (`df.stationary = false`) so they still exercise the loop.
- 2 new tests: stationary DF never changes position (after cooldown, and when greeting a player), each asserting the `stationary == true` premise so a future default flip can't silently no-op them.
- `flutter analyze --fatal-infos` clean; all 12 DF component tests pass.

## Gate
Locally verified (analyze + tests). Visual confirm pending: enter a room with DF present, watch that he stays put and glances when you approach.

## Review tier
Self-review — single-file behaviour change + tests, low blast radius, no trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)