### PR TITLE
docs(claude): correct Tech World identity (game-on-engine, not ed-tech)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Flutter client for Tech World — an educational multiplayer game where players solve coding challenges together. Uses Flame engine for the game world and LiveKit for video chat, player positions, and AI tutor chat. All real-time communication goes through LiveKit; there is no separate game server.
+Flutter client for **Tech World** — a multiplayer game *World* built on top of the Realm engine (`packages/realm/`; Tech World is the first-party World that consumes it). It is a place players explore together where **magic is real and takes several forms** — Words of Power (the spellbook), prompting challenges, and coding challenges (in one room among several). Casting is a **public, witnessed act** — triggered by being in a place that listens to you, never a private UI button (see "The world is the listener" below). It is a **consumer game, not an educational platform**, and coding is one school of magic, not the whole premise. Uses Flame for the game world and LiveKit for video chat, player positions, and AI-tutor chat; all real-time communication goes through LiveKit — there is no separate game server.
+
+**Two products, two tracks** (2026-08): the durable engineering investment is the **Realm engine** — a reusable substrate other people can build all kinds of games on. **Tech World** is the specific game submitted to Screen Australia's Games Production Fund (round closes 5pm AEST Thu 27 Aug 2026). For the grant, Tech World is presented as a self-contained *game*; the engine stays invisible plumbing (SA flags "scope evolved into an engine/middleware" as an eligibility risk). The submission does NOT depend on the engine migration — the game runs today on its original `lib/` code (zero `package:realm` consumers yet), so the deadline-gated submission and the deadline-free engine work are independent tracks.
 
 ## Build & Run
 


### PR DESCRIPTION
Corrects the stale `CLAUDE.md` Project Overview Nick flagged: Tech World is a game (a World on the Realm engine) where coding is one school of magic among several (Words of Power, prompting challenges), NOT an educational coding tool. Adds the two-products/two-tracks note + the SA grant framing (deadline 27 Aug 2026; submission is engine-independent). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)