### PR TITLE
fix(dreamfinder): 2D sprite on mobile web (embodied avatar renders black)

### DIFF
--- a/lib/device/web_safe_mode_io.dart
+++ b/lib/device/web_safe_mode_io.dart
@@ -7,3 +7,7 @@
 library;
 
 bool requiresWebSafeMode() => false;
+
+/// Native builds don't run the embodied-DF WebGL iframe, so there's nothing to
+/// suppress — always `false`.
+bool isMobileWeb() => false;

--- a/lib/device/web_safe_mode_policy.dart
+++ b/lib/device/web_safe_mode_policy.dart
@@ -58,3 +58,17 @@ int? iosMajorVersion(String userAgent) {
   if (match == null) return null;
   return int.tryParse(match.group(1)!);
 }
+
+/// True when [userAgent] is a mobile browser (iPhone / iPad / iPod / Android).
+///
+/// Separate concern from safe mode: on mobile WebKit the embodied Dreamfinder's
+/// WebGL-iframe capture renders **black** (mobile WebKit clears the WebGL
+/// drawing buffer, so the `drawImage`→`getImageData` readback in
+/// `canvas_capture_web.dart` reads black). Mobile clients therefore fall back to
+/// DF's 2D sprite, which renders everywhere. Returns `false` for a null UA —
+/// positive identification only (the runtime accessor fails safe on throw).
+bool isMobileWebUserAgent({required String? userAgent}) {
+  if (userAgent == null) return false;
+  return RegExp(r'iPhone|iPad|iPod|Android', caseSensitive: false)
+      .hasMatch(userAgent);
+}

--- a/lib/device/web_safe_mode_web.dart
+++ b/lib/device/web_safe_mode_web.dart
@@ -22,3 +22,16 @@ bool requiresWebSafeMode() {
     return true;
   }
 }
+
+/// `true` on a mobile browser (see [isMobileWebUserAgent]).
+///
+/// Fails **safe** (returns `true`) if the userAgent read throws — showing DF's
+/// 2D sprite is harmless, whereas a false negative on mobile brings back the
+/// black embodied bubble this suppresses.
+bool isMobileWeb() {
+  try {
+    return isMobileWebUserAgent(userAgent: web.window.navigator.userAgent);
+  } catch (_) {
+    return true;
+  }
+}

--- a/lib/flame/bubble_manager.dart
+++ b/lib/flame/bubble_manager.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart'
     show ValueListenable, ValueNotifier, visibleForTesting;
 
 import 'package:tech_world/bots/bot_config.dart';
+import 'package:tech_world/device/web_safe_mode.dart';
 import 'package:tech_world/flame/components/bot_bubble_component.dart';
 import 'package:tech_world/flame/components/bot_status.dart';
 import 'package:tech_world/flame/components/bot_character_component.dart';
@@ -64,6 +65,12 @@ class BubbleManager {
   /// before each room entry. Existing bubbles are not retroactively swapped —
   /// the toggle takes effect for newly created bubbles only.
   bool hideVideoBubbles;
+
+  /// Whether this client is a mobile browser, where the embodied Dreamfinder's
+  /// WebGL-iframe capture renders black (see [isMobileWeb]). Computed once — the
+  /// browser can't change mid-session. When true, DF stays a 2D sprite: the
+  /// embodied video bubble is never created and its iframe bridge never loads.
+  final bool _isMobileWeb = isMobileWeb();
 
   /// When true, purely decorative animation on proximity video bubbles
   /// renders in its resting state: no breathing scale, no glow pulse, no
@@ -255,9 +262,11 @@ class BubbleManager {
           final dfParticipant =
               _liveKitService?.getParticipant(dreamfinderIdentity);
           PositionComponent bubble;
-          if (dfParticipant != null && !hideVideoBubbles) {
+          if (dfParticipant != null && !hideVideoBubbles && !_isMobileWeb) {
             bubble = _createDreamfinderVideoBubble(dfParticipant);
           } else {
+            // Mobile web (or hidden video) → the 2D sprite + a status bubble,
+            // not the black embodied WebGL bubble.
             bubble = BotBubbleComponent(botStatus: _botStatus);
           }
           bubble.position =
@@ -337,9 +346,10 @@ class BubbleManager {
           _liveKitService?.getParticipant(dreamfinderIdentity);
       if (dfParticipant == null) return;
 
-      // When the user has hidden video bubbles, never upgrade the DF bubble
-      // to a video bubble — the existing BotBubbleComponent stays in place.
-      if (hideVideoBubbles) return;
+      // When video bubbles are hidden, or on mobile web (where the embodied
+      // WebGL bubble renders black), never upgrade the DF bubble to a video
+      // bubble — the existing BotBubbleComponent stays in place.
+      if (hideVideoBubbles || _isMobileWeb) return;
 
       final hasCanvasCapture = existingBubble is VideoBubbleComponent &&
           existingBubble.externalVideoCapture != null;
@@ -458,6 +468,9 @@ class BubbleManager {
 
   /// Initialize the Dreamfinder 3D avatar bridge (web only).
   void initDreamfinderBridge() {
+    // Mobile web renders the embodied WebGL avatar black, so DF stays a 2D
+    // sprite there — don't load the iframe bridge at all.
+    if (_isMobileWeb) return;
     if (_dreamfinderAvatarBridge != null) return;
     final liveKit = _liveKitService;
     if (liveKit == null) return;

--- a/test/device/web_safe_mode_policy_test.dart
+++ b/test/device/web_safe_mode_policy_test.dart
@@ -100,6 +100,33 @@ void main() {
     });
   });
 
+  group('isMobileWebUserAgent — embodied-DF sprite fallback gate', () {
+    test('iPhone (any iOS) is mobile', () {
+      expect(isMobileWebUserAgent(userAgent: iphone8IOS16), isTrue);
+      expect(isMobileWebUserAgent(userAgent: iphone17IOS17), isTrue);
+      expect(isMobileWebUserAgent(userAgent: iphone15IOS18), isTrue);
+    });
+    test('iPad is mobile', () {
+      expect(isMobileWebUserAgent(userAgent: ipadIOS16), isTrue);
+    });
+    test('Chrome-on-iOS and Firefox-on-iOS are mobile', () {
+      expect(isMobileWebUserAgent(userAgent: chromeIOS16), isTrue);
+      expect(isMobileWebUserAgent(userAgent: firefoxIOS16), isTrue);
+    });
+    test('Android Chrome is mobile', () {
+      expect(isMobileWebUserAgent(userAgent: androidChrome), isTrue);
+    });
+    test('desktop Chrome and Mac Safari are NOT mobile', () {
+      expect(isMobileWebUserAgent(userAgent: desktopChrome), isFalse);
+      expect(isMobileWebUserAgent(userAgent: macSafari), isFalse);
+    });
+    test('null / empty / garbage → not mobile (positive-ID only)', () {
+      expect(isMobileWebUserAgent(userAgent: null), isFalse);
+      expect(isMobileWebUserAgent(userAgent: ''), isFalse);
+      expect(isMobileWebUserAgent(userAgent: 'not a real ua'), isFalse);
+    });
+  });
+
   group('iosMajorVersion + boundary', () {
     test('parses iPhone UA', () => expect(iosMajorVersion(iphone8IOS16), 16));
     test('parses iPad UA (CPU OS form)',


### PR DESCRIPTION
**Reported:** DF shows as a black blob on phones; desktop is fine.

## Cause
DF's embodied 3D avatar is a **Three.js WebGL iframe**, captured by `drawImage(canvas) → getImageData → decodeImageFromPixels` (`canvas_capture_web.dart`). **Mobile WebKit clears the WebGL drawing buffer**, so that pixel readback returns black. Desktop Chrome preserves it → works. This is a mobile-WebKit limitation, not a regression from recent DF work (that was the sprite, all-platforms).

## Fix (subtraction, not repair)
DF has two visual layers — the 2D **sprite** (`DreamfinderComponent`, renders everywhere) and the embodied WebGL bubble (black on mobile). On mobile web we simply don't create the embodied bubble or load its iframe: DF stays his pixel-art sprite + the normal `BotBubbleComponent`. Desktop keeps the full 3D embodied avatar.

- New `isMobileWebUserAgent` (pure, unit-tested) + `isMobileWeb()` accessor (conditional-export web/native; **fails safe to `true`** on a UA-read error — showing the sprite is harmless, a false negative brings back the black bubble). Reuses the existing web-safe-mode UA infra.
- `BubbleManager` caches `_isMobileWeb` (browser can't change mid-session) and gates: initial bubble creation (`:259`), the video-track upgrade (`:342`), and `initDreamfinderBridge` (`:460`).

## Testing
- `isMobileWebUserAgent` over real device UAs: iPhone/iPad/Chrome-iOS/Firefox-iOS/Android → mobile; desktop Chrome/Mac Safari → not; null/empty/garbage → not.
- `flutter analyze --fatal-infos` clean; **full suite green (2209)**.

## Gate
Locally verified (analyze + suite). Visual confirm pending: on a phone, DF appears as his sprite (no black blob); on desktop, the 3D embodied avatar still renders.

## Review tier
Self-review — targeted platform gate + pure detector + tests, low blast radius, no trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)