### PR TITLE
feat(realm_firebase): FirestoreRoomConfigStore (step 4)

### DIFF
--- a/packages/realm_firebase/lib/realm_firebase.dart
+++ b/packages/realm_firebase/lib/realm_firebase.dart
@@ -16,3 +16,4 @@
 library;
 
 export 'src/firebase_storage_provider.dart';
+export 'src/firestore_room_config_store.dart';

--- a/packages/realm_firebase/lib/src/firestore_room_config_store.dart
+++ b/packages/realm_firebase/lib/src/firestore_room_config_store.dart
@@ -1,0 +1,191 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:realm/realm.dart';
+
+/// Firestore implementation of [RoomConfigStore].
+///
+/// Maps the live `rooms` collection ↔ engine [RoomDescriptor]. **No-leak**: the
+/// public surface accepts and returns only engine value types; Firestore's
+/// `DocumentSnapshot`, `QuerySnapshot`, `Timestamp` and `FieldValue` never
+/// cross the boundary. (The injected `CollectionReference` is a DI seam, the
+/// same convention [FirebaseStorageProvider] uses for `FirebaseStorage`.)
+///
+/// ## Schema mapping (tech-world-era Firestore)
+///
+/// Engine metadata maps to named top-level fields (`name` →
+/// [RoomDescriptor.displayName], plus `ownerId`, `ownerDisplayName`,
+/// `editorIds`, `isPublic`, `worldType`). **Every other key in the document is
+/// the opaque [RoomDescriptor.worldConfig]** — copied through verbatim without
+/// interpretation, so a tilemap (`mapData`), a `mapVersion`, or any future
+/// world-authored key rides along and this plugin never depends on `tech_world`.
+///
+/// ## Visibility: `unlisted` is this backend's ceiling
+///
+/// The engine's [RoomVisibility] is three-state, but the live schema stores a
+/// two-state `isPublic` bool that controls *listing only*, not
+/// reachability-by-id. The honest mapping is therefore `true ↔ public`,
+/// `false ↔ unlisted`. **[RoomVisibility.private] is deliberately unsupported
+/// here**: this backend cannot gate reachability without a Firestore
+/// security-rules change, and returning or accepting `private` while anyone
+/// holding the id can still join would make the interface lie. [createRoom]
+/// throws on `private` rather than silently downgrading it.
+///
+/// ## `getRoom` is a pure read
+///
+/// Unlike `tech_world`'s `RoomData.fromFirestore` (which self-heals renames and
+/// wall styles by *writing during the read*), this store never writes during a
+/// read. Those migrations relocate to the step-5 metadata-update door.
+class FirestoreRoomConfigStore implements RoomConfigStore {
+  /// Creates a store over [collection] (defaults to the `rooms` collection).
+  ///
+  /// [worldTypeRegistry] validates each document's `worldType` wire string on
+  /// read — the brand is forgeable and carries no registry watermark, so a
+  /// stored value is re-`parse`d against this registry rather than trusted.
+  /// [defaultWorldType] is used for legacy documents that carry no `worldType`
+  /// field (every live room today is implicitly `tech_world`).
+  FirestoreRoomConfigStore({
+    required WorldTypeRegistry worldTypeRegistry,
+    CollectionReference<Map<String, dynamic>>? collection,
+    String defaultWorldType = 'tech_world',
+  })  : _registry = worldTypeRegistry,
+        _defaultWorldType = defaultWorldType,
+        _collection =
+            collection ?? FirebaseFirestore.instance.collection('rooms');
+
+  final WorldTypeRegistry _registry;
+  final String _defaultWorldType;
+  final CollectionReference<Map<String, dynamic>> _collection;
+
+  /// Keys the engine owns. Every other document key is opaque `worldConfig`.
+  static const _engineKeys = {
+    'name',
+    'ownerId',
+    'ownerDisplayName',
+    'editorIds',
+    'isPublic',
+    'worldType',
+    'createdAt',
+    'updatedAt',
+  };
+
+  @override
+  Future<List<RoomDescriptor>> listRooms({
+    UserId? ownedBy,
+    RoomVisibility? minVisibility,
+  }) async {
+    Query<Map<String, dynamic>> query = _collection;
+    if (ownedBy != null) {
+      query = query.where('ownerId', isEqualTo: ownedBy.value);
+    }
+    // Two-state backend: only `public` (rank 3) is expressible as a filter
+    // (`isPublic == true`). `unlisted` (rank 2) means public + unlisted = every
+    // room, so it needs no filter; `private` cannot exist in this backend.
+    // Per-caller authorization (who may see a given room) is enforced by
+    // Firestore security rules server-side, not re-implemented here.
+    if (minVisibility != null &&
+        minVisibility.isAtLeast(RoomVisibility.public)) {
+      query = query.where('isPublic', isEqualTo: true);
+    }
+    final snap = await query.get();
+    return snap.docs.map(_toDescriptor).toList();
+  }
+
+  @override
+  Future<RoomDescriptor?> getRoom(RoomId roomId) async {
+    final doc = await _collection.doc(roomId.value).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return _toDescriptor(doc);
+  }
+
+  @override
+  Stream<RoomDescriptor> watchRoom(RoomId roomId) => _collection
+      .doc(roomId.value)
+      .snapshots()
+      .where((doc) => doc.exists && doc.data() != null)
+      .map(_toDescriptor);
+
+  @override
+  Future<RoomDescriptor> createRoom(NewRoomSpec spec) async {
+    final data = <String, dynamic>{
+      'name': spec.displayName,
+      'ownerId': spec.ownerId.value,
+      'editorIds': spec.editorIds.map((e) => e.value).toList(),
+      'isPublic': _isPublicFor(spec.visibility),
+      'worldType': spec.worldType.value,
+      ...spec.worldConfig, // opaque world keys, stored at top level
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+    final ref = await _collection.add(data);
+    return RoomDescriptor(
+      id: RoomId(ref.id),
+      displayName: spec.displayName,
+      worldType: spec.worldType,
+      visibility: spec.visibility,
+      ownerId: spec.ownerId,
+      worldConfig: spec.worldConfig,
+      editorIds: spec.editorIds,
+    );
+  }
+
+  @override
+  Future<void> updateRoomConfig(
+    RoomId roomId,
+    Map<String, Object?> patch,
+  ) async {
+    // This door patches `worldConfig` ONLY. A patch key that collides with an
+    // engine-metadata field would smuggle a rename/visibility/owner change
+    // through the config door — exactly what the step-5 metadata door is for.
+    final collisions = patch.keys.where(_engineKeys.contains).toList();
+    if (collisions.isNotEmpty) {
+      throw ArgumentError.value(
+        collisions,
+        'patch',
+        'updateRoomConfig patches worldConfig only; these engine-owned '
+            'metadata keys must go through the step-5 metadata-update door',
+      );
+    }
+    await _collection.doc(roomId.value).update({
+      ...patch,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  bool _isPublicFor(RoomVisibility v) => switch (v) {
+        RoomVisibility.public => true,
+        RoomVisibility.unlisted => false,
+        RoomVisibility.private => throw UnsupportedError(
+            'FirestoreRoomConfigStore does not support RoomVisibility.private: '
+            'the Firestore backend cannot gate reachability-by-id without a '
+            'security-rules change. Use unlisted, or add rules enforcement '
+            'first (step-5 metadata door).',
+          ),
+      };
+
+  RoomDescriptor _toDescriptor(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    final worldConfig = <String, Object?>{
+      for (final e in data.entries)
+        if (!_engineKeys.contains(e.key)) e.key: e.value,
+    };
+    return RoomDescriptor(
+      id: RoomId(doc.id),
+      displayName: data['name'] as String,
+      // Re-parse the wire against our own registry — a stored brand is not
+      // proof of registration (see WorldTypeId's forgeability contract).
+      worldType: WorldTypeId.parse(
+        data['worldType'] as String? ?? _defaultWorldType,
+        _registry,
+      ),
+      visibility: (data['isPublic'] as bool? ?? true)
+          ? RoomVisibility.public
+          : RoomVisibility.unlisted,
+      ownerId: UserId(data['ownerId'] as String),
+      ownerDisplayName: data['ownerDisplayName'] as String?,
+      editorIds: (data['editorIds'] as List<dynamic>?)
+              ?.map((e) => UserId(e as String))
+              .toList() ??
+          const [],
+      worldConfig: worldConfig,
+    );
+  }
+}

--- a/packages/realm_firebase/pubspec.yaml
+++ b/packages/realm_firebase/pubspec.yaml
@@ -31,6 +31,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.25.0
-  fake_cloud_firestore: ^4.0.1
+  fake_cloud_firestore: ^4.2.0 # 4.2.0 is the first to support cloud_firestore 6.7.x
   firebase_storage_mocks: ^0.8.1
   firebase_auth_mocks: ^0.15.2

--- a/packages/realm_firebase/test/firestore_room_config_store_test.dart
+++ b/packages/realm_firebase/test/firestore_room_config_store_test.dart
@@ -1,0 +1,219 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:realm/realm.dart';
+import 'package:realm_firebase/realm_firebase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late WorldTypeRegistry registry;
+  late FirestoreRoomConfigStore store;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    registry = WorldTypeRegistry()
+      // Factory is never invoked by the config store; a dummy suffices.
+      ..register('tech_world', (_) => throw UnimplementedError());
+    store = FirestoreRoomConfigStore(
+      worldTypeRegistry: registry,
+      collection: firestore.collection('rooms'),
+    );
+  });
+
+  NewRoomSpec spec({
+    String name = 'Imagination Center',
+    RoomVisibility visibility = RoomVisibility.public,
+    Map<String, Object?> worldConfig = const {},
+    List<UserId> editorIds = const [],
+  }) =>
+      NewRoomSpec(
+        displayName: name,
+        worldType: WorldTypeId.parse('tech_world', registry),
+        ownerId: const UserId('owner-1'),
+        visibility: visibility,
+        worldConfig: worldConfig,
+        editorIds: editorIds,
+      );
+
+  test('is a RoomConfigStore', () {
+    expect(store, isA<RoomConfigStore>());
+  });
+
+  group('createRoom → getRoom round-trip', () {
+    test('maps every engine field back', () async {
+      final created = await store.createRoom(spec(
+        editorIds: const [UserId('ed-1'), UserId('ed-2')],
+      ));
+      final fetched = await store.getRoom(created.id);
+
+      expect(fetched, isNotNull);
+      expect(fetched!.id.value, created.id.value);
+      expect(fetched.displayName, 'Imagination Center');
+      expect(fetched.worldType.value, 'tech_world');
+      expect(fetched.visibility, RoomVisibility.public);
+      expect(fetched.ownerId.value, 'owner-1');
+      expect(fetched.editorIds.map((e) => e.value), ['ed-1', 'ed-2']);
+    });
+
+    test('worldConfig is opaque — round-trips verbatim, no engine keys leak',
+        () async {
+      final config = {
+        'mapData': {
+          'walls': [
+            {'style': 'modern_gray_07'}
+          ]
+        },
+        'mapVersion': 'v3',
+      };
+      final created = await store.createRoom(spec(worldConfig: config));
+      final fetched = await store.getRoom(created.id);
+
+      expect(fetched!.worldConfig, config);
+      // Engine metadata must NOT bleed into the opaque blob.
+      expect(fetched.worldConfig.containsKey('name'), isFalse);
+      expect(fetched.worldConfig.containsKey('isPublic'), isFalse);
+      expect(fetched.worldConfig.containsKey('worldType'), isFalse);
+    });
+  });
+
+  group('visibility mapping (unlisted is the ceiling)', () {
+    test('public ↔ isPublic true', () async {
+      final r = await store.createRoom(spec(visibility: RoomVisibility.public));
+      expect((await store.getRoom(r.id))!.visibility, RoomVisibility.public);
+      final raw = await firestore.collection('rooms').doc(r.id.value).get();
+      expect(raw.data()!['isPublic'], isTrue);
+    });
+
+    test('unlisted ↔ isPublic false', () async {
+      final r =
+          await store.createRoom(spec(visibility: RoomVisibility.unlisted));
+      expect((await store.getRoom(r.id))!.visibility, RoomVisibility.unlisted);
+      final raw = await firestore.collection('rooms').doc(r.id.value).get();
+      expect(raw.data()!['isPublic'], isFalse);
+    });
+
+    test('private is refused — the backend cannot honor it', () {
+      expect(
+        () => store.createRoom(spec(visibility: RoomVisibility.private)),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('legacy doc missing isPublic defaults to public', () async {
+      final ref = await firestore.collection('rooms').add({
+        'name': 'Legacy',
+        'ownerId': 'owner-1',
+        'worldType': 'tech_world',
+      });
+      final fetched = await store.getRoom(RoomId(ref.id));
+      expect(fetched!.visibility, RoomVisibility.public);
+    });
+  });
+
+  group('worldType trust boundary', () {
+    test('legacy doc with no worldType uses the default', () async {
+      final ref = await firestore.collection('rooms').add({
+        'name': 'Legacy',
+        'ownerId': 'owner-1',
+        'isPublic': true,
+      });
+      final fetched = await store.getRoom(RoomId(ref.id));
+      expect(fetched!.worldType.value, 'tech_world');
+    });
+
+    test('a doc naming an unregistered worldType throws on read', () async {
+      final ref = await firestore.collection('rooms').add({
+        'name': 'Alien',
+        'ownerId': 'owner-1',
+        'isPublic': true,
+        'worldType': 'repo_body', // not registered in this test's registry
+      });
+      expect(
+        () => store.getRoom(RoomId(ref.id)),
+        throwsA(isA<WorldTypeNotRegistered>()),
+      );
+    });
+  });
+
+  group('getRoom', () {
+    test('returns null for a missing room', () async {
+      expect(await store.getRoom(const RoomId('nope')), isNull);
+    });
+  });
+
+  group('listRooms', () {
+    setUp(() async {
+      await store.createRoom(spec(name: 'Pub', visibility: RoomVisibility.public));
+      await store
+          .createRoom(spec(name: 'Unl', visibility: RoomVisibility.unlisted));
+    });
+
+    test('no filter returns every room', () async {
+      final rooms = await store.listRooms();
+      expect(rooms, hasLength(2));
+    });
+
+    test('minVisibility public returns only public rooms', () async {
+      final rooms = await store.listRooms(minVisibility: RoomVisibility.public);
+      expect(rooms.map((r) => r.displayName), ['Pub']);
+    });
+
+    test('minVisibility unlisted returns public + unlisted (all)', () async {
+      final rooms =
+          await store.listRooms(minVisibility: RoomVisibility.unlisted);
+      expect(rooms, hasLength(2));
+    });
+
+    test('ownedBy filters to one owner', () async {
+      final ref = await firestore.collection('rooms').add({
+        'name': 'Other',
+        'ownerId': 'owner-2',
+        'isPublic': true,
+        'worldType': 'tech_world',
+      });
+      addTearDown(() => firestore.collection('rooms').doc(ref.id).delete());
+      final mine = await store.listRooms(ownedBy: const UserId('owner-1'));
+      expect(mine.every((r) => r.ownerId.value == 'owner-1'), isTrue);
+      expect(mine.map((r) => r.displayName), containsAll(['Pub', 'Unl']));
+    });
+  });
+
+  group('updateRoomConfig', () {
+    test('patches an opaque worldConfig key', () async {
+      final r = await store.createRoom(spec(worldConfig: {'mapVersion': 'v1'}));
+      await store.updateRoomConfig(r.id, {'mapVersion': 'v2'});
+      final fetched = await store.getRoom(r.id);
+      expect(fetched!.worldConfig['mapVersion'], 'v2');
+    });
+
+    test('rejects a patch touching an engine-owned metadata key', () async {
+      final r = await store.createRoom(spec());
+      expect(
+        () => store.updateRoomConfig(r.id, {'isPublic': false}),
+        throwsArgumentError,
+      );
+      expect(
+        () => store.updateRoomConfig(r.id, {'name': 'sneaky rename'}),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('watchRoom', () {
+    test('emits the current descriptor and again after a config change',
+        () async {
+      final r = await store.createRoom(spec(worldConfig: {'mapVersion': 'v1'}));
+      final emissions = <String?>[];
+      final sub = store
+          .watchRoom(r.id)
+          .listen((d) => emissions.add(d.worldConfig['mapVersion'] as String?));
+
+      await Future<void>.delayed(Duration.zero);
+      await store.updateRoomConfig(r.id, {'mapVersion': 'v2'});
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(emissions, contains('v1'));
+      expect(emissions.last, 'v2');
+    });
+  });
+}


### PR DESCRIPTION
The second real Firebase provider plugin (step 4): `FirestoreRoomConfigStore`,
mapping the live `rooms` collection ↔ engine `RoomDescriptor`.

> **Stacked on #523** (base `feat/realm-firebase-step4`), which is itself
> stacked on #522. Merge order: #522 → #523 → this. Every commit landed through
> the fixed pre-commit hook — zero `--no-verify`.

## Mapping decisions

- **`worldConfig` is the opaque remainder.** Engine metadata maps to named
  top-level fields (`name`, `ownerId`, `ownerDisplayName`, `editorIds`,
  `isPublic`, `worldType`); *every other document key* rides through
  `worldConfig` verbatim. So a tilemap (`mapData`), `mapVersion`, or any future
  world key needs no interpretation — and this plugin **never depends on
  `tech_world`**. `TechWorld.parseConfig()` reconstitutes the `GameMap` later,
  in the World.
- **`unlisted` is this backend's ceiling.** `isPublic` true↔`public`,
  false↔`unlisted` (the live bool controls *listing*, not reachability-by-id).
  **`RoomVisibility.private` is refused** — `createRoom` throws — because the
  Firestore backend can't gate reachability without a security-rules change, and
  honoring it would make the engine contract lie. Honest over convenient.
- **`getRoom` is a pure read.** No self-healing writes-during-read like
  `tech_world`'s `RoomData.fromFirestore`; those relocate to the step-5
  metadata door.
- **`worldType` re-parsed against the injected registry on every read** (the
  brand is forgeable per `WorldTypeId`'s contract). Legacy docs with no
  `worldType` default to `tech_world`.
- **`updateRoomConfig` rejects engine-metadata keys** — rename / visibility /
  editors must go through the step-5 metadata door, not the config door.

## Also: `fake_cloud_firestore` ^4.0.1 → ^4.2.0

The skeleton's constraint resolved to 4.1.1, which fails to compile against
`cloud_firestore 6.7.1` (generic `WriteBatch.update`). 4.2.0 is the first
release supporting 6.7.x. Surfaced only now — the config store is the first
`fake_cloud_firestore` consumer (the storage test uses `firebase_storage_mocks`).

## Verification

17 new tests green under `fvm flutter 3.41.7`: create→get round-trip,
opaque-`worldConfig` (no engine-key bleed), visibility mapping incl.
private-refused, `worldType` trust-boundary re-parse (unregistered → throws),
`listRooms` filters, `updateRoomConfig` metadata-key guard, `watchRoom`.
Workspace-wide `analyze --fatal-infos` clean.

## Step 4 after this

Only `FirebaseAuthProvider` remains — deliberately held, because its crux
(`getCredential` → server-side exchange) needs the `examples/livekit-token-server`
exchange endpoint built and an architecture decision, not a momentum build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
