### PR TITLE
feat(dreamfinder): small-area wander + walkable spawn (fixes DF-in-wall)

### DIFF
--- a/lib/flame/components/dreamfinder_component.dart
+++ b/lib/flame/components/dreamfinder_component.dart
@@ -20,14 +20,16 @@ import 'package:tech_world/flame/tech_world_game.dart';
 ///   Row 1 (y=64):  Working idle — 4 frames, looping
 ///   Row 2 (y=128): Surprise — 4 frames, one-shot
 ///
-/// See [kDreamfinderStationary] for the "standing host" demo mode.
+/// See [kDreamfinderWanderRadius] for how far Dreamfinder roams.
 
-/// When true, Dreamfinder stays planted at his spawn spot: no autonomous
-/// wandering and no walking over to greet arrivals. He still reacts in place
-/// (surprise glance, working-idle animation), so he reads as an attentive host
-/// rather than a frozen statue. A roaming host is distracting during a live
-/// demo — flip to false to restore the full wandering behaviour.
-const bool kDreamfinderStationary = true;
+/// How far (grid cells, Chebyshev) Dreamfinder wanders from his home cell.
+///
+/// He drifts around a small area rather than roaming the whole map — a roaming
+/// host is distracting during a live demo. `0` pins him in place (a standing
+/// host); larger values give a wider patrol. Home is his spawn cell, which is
+/// snapped to the nearest walkable tile (see the spawn logic in tech_world.dart)
+/// so the patrol never centres on a wall.
+const int kDreamfinderWanderRadius = 3;
 
 class DreamfinderComponent
     extends SpriteAnimationGroupComponent<DreamfinderState>
@@ -54,19 +56,18 @@ class DreamfinderComponent
   bool _isGreeting = false;
   bool _serverControlled = false;
 
-  /// See [kDreamfinderStationary]. When true, suppresses both movement sources
-  /// (autonomous wander and the greeting-walk) so DF never changes position;
-  /// he still plays the working-idle and surprise animations in place.
-  /// Mutable so tests (and any future runtime toggle) can flip it.
-  bool stationary = kDreamfinderStationary;
+  /// See [kDreamfinderWanderRadius]. How far DF wanders from [_homeCell] (grid
+  /// cells, Chebyshev). 0 = stays put. Mutable so tests can set it.
+  int wanderRadius = kDreamfinderWanderRadius;
+
+  /// The cell DF wanders around — captured from his spawn in [onLoad] so the
+  /// small patrol orbits wherever he was placed (a walkable cell).
+  (int, int)? _homeCell;
+
   double _wanderCooldown = 0;
   List<MoveEffect> _moveEffects = [];
   List<Direction> _directions = [];
   int _pathSegmentNum = 0;
-
-  /// Interesting positions to wander toward (e.g. terminal locations).
-  /// If empty, picks random walkable grid cells.
-  List<Point<int>> wanderTargets = [];
 
   static const _initialWanderDelay = 3.0;
   static const _minWorkDuration = 5.0;
@@ -83,6 +84,8 @@ class DreamfinderComponent
     // Start in working state — Dreamfinder was here before you arrived.
     current = DreamfinderState.working;
     playing = true;
+    // Home is wherever DF spawned (a walkable cell); the small wander orbits it.
+    _homeCell = miniGridTuple;
     _wanderCooldown = _initialWanderDelay;
     return super.onLoad();
   }
@@ -94,8 +97,7 @@ class DreamfinderComponent
         (position.x.round().abs() % kPriorityStride);
 
     // Tick the wander cooldown when idle/working and not otherwise occupied.
-    // In [stationary] mode DF never wanders, so skip the whole cooldown.
-    if (!_isWandering && !_isGreeting && !_serverControlled && !stationary &&
+    if (!_isWandering && !_isGreeting && !_serverControlled &&
         _wanderCooldown > 0) {
       _wanderCooldown -= dt;
       if (_wanderCooldown <= 0) {
@@ -194,7 +196,9 @@ class DreamfinderComponent
 
   /// Called when a human player joins the room.
   ///
-  /// Triggers the surprise → walk-to-player sequence.
+  /// Triggers a surprise glance in place, then settles back to the working idle.
+  /// DF does not walk over to the player — that would pull him out of his small
+  /// wander area — the [playerPosition] argument is kept for API compatibility.
   void noticePlayer(Vector2 playerPosition) {
     if (_hasNoticedPlayer) return;
     _hasNoticedPlayer = true;
@@ -208,53 +212,21 @@ class DreamfinderComponent
     current = DreamfinderState.surprised;
     playing = true;
 
-    // When surprise finishes, walk toward the player.
+    // When the surprise glance finishes, settle back in place.
     animationTicker?.onComplete = () {
       animationTicker?.onComplete = null;
-      _walkToPlayer(playerPosition);
+      _settleAfterGreeting();
     };
   }
 
-  void _walkToPlayer(Vector2 targetPosition) {
-    // Standing-host mode: the surprise glance has already played; settle back
-    // to the working idle at the same spot instead of walking over. Mirrors the
-    // "already near the player" settle path below.
-    if (stationary) {
-      _isGreeting = false;
-      current = DreamfinderState.working;
-      playing = true;
-      _wanderCooldown = _postGreetingDelay;
-      return;
-    }
-
-    final targetGrid = (
-      (targetPosition.x / gridSquareSizeDouble).round().clamp(0, gridSize - 1),
-      (targetPosition.y / gridSquareSizeDouble).round().clamp(0, gridSize - 1),
-    );
-
-    // Stop 2 cells away from the player so we don't overlap.
-    final myGrid = miniGridTuple;
-    final dx = targetGrid.$1 - myGrid.$1;
-    final dy = targetGrid.$2 - myGrid.$2;
-    final approachTarget = (
-      (targetGrid.$1 - dx.sign * 2).clamp(0, gridSize - 1),
-      (targetGrid.$2 - dy.sign * 2).clamp(0, gridSize - 1),
-    );
-
-    _pathComponent.calculatePath(start: myGrid, end: approachTarget);
-    final directions = _pathComponent.directions;
-    final points = _pathComponent.largeGridPoints;
-
-    if (directions.isEmpty || points.isEmpty) {
-      // Already near the player — greeting is done, resume wandering.
-      _isGreeting = false;
-      current = DreamfinderState.idle;
-      playing = false;
-      _wanderCooldown = _postGreetingDelay;
-      return;
-    }
-
-    _move(directions, points);
+  /// After the surprise glance, return to the working idle in place, then resume
+  /// the bounded wander after [_postGreetingDelay]. DF greets without leaving his
+  /// small patrol area.
+  void _settleAfterGreeting() {
+    _isGreeting = false;
+    current = DreamfinderState.working;
+    playing = true;
+    _wanderCooldown = _postGreetingDelay;
   }
 
   // ---------------------------------------------------------------------------
@@ -276,17 +248,18 @@ class DreamfinderComponent
     _move(directions, points);
   }
 
-  /// Pick a destination: prefer terminal locations, fall back to random grid cell.
+  /// Pick a destination within [wanderRadius] cells of [_homeCell], so DF drifts
+  /// around a small area instead of roaming the whole map. Pathfinding skips any
+  /// wall cell that lands in range (empty path → [_startWander] just retries).
   (int, int) _pickWanderTarget() {
-    if (wanderTargets.isNotEmpty && _random.nextDouble() < 0.7) {
-      final target = wanderTargets[_random.nextInt(wanderTargets.length)];
-      final offset = _random.nextInt(3) - 1;
-      return (
-        (target.x + offset).clamp(0, gridSize - 1),
-        (target.y + 1).clamp(0, gridSize - 1),
-      );
-    }
-    return (_random.nextInt(gridSize), _random.nextInt(gridSize));
+    final home = _homeCell ?? miniGridTuple;
+    if (wanderRadius <= 0) return home;
+    final dx = _random.nextInt(wanderRadius * 2 + 1) - wanderRadius;
+    final dy = _random.nextInt(wanderRadius * 2 + 1) - wanderRadius;
+    return (
+      (home.$1 + dx).clamp(0, gridSize - 1),
+      (home.$2 + dy).clamp(0, gridSize - 1),
+    );
   }
 
   void _resetWanderCooldown() {

--- a/lib/flame/tech_world.dart
+++ b/lib/flame/tech_world.dart
@@ -593,10 +593,18 @@ class TechWorld extends World with TapCallbacks {
         // (e.g. `agent-{jobId}` instead of `bot-dreamfinder`).
         _bubbleManager.dreamfinderIdentity = participant.identity;
         if (_dreamfinderComponent == null) {
+          // DF's home is a fixed offset from the player spawn, but that offset
+          // can land inside a wall on some maps (e.g. Imagination Center). Snap
+          // it to the nearest walkable cell so DF never spawns in a wall; that
+          // cell becomes the centre of his small wander.
+          final dfCell = _nearestWalkableCell((
+            (spawn.x + 8).clamp(0, gridSize - 1),
+            (spawn.y - 5).clamp(0, gridSize - 1),
+          ));
           final dfComp = DreamfinderComponent(
             position: Vector2(
-              (spawn.x + 8).clamp(0, gridSize - 1) * gridSquareSizeDouble,
-              (spawn.y - 5).clamp(0, gridSize - 1) * gridSquareSizeDouble,
+              dfCell.$1 * gridSquareSizeDouble,
+              dfCell.$2 * gridSquareSizeDouble,
             ),
             id: participant.identity,
             displayName: botConfig.displayName,
@@ -670,6 +678,31 @@ class TechWorld extends World with TapCallbacks {
       // Dreamfinder notices the new human player arriving.
       _dreamfinderComponent?.noticePlayer(playerComponent.position);
     }
+  }
+
+  /// Find the nearest walkable cell to [candidate] (Chebyshev-ring spiral out),
+  /// so a blind spawn offset never lands an entity inside a wall. Returns
+  /// [candidate] unchanged if it is already walkable (or if — impossibly — the
+  /// whole grid is barriers).
+  (int, int) _nearestWalkableCell((int, int) candidate) {
+    final barriers = _barriersComponent.tuples.toSet();
+    bool walkable((int, int) c) =>
+        c.$1 >= 0 &&
+        c.$1 < gridSize &&
+        c.$2 >= 0 &&
+        c.$2 < gridSize &&
+        !barriers.contains(c);
+    if (walkable(candidate)) return candidate;
+    for (var r = 1; r < gridSize; r++) {
+      for (var dx = -r; dx <= r; dx++) {
+        for (var dy = -r; dy <= r; dy++) {
+          if (dx.abs() != r && dy.abs() != r) continue; // ring perimeter only
+          final c = (candidate.$1 + dx, candidate.$2 + dy);
+          if (walkable(c)) return c;
+        }
+      }
+    }
+    return candidate;
   }
 
   /// Handle a participant leaving the room.

--- a/test/flame/components/dreamfinder_component_test.dart
+++ b/test/flame/components/dreamfinder_component_test.dart
@@ -190,7 +190,6 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
-        df.stationary = false; // opt into the wandering loop under test
 
         final initialPos = df.position.clone();
 
@@ -219,7 +218,6 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
-        df.stationary = false; // opt into the wandering loop under test
 
         // Needs enough time for: initial cooldown (3-8s) + path walk +
         // arrival + working cooldown (5-12s) + second wander start + arrival.
@@ -251,7 +249,6 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
-        df.stationary = false; // opt into the wandering loop under test
 
         df.noticePlayer(Vector2(320, 160));
 
@@ -293,11 +290,11 @@ void main() {
     );
 
     // -----------------------------------------------------------------------
-    // Stationary mode (kDreamfinderStationary) — the "standing host" default
+    // Bounded wander (kDreamfinderWanderRadius) — the "small patrol" behaviour
     // -----------------------------------------------------------------------
 
     testWithGame<TestGameWithDreamfinder>(
-      'stationary DF stays put after cooldown (never wanders)',
+      'wanderRadius 0 pins DF in place (standing host)',
       TestGameWithDreamfinder.new,
       (game) async {
         final df = DreamfinderComponent(
@@ -310,10 +307,7 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
-
-        // Default is stationary (kDreamfinderStationary). Assert the premise so
-        // this test is meaningful even if that default is later flipped.
-        expect(df.stationary, isTrue);
+        df.wanderRadius = 0; // stand still
 
         final initialPos = df.position.clone();
         for (var i = 0; i < 200; i++) {
@@ -321,14 +315,14 @@ void main() {
         }
 
         expect(df.position, equals(initialPos),
-            reason: 'Stationary Dreamfinder must never change position');
+            reason: 'wanderRadius 0 must never change position');
         expect(df.current, equals(DreamfinderState.working),
-            reason: 'Stationary Dreamfinder stays in the working idle');
+            reason: 'A pinned Dreamfinder stays in the working idle');
       },
     );
 
     testWithGame<TestGameWithDreamfinder>(
-      'stationary DF reacts in place, does not walk over to greet',
+      'DF greets in place, does not walk over to the player',
       TestGameWithDreamfinder.new,
       (game) async {
         final df = DreamfinderComponent(
@@ -341,7 +335,7 @@ void main() {
         await game.world.add(pathComponent);
         await game.world.add(df);
         await game.ready();
-        expect(df.stationary, isTrue);
+        df.wanderRadius = 0; // isolate greeting from wander movement
 
         final initialPos = df.position.clone();
 
@@ -354,9 +348,44 @@ void main() {
         }
 
         expect(df.position, equals(initialPos),
-            reason: 'Stationary Dreamfinder greets in place, never walks over');
+            reason: 'DF greets in place, never walks over to the player');
         expect(df.current, equals(DreamfinderState.working),
             reason: 'After the surprise glance, DF settles back to working');
+      },
+    );
+
+    testWithGame<TestGameWithDreamfinder>(
+      'bounded wander stays within radius of home',
+      TestGameWithDreamfinder.new,
+      (game) async {
+        final df = DreamfinderComponent(
+          position: Vector2(256, 160), // home cell (8, 5)
+          id: 'bot-dreamfinder',
+          displayName: 'Dreamfinder',
+          pathComponent: pathComponent,
+        );
+
+        await game.world.add(pathComponent);
+        await game.world.add(df);
+        await game.ready();
+        df.wanderRadius = 3;
+
+        const homeX = 8, homeY = 5;
+        var maxDeviation = 0;
+        for (var i = 0; i < 600; i++) {
+          game.update(0.1);
+          final c = df.miniGridPosition;
+          final dx = (c.x - homeX).abs();
+          final dy = (c.y - homeY).abs();
+          final dev = dx > dy ? dx : dy; // Chebyshev distance from home
+          if (dev > maxDeviation) maxDeviation = dev;
+        }
+
+        // +1 tolerance for mid-transit interpolation rounding.
+        expect(maxDeviation, lessThanOrEqualTo(df.wanderRadius + 1),
+            reason: 'DF must stay within its small area (saw $maxDeviation)');
+        expect(maxDeviation, greaterThan(0),
+            reason: 'DF should actually wander off home within the area');
       },
     );
   });


### PR DESCRIPTION
Supersedes the stationary change (#516). You wanted DF **wandering a small area** rather than standing still — and that folds in the **DF-spawns-in-a-wall** bug (Imagination Center), because a bounded wander needs a walkable home to orbit anyway.

## 1. Small-area wander
Replaces the `stationary` bool with `wanderRadius` (`kDreamfinderWanderRadius = 3`) — one dial:
- `0` → stands still (the old stationary behaviour).
- `3` → drifts around a small area near his home cell.

`_pickWanderTarget` now picks a cell within `wanderRadius` (Chebyshev) of home instead of `(_random.nextInt(gridSize), _random.nextInt(gridSize))` — anywhere on the map. Existing pathfinding skips any wall that lands in range (empty path → retry). Greeting is **in-place** (surprise glance, no walk-over) so DF never leaves his area.

## 2. Walkable spawn — fixes DF-in-a-wall
DF's home was a blind `(spawn.x + 8, spawn.y - 5)` offset that only `clamp`ed to the grid, never checked walls — so on the Imagination Center map it landed inside a wall (and, now stationary-ish, stayed there). `_nearestWalkableCell` (Chebyshev-ring spiral over the barrier set) snaps it to the nearest walkable tile, which becomes the wander home.

## Testing
- Existing wander tests now exercise the bounded wander.
- New: `wanderRadius 0` pins DF; DF greets in place (no walk-over); **containment** assertion — over 600 ticks DF never strays beyond `wanderRadius` of home.
- `flutter analyze --fatal-infos` clean; **full suite green (2203 tests)**.

## Gate
Locally verified (analyze + full suite). Visual confirm pending: enter Imagination Center → DF spawns on the floor (not in a wall) and drifts a small patrol.

## Review tier
Self-review — behaviour change across 2 files + tests, low blast radius, no trust boundary. (`_nearestWalkableCell` is a pure spiral; the containment test guards the wander.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)